### PR TITLE
API: extend pagination changes to person, organization & post viewsets

### DIFF
--- a/candidates/views/api.py
+++ b/candidates/views/api.py
@@ -183,6 +183,7 @@ class PersonViewSet(viewsets.ModelViewSet):
         ) \
         .order_by('id')
     serializer_class = serializers.PersonSerializer
+    pagination_class = ResultsSetPagination
 
 
 class OrganizationViewSet(viewsets.ModelViewSet):
@@ -202,6 +203,7 @@ class OrganizationViewSet(viewsets.ModelViewSet):
         .order_by('base__id')
     lookup_field = 'slug'
     serializer_class = serializers.OrganizationExtraSerializer
+    pagination_class = ResultsSetPagination
 
 
 class PostViewSet(viewsets.ModelViewSet):
@@ -219,6 +221,7 @@ class PostViewSet(viewsets.ModelViewSet):
         .order_by('base__id')
     lookup_field = 'slug'
     serializer_class = serializers.PostExtraSerializer
+    pagination_class = ResultsSetPagination
 
 
 class AreaViewSet(viewsets.ModelViewSet):


### PR DESCRIPTION
I missed adding the new `pagination_class` to these three viewsets previously.