### PR TITLE
Display confirmed CandidateResult data on person pages

### DIFF
--- a/candidates/static/candidates/_people.scss
+++ b/candidates/static/candidates/_people.scss
@@ -461,3 +461,7 @@
 .plaintext-with-newlines {
   white-space: pre-line;
 }
+
+.candidate-result-confirmed {
+  font-weight: bold;
+}


### PR DESCRIPTION
This is a minimal change to display the vote count and whether someone
was reported as the winner for any candidacy where that CandidateResult
is associated with a ResultSet and PostResult where the PostResult is
confirmed.

This is a quick fix for #878 and only suitable for the DC fork of YNR.

![show-vote-count](https://cloud.githubusercontent.com/assets/7907/14967243/3a1a2f8a-10ae-11e6-849f-1f19dfc65625.png)
