### PR TITLE
Limit (slow) calls to PartySet.party_choices when creating forms

### DIFF
--- a/candidates/forms.py
+++ b/candidates/forms.py
@@ -13,6 +13,7 @@ from django import forms, VERSION as django_version
 from django.conf import settings
 from django.contrib.sites.models import Site
 from django.core.exceptions import ValidationError
+from django.utils.functional import cached_property
 from django.utils.translation import ugettext_lazy as _
 
 from candidates.models import (
@@ -384,6 +385,16 @@ class NewPersonForm(BasePersonForm):
 
 class AddElectionFieldsMixin(object):
 
+    @cached_property
+    def party_sets_and_party_choices(self):
+        # Generating the party choices for each party set is quite
+        # slow, so cache these results, so they're not fetched from
+        # the database again each time add_election_fields is called.
+        return [
+            (party_set, party_set.party_choices())
+            for party_set in PartySet.objects.all()
+        ]
+
     def add_elections_fields(self, elections):
         for election_data in elections:
             self.add_election_fields(election_data)
@@ -413,14 +424,14 @@ class AddElectionFieldsMixin(object):
                 ),
                 widget=forms.Select(attrs={'class': 'post-select'}),
             )
-        for party_set in PartySet.objects.all():
+        for party_set, party_choices in self.party_sets_and_party_choices:
             self.fields['party_' + party_set.slug + '_' + election] = \
                 forms.ChoiceField(
                     label=_("Party in {election} ({party_set_name})").format(
                         election=election_data.name,
                         party_set_name=party_set.name,
                     ),
-                    choices=party_set.party_choices(),
+                    choices=party_choices,
                     required=False,
                     widget=forms.Select(
                         attrs={

--- a/candidates/models/popolo_extra.py
+++ b/candidates/models/popolo_extra.py
@@ -666,51 +666,6 @@ class PartySet(models.Model):
             return self.party_choices_basic()
         result = [('', '')]
         parties_with_candidates = []
-        for t in qs \
-                .values('on_behalf_of', 'on_behalf_of__name') \
-                .order_by() \
-                .annotate(party_count=models.Count('pk')) \
-                .order_by('-party_count', 'on_behalf_of__name'):
-            parties_with_candidates.append(t['on_behalf_of'])
-            name_with_count = \
-                _('{party_name} ({number_of_candidates} candidates)').format(
-                    party_name=t['on_behalf_of__name'],
-                    number_of_candidates=t['party_count']
-                )
-            result.append(
-                (t['on_behalf_of'], name_with_count)
-            )
-        result += self.parties.exclude(id__in=parties_with_candidates) \
-            .order_by('name').values_list('id', 'name')
-        return result
-
-    def party_choices(self):
-        # For various reasons, we've found it's best to order the
-        # parties by those that have the most candidates - this means
-        # that the commonest parties to select are at the top of the
-        # drop down.  The logic here tries to build such an ordered
-        # list of candidates if there are enough that such an ordering
-        # makes sense.  Otherwise the fallback is to rank
-        # alphabetically.
-        candidacies_current_qs = Membership.objects.filter(
-            extra__election__current=True,
-            role=models.F('extra__election__candidate_membership_role'),
-            on_behalf_of__party_sets=self,
-        )
-        candidacies_ever_qs =  Membership.objects.filter(
-            role=models.F('extra__election__candidate_membership_role'),
-            on_behalf_of__party_sets=self,
-        )
-        minimum_count = settings.CANDIDATES_REQUIRED_FOR_WEIGHTED_PARTY_LIST
-        qs = None
-        if candidacies_current_qs.count() > minimum_count:
-            qs = candidacies_current_qs
-        elif candidacies_ever_qs.count() > minimum_count:
-            qs = candidacies_ever_qs
-        else:
-            return self.party_choices_basic()
-        result = [('', '')]
-        parties_with_candidates = []
         for party_tuple in qs \
                 .values('on_behalf_of', 'on_behalf_of__name') \
                 .order_by() \


### PR DESCRIPTION
When creating a new form for a person on a site with lots of elections
and parties, PartySet.party_choices might be called many times (over
30 in the UK case); there's no need for this, so this commit caches
the results the first time they're fetched when creating a form object
and reused subsequently, using Django's helpful cached_property
decorator.

We were seeing timeouts when users were updating some candidates -
hopefully this should fix that issue, since these were causing the
most expensive queries when updating someone.