### PR TITLE
Updates to party list display

### DIFF
--- a/candidates/templates/candidates/_candidates_for_post.html
+++ b/candidates/templates/candidates/_candidates_for_post.html
@@ -107,7 +107,7 @@
               {% endif %}
           {% endif %}
 
-          {% for c, candidate_elected in people %}
+          {% for position_in_list, c, candidate_elected in people %}
             {% if forloop.first %}
               <ul class="candidate-list">
             {% endif %}
@@ -143,7 +143,7 @@
               </ul>
             {% endif %}
 
-          {% endfor %} {# end of 'for c, candidate_elected in people' #}
+          {% endfor %} {# end of 'for position_in_list, c, candidate_elected in people' #}
 
         </div>
 
@@ -205,7 +205,7 @@
               {% endif %}
 
               <ul class="candidate-list">
-                {% for c, candidate_elected in people %}
+                {% for position_in_list, c, candidate_elected in people %}
 
                   <li class="candidates-list__person">
                     {% include 'candidates/_person_in_list.html' %}
@@ -223,7 +223,7 @@
                     {% endif %}
                     {% endif %}
                   </li>
-                {% endfor %} {# end of 'for c, candidate_elected in people' #}
+                {% endfor %} {# end of 'for position_in_list, c, candidate_elected in people' #}
               </ul>
 
             </div>
@@ -251,7 +251,7 @@
               {% endif %}
 
               <ul class="candidate-list">
-                {% for c, candidate_elected in people %}
+                {% for position_in_list, c, candidate_elected in people %}
 
                   <li class="candidates-list__person">
                     {% include 'candidates/_person_in_list.html' %}
@@ -267,7 +267,7 @@
                     {% endif %}
                     {% endif %}
                   </li>
-                {% endfor %} {# end of 'for c, candidate_elected in people' #}
+                {% endfor %} {# end of 'for position_in_list, c, candidate_elected in people' #}
               </ul>
 
             </div>

--- a/candidates/templates/candidates/_candidates_for_post.html
+++ b/candidates/templates/candidates/_candidates_for_post.html
@@ -100,8 +100,10 @@
           {% if party_lists_in_use %}
             <h4 class="party-list-header">{{ party.name }}</h4>
             <p class="party-list-description">
-              {% if party.total_count %}
+              {% if party.truncated %}
                 {% trans "Showing the top candidates." %} <a href="{% url 'party-for-post' election=election post_id=post_data.id organization_id=party.id %}">{% blocktrans with count=party.total_count %}See all {{ count }} members on the party list{% endblocktrans %} &raquo;</a>
+              {% else %}
+                <a href="{% url 'party-for-post' election=election post_id=post_data.id organization_id=party.id %}">{% blocktrans with count=party.total_count %}See just this party list{% endblocktrans %} &raquo;</a>
               {% endif %}
           {% endif %}
 

--- a/candidates/views/helpers.py
+++ b/candidates/views/helpers.py
@@ -226,9 +226,7 @@ def group_candidates_by_party(election_data, candidacies, party_list=True, max_p
                     'truncated': party_truncated[k],
                     'total_count': party_total[k],
                 },
-                # throw away the party list position data we
-                # were only using for sorting
-                [(p[1], p[2]) for p in v]
+                v
             )
             for k, v in party_id_to_people.items()
         ]
@@ -237,7 +235,7 @@ def group_candidates_by_party(election_data, candidacies, party_list=True, max_p
     if party_list:
         result.sort(key=lambda t: t[0]['name'])
     else:
-        result.sort(key=lambda t: t[1][0][0].family_name)
+        result.sort(key=lambda t: t[1][0][1].family_name)
     return {
         'party_lists_in_use': party_list,
         'parties_and_people': result


### PR DESCRIPTION
These are some changes that @symroe and @JoeMitchell asked for:

* Display the party list link in all circumstances, not just when the list
   of people was truncated.
* Display the big numbers representing the candidate's order in the
   party list wherever the party list is shown (i.e. on post and area
   pages too).