### PR TITLE
Add a function + management command to check paired models

### DIFF
--- a/candidates/management/commands/candidates_check_paired_models.py
+++ b/candidates/management/commands/candidates_check_paired_models.py
@@ -1,0 +1,17 @@
+from __future__ import print_function, unicode_literals
+
+import sys
+
+from django.core.management.base import BaseCommand
+
+from candidates.models import check_paired_models
+
+
+class Command(BaseCommand):
+
+    def handle(self, *args, **options):
+        errors = check_paired_models()
+        if errors:
+            for error in errors:
+                print(error)
+            sys.exit(1)

--- a/candidates/models/__init__.py
+++ b/candidates/models/__init__.py
@@ -2,6 +2,8 @@ from .auth import get_constituency_lock
 from .auth import get_constituency_lock_from_person_data
 from .auth import get_edits_allowed
 
+from .constraints import check_paired_models
+
 from .merge import merge_popit_people
 
 from .popolo_extra import AreaExtra

--- a/candidates/models/constraints.py
+++ b/candidates/models/constraints.py
@@ -1,0 +1,42 @@
+from . import popolo_extra as models
+
+
+def check_paired_models():
+    errors = []
+    for base, extra in (
+        (models.Person, models.PersonExtra),
+        (models.Organization, models.OrganizationExtra),
+        (models.Post, models.PostExtra),
+        (models.Area, models.AreaExtra),
+        (models.Image, models.ImageExtra),
+    ):
+        format_kwargs = {'base': base.__name__, 'extra': extra.__name__}
+        base_ids = set(
+            base.objects.values_list('pk', flat=True))
+        base_ids_from_extra = set(
+            extra.objects.values_list('base_id', flat=True))
+        extra_ids = set(
+            extra.objects.values_list('pk', flat=True))
+        if len(base_ids) != len(extra_ids):
+            msg = 'There were {base_count} {base} objects, but ' \
+                  '{extra_count} {extra} objects'
+            fmt = format_kwargs.copy()
+            fmt.update({
+                'base_count': len(base_ids),
+                'extra_count': len(extra_ids)})
+            errors.append(msg.format(**fmt))
+        base_ids_with_no_extra = sorted(base_ids - base_ids_from_extra)
+        for base_id in base_ids_with_no_extra:
+            msg = 'The {base} object with ID {id} had no corresponding ' \
+                  '{extra} object'
+            fmt = format_kwargs.copy()
+            fmt.update({'id': base_id})
+            errors.append(msg.format(**fmt))
+        # We could try to check for other errors here, but they are
+        # prevented by various constraints. For example, you can't
+        # have an *Extra object with no corresponding base object,
+        # because the OneToOneField 'base' fields have the default
+        # null=False. As a second example, you can't have more than
+        # one *Extra object pointing to the same base object because
+        # there is a unique constraint on the base_id field.
+    return errors

--- a/candidates/tests/test_paired_constraint_check.py
+++ b/candidates/tests/test_paired_constraint_check.py
@@ -1,0 +1,27 @@
+from __future__ import unicode_literals
+
+from django.test import TestCase
+from popolo.models import Post
+
+from ..models import check_paired_models
+from .uk_examples import UK2015ExamplesMixin
+
+
+class PairedConstraintCheckTests(UK2015ExamplesMixin, TestCase):
+
+    def test_no_problems_normally(self):
+        errors = check_paired_models()
+        for e in errors:
+            print e
+        self.assertEqual(0, len(errors))
+
+    def test_base_with_no_extra_detected(self):
+        unpaired_post = Post.objects.create(organization=self.commons)
+        expected_errors = [
+            'There were 5 Post objects, but 4 PostExtra objects',
+            'The Post object with ID {} had no corresponding ' \
+            'PostExtra object'.format(unpaired_post.id)
+            ]
+        self.assertEqual(
+            check_paired_models(),
+            expected_errors)

--- a/candidates/tests/uk_examples.py
+++ b/candidates/tests/uk_examples.py
@@ -13,7 +13,8 @@ class UK2015ExamplesMixin(object):
         self.ni_parties = factories.PartySetFactory.create(
             slug='ni', name='Northern Ireland'
         )
-        self.commons = factories.ParliamentaryChamberFactory.create()
+        commons_extra = factories.ParliamentaryChamberExtraFactory.create()
+        self.commons = commons_extra.base
         # Create the 2010 and 2015 general elections:
         self.election = factories.ElectionFactory.create(
             slug='2015',


### PR DESCRIPTION
For all the *Extra models that are linked by a OneToOneField to a base
object, like PostExtra <-> Post, AreaExtra <-> Area we should never
have an object from the base model without exactly one corresponding
object of the extra model.  This can happen through coding errors,
manual changes to the database, or changes made in the Django admin.

This commit adds a function which will check for any such base objects
of these models that are unpaired. This can be called at the end of
transactions that make complex changes to the data to ensure that it
hasn't created that situation. It also provides this check as a
management command, for one-off checks.