### PR TITLE
If none of the Twitter details are valid, remove them

### DIFF
--- a/candidates/management/commands/candidates_update_twitter_usernames.py
+++ b/candidates/management/commands/candidates_update_twitter_usernames.py
@@ -71,11 +71,21 @@ class Command(BaseCommand):
                 .get(contact_type='twitter').value
         except ContactDetail.DoesNotExist:
             screen_name = None
+        except ContactDetail.MultipleObjectsReturned:
+            print(_("WARNING: multiple Twitter screen names found for {name} ({id}), skipping.").format(
+                name=person.name, id=person.id
+            ))
+            return
         try:
             user_id = person.identifiers \
                 .get(scheme='twitter').identifier
         except Identifier.DoesNotExist:
             user_id = None
+        except Identifier.MultipleObjectsReturned:
+            print(_("WARNING: multiple Twitter user IDs found for {name} ({id}), skipping.").format(
+                name=person.name, id=person.id
+            ))
+            return
         # If they have a Twitter user ID, then check to see if we
         # need to update the screen name from that; if so, update
         # the screen name.  Skip to the next person. This catches


### PR DESCRIPTION
The candidates_update_twitter_usernames script behaved less than ideally
in the case where none of their Twitter details correspond to a real
Twitter account (typically when they delete their account, or we only
have an old screen name that predates a change of screen name): it would
print out a warning, which would be emailed if the script is run from
a cron job.  This isn't ideal because we never want to be linking to
non-existent Twitter accounts from the site - the action you'd take on
seeing this warning is always going to be to remove or fix the bad data.
(The old values will still be in the version history, after all.)  You
might want to search for a new Twitter account too, but you can still do
that afterwards if the bad data were deleted.

This commit changes the behaviour of the script so this bad Twitter
account data is deleted automatically; it still emits a warning, so those
cases can be investigated (and in some cases new accounts found) by hand
afterwards.

This pull request also makes the script cope with people who have multiple
Twitter screen names or user IDs associated with them.