### PR TITLE
Speed up SuggestLockReviewListView by reducing the number of queries

### DIFF
--- a/moderation_queue/models.py
+++ b/moderation_queue/models.py
@@ -105,4 +105,12 @@ class SuggestedPostLock(models.Model):
 
     @property
     def election_for_suggestion(self):
-        return self.post_extra.elections.filter(current=True)[0]
+        # This might look like a poor alternative to:
+        #    self.post_extra.elections.filter(current=True)[0]
+        # However, that would negate any advantage from prefetching
+        # the elections in the get_queryset of SuggestLockReviewListView.
+        # Calling .filter() on a prefetched relationship causes an extra
+        # query where as iterating over .all() doesn't.
+        for election in self.post_extra.elections.all():
+            if election.current:
+                return election

--- a/moderation_queue/views.py
+++ b/moderation_queue/views.py
@@ -468,4 +468,6 @@ class SuggestLockReviewListView(ListView):
 
     def get_queryset(self):
         return SuggestedPostLock.objects.filter(
-            post_extra__candidates_locked=False)
+            post_extra__candidates_locked=False).select_related(
+                'user', 'post_extra__base',
+            ).prefetch_related('post_extra__elections')


### PR DESCRIPTION
The SuggestLockReviewListView view was rather slow due to doing a huge
number of queries; these can be reduced to a constant number of queries
by using select_related and prefetch_related.