### PR TITLE
Sort candidates in non-party-list posts like the SOPN

### DIFF
--- a/candidates/views/areas.py
+++ b/candidates/views/areas.py
@@ -79,8 +79,6 @@ class AreasView(TemplateView):
                 current_candidacies = group_candidates_by_party(
                     election,
                     current_candidacies,
-                    party_list=election.party_lists_in_use,
-                    max_people=election.default_party_list_members_to_show
                 )
                 post_context = {
                     'election': election.slug,

--- a/candidates/views/constituencies.py
+++ b/candidates/views/constituencies.py
@@ -163,23 +163,17 @@ class ConstituencyDetailView(ElectionMixin, TemplateView):
             group_candidates_by_party(
                 self.election_data,
                 not_standing_candidacies,
-                party_list=self.election_data.party_lists_in_use,
-                max_people=self.election_data.default_party_list_members_to_show
             )
 
         context['candidacies_might_stand_again'] = \
             group_candidates_by_party(
                 self.election_data,
                 might_stand_candidacies,
-                party_list=self.election_data.party_lists_in_use,
-                max_people=self.election_data.default_party_list_members_to_show
             )
 
         context['candidacies'] = group_candidates_by_party(
             self.election_data,
             current_candidacies,
-            party_list=self.election_data.party_lists_in_use,
-            max_people=self.election_data.default_party_list_members_to_show
         )
 
         context['show_retract_result'] = False

--- a/candidates/views/helpers.py
+++ b/candidates/views/helpers.py
@@ -191,7 +191,7 @@ def order_candidates_by_name_no_grouping(election_data, candidacies):
         'parties_and_people': result
     }
 
-def group_candidates_by_party(election_data, candidacies, party_list=True, max_people=None):
+def group_candidates_by_party(election_data, candidacies):
     """Take a list of candidacies and return the people grouped by party
 
     This returns a tuple of the party_list boolean and a list of
@@ -212,6 +212,9 @@ def group_candidates_by_party(election_data, candidacies, party_list=True, max_p
     there's more than one candidate for a party and party_list is
     False, that party will once in the list for each candidate.)
     """
+
+    party_list = election_data.party_lists_in_use
+    max_people = election_data.default_party_list_members_to_show
 
     if not party_list:
         return order_candidates_by_name_no_grouping(election_data, candidacies)

--- a/elections/st_paul_municipal_2015/views/areas.py
+++ b/elections/st_paul_municipal_2015/views/areas.py
@@ -68,8 +68,6 @@ class StPaulAreasView(TemplateView):
                 current_candidacies = group_candidates_by_party(
                     election,
                     current_candidacies,
-                    party_list=election.party_lists_in_use,
-                    max_people=election.default_party_list_members_to_show
                 )
                 context['posts'].append({
                     'election': election.slug,


### PR DESCRIPTION
The ordering of candidates for a post was confusingly different from UK
Statements of Persons Nominated where (a) party lists were not in use
and (b) there was more than one candidate from a party for that post.
(Candidates were grouped by party and then the parties were ordered by
the name of the first candidate in each party (!))

There's a huge advantage in just ordering candidates by their last name
in this case, because checking our candidates against the SOPN is way
faster and more reliable when you can step down the two lists
candidate-by-candidate checking that they correspond.  This commit
changes the ordering of candidates in the non-party list case so that
that's the case.