### PR TITLE
Fixes for election not being removed from not_standing when bulk adding

### DIFF
--- a/bulk_adding/views.py
+++ b/bulk_adding/views.py
@@ -155,6 +155,7 @@ class BulkAddReviewView(BaseBulkAddView):
         )
 
         previous_memberships_in_this_election.delete()
+        person_extra.not_standing.remove(election)
 
         membership, _ = Membership.objects.get_or_create(
             post=post,

--- a/candidates/management/commands/candidates_fix_not_standing.py
+++ b/candidates/management/commands/candidates_fix_not_standing.py
@@ -1,0 +1,45 @@
+from __future__ import print_function, unicode_literals
+
+from django.core.management.base import BaseCommand
+
+from popolo.models import Membership
+
+from candidates.models import PersonExtra
+
+class Command(BaseCommand):
+
+    help = "Find elections in not_standing that should be removed"
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            '--delete', action='store_true',
+            help="Don't just find these broken cases, also fix them",
+        )
+
+    def handle(self, *args, **options):
+        for person_extra in PersonExtra.objects.filter(
+            not_standing__isnull=False
+        ):
+            election_to_remove = []
+            for election in person_extra.not_standing.all():
+                candidacies = Membership.objects.filter(
+                    person=person_extra.base,
+                    extra__election=election,
+                    role=election.candidate_membership_role,
+                )
+                if candidacies.exists():
+                    election_to_remove.append(election)
+            # Now print out the elections we would remove from
+            # not_standing for that person.  (And, if --delete is
+            # specified, actually remove it.)
+            for election in election_to_remove:
+                fmt = '{person} is marked as not standing in {election}'
+                print(fmt.format(person=person_extra.base, election=election))
+                print('  ... but also has a candidacy in that election!')
+                if options['delete']:
+                    fmt = "  Deleting {election} from {person}'s not_standing"
+                    print(fmt.format(
+                        election=election.name,
+                        person=person_extra.base.name,
+                    ))
+                    person_extra.not_standing.remove(election)


### PR DESCRIPTION
If someone had been marked as not standing in an election, but they were
later marked as actually standing in it via the bulk add tool, they would end
up with inconsistent data - they'd both have the election in not_standing and
have a Membership / MembershipExtra in that election.  This inconsistency
meant that you couldn't edit such people at all.

This pull request includes a fix for the underlying bug and a script to clean
up the inconsistent data so that these people can be edited again.