### PR TITLE
Further fixes for updating Twitter user IDs

### DIFF
--- a/candidates/models/versions.py
+++ b/candidates/models/versions.py
@@ -4,6 +4,8 @@ from .fields import ExtraField, SimplePopoloField, ComplexPopoloField
 
 from django.db.models import F
 
+from ..twitter_api import update_twitter_user_id, TwitterAPITokenMissing
+
 # FIXME: handle the extra fields (e.g. cv & program for BF)
 # FIXME: check all the preserve_fields are dealt with
 
@@ -166,3 +168,7 @@ def revert_person_from_version_data(person, person_extra, version_data):
             )
     person.save()
     person_extra.save()
+    try:
+        update_twitter_user_id(person)
+    except TwitterAPITokenMissing:
+        pass

--- a/candidates/twitter_api.py
+++ b/candidates/twitter_api.py
@@ -52,12 +52,18 @@ def update_twitter_user_id(person):
     try:
         screen_name = person.contact_details \
             .get(contact_type='twitter').value
+        user_id = get_twitter_user_id(screen_name)
     except ContactDetail.DoesNotExist:
-        return
-    user_id = get_twitter_user_id(screen_name)
-    if not user_id:
-        return
-    person.identifiers.update_or_create(
-        scheme='twitter',
-        defaults={'identifier': user_id}
-    )
+        screen_name = None
+        user_id = None
+    # Remove any existing Twitter user ID identifiers. (There might be
+    # multiple such identifiers in some cases, but one only want one
+    # after setting the screen name.  Or, if the Twitter screen name
+    # has been removed, the identifier should be removed too.)
+    person.identifiers.filter(scheme='twitter').delete()
+    # If a Twitter user ID was found, create an identifier for it:
+    if user_id:
+        person.identifiers.create(
+            scheme='twitter',
+            identifier=user_id,
+        )


### PR DESCRIPTION
These commits make sure that the Twitter user ID is updated correctly when:

* Removing the screen name
* Merging two people with Twitter screen names set
* Reverting to and old version of someone with a Twitter screen name but not identifier set