### PR TITLE
Remove in-page JS which couldn't reference obfuscated function names

### DIFF
--- a/candidates/static/js/person_form.js
+++ b/candidates/static/js/person_form.js
@@ -144,6 +144,32 @@ function updateFields() {
     updateSelectsForElection(standing, election); });
 }
 
+/* This is called to display a new election form on the edit person
+   page, if the dynamic "add new election" button is being used. */
+
+function showElectionsForm() {
+  $.getJSON("/api/current-elections/").done(function( data ) {
+    var select_data = $.map(data, function(obj, key) {
+      return { id: key, text: obj.name + ' (' + obj.election_date + ')' };
+    })
+    $('#add_more_elections').select2({
+      data: select_data,
+    }).on('change', function(e) {
+      var url = window.location.pathname + '/single_election_form/' + e.val;
+      $.get(url, function(data) {
+        $('.extra_elections_forms').html(data);
+        setUpStandingCheckbox();
+        setUpPartySelect2s();
+        setUpPostSelect2s();
+        updateFields();
+      });
+    });
+    $('.add_more_elections_field').show();
+    $('#add_election_button').hide();
+  });
+}
+
+
 $(document).ready(function() {
   $.getJSON('/post-id-to-party-set.json', function(data) {
       window.postIDToPartySet = data;
@@ -151,5 +177,8 @@ $(document).ready(function() {
       setUpPostSelect2s();
       setUpStandingCheckbox();
       updateFields();
+      /* Now enable the "add an extra election" button if it's present */
+      $('#add_election_button').on('click', showElectionsForm);
+      $('.add_more_elections_field').hide();
   });
 });

--- a/elections/uk/templates/candidates/_person_form.html
+++ b/elections/uk/templates/candidates/_person_form.html
@@ -95,32 +95,6 @@
             <input type="hidden" id="add_more_elections" style="width:100%">
           </div>
 
-          <script type="text/javascript">
-          function showElectionsForm() {
-            $.getJSON("/api/current-elections/").done(function( data ) {
-              var select_data = $.map(data, function(obj, key) {
-                return { id: key, text: obj.name + ' (' + obj.election_date + ')' };
-              })
-              $('#add_more_elections').select2({
-                data: select_data,
-              }).on('change', function(e) {
-                var url = window.location.pathname + '/single_election_form/' + e.val;
-                $.get(url, function(data) {
-                  $('.extra_elections_forms').html(data);
-                  setUpStandingCheckbox();
-                  setUpPartySelect2s();
-                  setUpPostSelect2s();
-                  updateFields();
-                });
-              });
-              $('.add_more_elections_field').show();
-              $('#add_election_button').hide();
-            });
-          }
-
-          $('#add_election_button').on('click', showElectionsForm);
-          $('.add_more_elections_field').hide();
-          </script>
         </div>
         <div class="extra_elections_forms"></div>
 


### PR DESCRIPTION
The in-page Javascript code worked OK with DEBUG = True, but in
production the person_form.js Javascript is wrapped in an IIFE
(immediately-invoked function expression) by django-pipeline and
the Javascript compressor is free to change the names of functions
defined within it, so the in-page Javascript can't find those
names any more.

There's no reason for the Javascript to be in-page, anyway, so this
commit moves it into person_form.js where references to those
functions will be obfuscated along with the definition.