### PR TITLE
UK: Add a link to the other names / AKA editing on person edit forms

### DIFF
--- a/elections/uk/templates/candidates/_person_form.html
+++ b/elections/uk/templates/candidates/_person_form.html
@@ -23,6 +23,15 @@
         {{ simple_field }}
       </p>
       {{ simple_field.errors }}
+      {% if simple_field.name == 'name'%}
+        {% if not add_candidate_form %}
+          <p class="alternative-names">
+            <a href="{% url 'person-other-names' person_id=person.id %}">
+              {% trans "Manage alternative names..." %}
+          </a></p>
+        {% endif %}
+      {% endif %}
+
     </div>
 
     {% endfor %}


### PR DESCRIPTION
This has been in upstream since f28e843296f but wasn't appearing in the
DC site because the _person_form.html partial template was overridden.