### PR TITLE
Tolerate bad SSL from local councils when importing nomination papers

### DIFF
--- a/candidates/management/commands/candidates_import_statements_of_persons_nominated.py
+++ b/candidates/management/commands/candidates_import_statements_of_persons_nominated.py
@@ -45,7 +45,11 @@ def download_file_cached(url):
     filename = join(directory, url_hash)
     if exists(filename):
         return filename
-    r = requests.get(url)
+    try:
+        r = requests.get(url)
+    except requests.exceptions.SSLError:
+        print("Caught an SSLError, so retrying without certificate validation")
+        r = requests.get(url, verify=False)
     with open(filename, 'w') as f:
         f.write(r.content)
     return filename


### PR DESCRIPTION
There are a couple of council web servers that give certificate errors
with the versions of requests, etc. that we're using, so as a fallback
try again without certificate validation.