### PR TITLE
Add a 'post_results' API endpoint with a 'confirmed' filter

### DIFF
--- a/candidates/urls.py
+++ b/candidates/urls.py
@@ -8,7 +8,10 @@ from django.views.generic import TemplateView
 from rest_framework import routers
 
 import candidates.views as views
-from uk_results.views import CouncilElectionViewSet
+from uk_results.views import (
+    CouncilElectionViewSet, CandidateResultViewSet, PostResultViewSet,
+    ResultSetViewSet,
+)
 
 from .feeds import RecentChangesFeed
 from .constants import ELECTION_ID_REGEX, POST_ID_REGEX
@@ -26,7 +29,11 @@ api_router.register(r'memberships', views.MembershipViewSet)
 api_router.register(r'logged_actions', views.LoggedActionViewSet)
 api_router.register(r'extra_fields', views.ExtraFieldViewSet)
 api_router.register(r'simple_fields', views.SimplePopoloFieldViewSet)
-api_router.register(r'results', CouncilElectionViewSet)
+api_router.register(r'council_elections', CouncilElectionViewSet)
+api_router.register(r'candidate_results', CandidateResultViewSet)
+api_router.register(r'post_results', PostResultViewSet)
+api_router.register(r'result_sets', ResultSetViewSet)
+
 
 urlpatterns = \
     patterns('',

--- a/uk_results/serializers.py
+++ b/uk_results/serializers.py
@@ -1,0 +1,52 @@
+from __future__ import unicode_literals
+
+from rest_framework import serializers
+
+from .models import PostResult, ResultSet, CandidateResult
+
+from candidates.serializers import (
+    MembershipSerializer, MinimalPostExtraSerializer
+)
+
+class CandidateResultSerializer(serializers.HyperlinkedModelSerializer):
+    class Meta:
+        model = CandidateResult
+        fields = (
+            'id', 'url',
+            'membership',
+            'result_set',
+            'num_ballots_reported', 'is_winner',
+        )
+
+    membership = MembershipSerializer(read_only=True)
+    # result_set = ResultSetSerializer(read_only=True)
+
+
+class ResultSetSerializer(serializers.HyperlinkedModelSerializer):
+    class Meta:
+        model = ResultSet
+        fields = (
+            'id', 'url',
+            'candidate_results',
+            'ip_address',
+            'num_turnout_reported', 'num_spoilt_ballots',
+            # 'post_result',
+            'user', 'user_id',
+        )
+    # post_result = PostResultSerializer()
+    user = serializers.ReadOnlyField(source='user.username')
+    user_id = serializers.ReadOnlyField(source='user.id')
+    candidate_results = CandidateResultSerializer(many=True, read_only=True)
+
+
+class PostResultSerializer(serializers.HyperlinkedModelSerializer):
+    class Meta:
+        model = PostResult
+        fields = (
+            'id', 'url',
+            'confirmed',
+            'post',
+            'result_sets',
+        )
+    post = MinimalPostExtraSerializer(source='post.extra')
+    result_sets = ResultSetSerializer(many=True)


### PR DESCRIPTION
This adds these API endpoints:

  - 'candidate_results' for CandidateResult objects
  - 'result_sets' for ResultSet objects
  - 'post_results' for PostResult objects

This also renames the 'results' endpoint to 'council_elections' after
consultation with Sym (@symroe), since we know the single user of that
at this point.

The 'post_results' endpoint return serialized PostResult objects, which
have all their related ResultSet object serialized and embedded in the
result; they in turn have all related CandidateResult objects embedded
in them.

Fixes mysociety/yournextrepresentative#877