### PR TITLE
Don't include those elected in *other* elections in election-specific

### DIFF
--- a/candidates/management/commands/candidates_create_csv.py
+++ b/candidates/management/commands/candidates_create_csv.py
@@ -72,7 +72,7 @@ class Command(BaseCommand):
                 qs, self.complex_popolo_fields
         ):
             for d in person_extra.as_list_of_dicts(
-                None,
+                election,
                 base_url=self.options['site_base_url']
             ):
                 all_people.append(d)


### PR DESCRIPTION
This was a stupid bug introduced when factoring out the get_people
method; the as_list_of_dicts call should be passed 'election' so it
only considers candidacies for the appropriate election when getting
data for an election-specific CSV file.