### PR TITLE
Group and order elections by date

### DIFF
--- a/candidates/templates/candidates/api.html
+++ b/candidates/templates/candidates/api.html
@@ -69,16 +69,20 @@ explaining how to get election results from this site</a>.
       {% else %}
         {% trans "Past Elections" %}
       {% endif %}</h3>
-      {% for role_data in era.roles %}
-        <h4>{{ role_data.role }}</h4>
-        <ul>
-          {% for election in role_data.elections %}
-            {% with slug=election.election.slug title=election.election.name %}
-              <li><a href="{{ MEDIA_URL }}candidates-{{ slug }}.csv">{% blocktrans %}Download of the {{ title }} candidates {% endblocktrans %}</a></li>
-            {% endwith %}
+        {% for date, roles in era.dates.items %}
+        <h4>{{ date }}</h4>
+          {% for role_data in roles %}
+            <h5>{{ role_data.role }}</h5>
+            <ul>
+              {% for election in role_data.elections %}
+                {% with slug=election.election.slug title=election.election.name %}
+                  <li><a href="{{ MEDIA_URL }}candidates-{{ slug }}.csv">{% blocktrans %}Download of the {{ title }} candidates {% endblocktrans %}</a></li>
+                {% endwith %}
+              {% endfor %}
+            </ul>
           {% endfor %}
-        </ul>
-      {% endfor %}
+        {% endfor %}
+
   </div>
   {% endfor %}
 

--- a/candidates/templates/candidates/posts.html
+++ b/candidates/templates/candidates/posts.html
@@ -14,23 +14,21 @@
   <p>{% trans "Follow one of the links below to see the known candidates for that post:" %}</p>
 
   {% for era in elections_and_posts %}
-    {% if era.current %}
-      {% for role_data in era.roles %}
-        <h2>{{ role_data.role }}</h2>
-        {% for election_data in role_data.elections %}
-          {% with election=election_data.election %}
-            <h3>{{ election.name }}</h3>
-            <ul>
-              {% for p in election_data.posts %}
-                <li>
-                 <a href="{% url 'constituency' election=election.slug post_id=p.slug ignored_slug=p.short_label|slugify %}">{{ p.base.label }}</a>
-                </li>
-              {% endfor %}
-            </ul>
-          {% endwith %}
-        {% endfor %}
+    {% for role_data in era.roles %}
+      <h2>{{ role_data.role }}</h2>
+      {% for election_data in role_data.elections %}
+        {% with election=election_data.election %}
+          <h3>{{ election.name }}</h3>
+          <ul>
+            {% for p in election_data.posts %}
+              <li>
+               <a href="{% url 'constituency' election=election.slug post_id=p.slug ignored_slug=p.short_label|slugify %}">{{ p.base.label }}</a>
+              </li>
+            {% endfor %}
+          </ul>
+        {% endwith %}
       {% endfor %}
-    {% endif %}
+    {% endfor %}
   {% endfor %}
 
 {% endblock %}

--- a/candidates/templates/candidates/posts.html
+++ b/candidates/templates/candidates/posts.html
@@ -12,21 +12,23 @@
 {% block content %}
 
   <p>{% trans "Follow one of the links below to see the known candidates for that post:" %}</p>
-
   {% for era in elections_and_posts %}
-    {% for role_data in era.roles %}
-      <h2>{{ role_data.role }}</h2>
-      {% for election_data in role_data.elections %}
-        {% with election=election_data.election %}
-          <h3>{{ election.name }}</h3>
-          <ul>
-            {% for p in election_data.posts %}
-              <li>
-               <a href="{% url 'constituency' election=election.slug post_id=p.slug ignored_slug=p.short_label|slugify %}">{{ p.base.label }}</a>
-              </li>
-            {% endfor %}
-          </ul>
-        {% endwith %}
+    {% for date, roles in era.dates.items %}
+      <h2>{{ date }}</h2>
+      {% for role_data in roles %}
+        <h3>{{ role_data.role }}</h3>
+        {% for election_data in role_data.elections %}
+          {% with election=election_data.election %}
+            <h4>{{ election.name }}</h4>
+            <ul>
+              {% for p in election_data.posts %}
+                <li>
+                 <a href="{% url 'constituency' election=election.slug post_id=p.slug ignored_slug=p.short_label|slugify %}">{{ p.base.label }}</a>
+                </li>
+              {% endfor %}
+            </ul>
+          {% endwith %}
+        {% endfor %}
       {% endfor %}
     {% endfor %}
   {% endfor %}

--- a/candidates/tests/test_group_elections.py
+++ b/candidates/tests/test_group_elections.py
@@ -1,3 +1,6 @@
+from collections import OrderedDict
+import datetime
+
 from django.test import TestCase
 
 from elections.models import Election
@@ -30,33 +33,39 @@ class TestElectionGrouping(UK2015ExamplesMixin, TestCase):
                 [
                     {
                         'current': True,
-                        'roles': [
-                            {
-                                'role': 'Member of Parliament',
-                                'elections': [
-                                    {'election': self.election},
-                                ]
-                            },
-                            {
-                                'role': 'Member of the Scottish Parliament',
-                                'elections': [
-                                    {'election': self.sp_c_election},
-                                    {'election': self.sp_r_election},
-                                ]
-                            }
-                        ]
+                        'dates': OrderedDict([
+                            (datetime.date(2016, 5, 5), [
+                                {
+                                    'role': 'Member of the Scottish Parliament',
+                                    'elections': [
+                                        {'election': self.sp_c_election},
+                                        {'election': self.sp_r_election},
+                                    ]
+                                }
+                            ]),
+                            (self.election.election_date, [
+                                {
+                                    'role': 'Member of Parliament',
+                                    'elections': [
+                                        {'election': self.election}
+                                    ]
+                                }
+                            ])
+                        ])
                     },
                     {
                         'current': False,
-                        'roles': [
-                            {
-                                'role': 'Member of Parliament',
-                                'elections': [
-                                    {'election': self.earlier_election},
-                                ]
-                            }
-                        ]
-                    },
+                        'dates': OrderedDict([
+                            (self.earlier_election.election_date, [
+                                {
+                                    'role': 'Member of Parliament',
+                                    'elections': [
+                                        {'election':self.earlier_election}
+                                    ]
+                                }
+                            ])
+                        ])
+                    }
                 ]
             )
 
@@ -67,49 +76,55 @@ class TestElectionGrouping(UK2015ExamplesMixin, TestCase):
                 [
                     {
                         'current': True,
-                        'roles': [
-                            {
+                        'dates': OrderedDict([
+                            (datetime.date(2016, 5, 5), [{
+                                'role': 'Member of the Scottish Parliament',
+                                'elections': [
+                                    {
+                                        'posts': [],
+                                        'election': self.sp_c_election
+                                    },
+                                    {
+                                        'posts': [],
+                                        'election': self.sp_r_election
+                                    }
+                                ]
+                            }]),
+                            (self.election.election_date, [{
                                 'role': 'Member of Parliament',
                                 'elections': [
                                     {
-                                        'election': self.election,
                                         'posts': [
                                             self.camberwell_post_extra,
                                             self.dulwich_post_extra,
                                             self.edinburgh_east_post_extra,
                                             self.edinburgh_north_post_extra,
-                                        ]
-                                    },
+                                        ],
+                                        'election': self.election
+                                    }
                                 ]
-                            },
-                            {
-                                'role': 'Member of the Scottish Parliament',
-                                'elections': [
-                                    {'election': self.sp_c_election, 'posts': []},
-                                    {'election': self.sp_r_election, 'posts': []},
-                                ]
-                            }
-                        ]
+                            }])
+                        ])
                     },
                     {
                         'current': False,
-                        'roles': [
-                            {
+                        'dates': OrderedDict([
+                            (self.earlier_election.election_date, [{
                                 'role': 'Member of Parliament',
                                 'elections': [
                                     {
-                                        'election': self.earlier_election,
                                         'posts': [
                                             self.camberwell_post_extra,
                                             self.dulwich_post_extra,
                                             self.edinburgh_east_post_extra,
                                             self.edinburgh_north_post_extra,
-                                        ]
-                                    },
+                                        ],
+                                        'election': self.earlier_election
+                                    }
                                 ]
-                            }
-                        ]
-                    },
+                            }])
+                        ])
+                    }
                 ]
             )
 
@@ -122,25 +137,24 @@ class TestElectionGrouping(UK2015ExamplesMixin, TestCase):
                 [
                     {
                         'current': True,
-                        'roles': [
-                            {
-                                'role': 'Member of Parliament',
-                                'elections': [
-                                    {'election': self.election},
+                        'dates': OrderedDict([
+                            (self.election.election_date, [{
+                                'role': 'Member of Parliament', 'elections': [
+                                    {'election': self.election}
                                 ]
-                            },
-                        ]
+                            }])
+                        ])
                     },
                     {
                         'current': False,
-                        'roles': [
-                            {
+                        'dates': OrderedDict([
+                            (self.earlier_election.election_date, [{
                                 'role': 'Member of Parliament',
                                 'elections': [
-                                    {'election': self.earlier_election},
+                                    {'election': self.earlier_election}
                                 ]
-                            }
-                        ]
-                    },
+                            }])
+                        ])
+                    }
                 ]
             )

--- a/candidates/views/posts.py
+++ b/candidates/views/posts.py
@@ -10,5 +10,6 @@ class PostListView(TemplateView):
     def get_context_data(self, **kwargs):
         context = super(PostListView, self).get_context_data(**kwargs)
         context['elections_and_posts'] = \
-            Election.group_and_order_elections(include_posts=True)
+            Election.group_and_order_elections(
+                include_posts=True, include_noncurrent=False)
         return context

--- a/elections/models.py
+++ b/elections/models.py
@@ -1,6 +1,6 @@
 from __future__ import unicode_literals
 
-from collections import defaultdict
+from collections import defaultdict, OrderedDict
 from datetime import date
 
 from django.db import models
@@ -96,8 +96,9 @@ class Election(models.Model):
         We should order and group elections in the following way:
 
           Group by current=True, then current=False
-            Group by for_post_role (ordered alphabetically)
-              Order election by election date (new to old) then election name
+            Group election by election date (new to old)
+              Group by for_post_role (ordered alphabetically)
+                Order by election name
 
         If the parameter include_posts is set to True, then the posts
         will be included as well.
@@ -107,7 +108,7 @@ class Election(models.Model):
         [
           {
             'current': True,
-            'roles': [
+            'dates': OrderedDict([(datetime.date(2017, 1, 5), [
               {
                 'role': 'Member of Parliament',
                 'elections': [
@@ -142,11 +143,11 @@ class Election(models.Model):
                   }
                 ]
               }
-            ]
+            ])
           },
           {
             'current': False,
-            'roles': [
+            'dates': OrderedDict([(datetime.date(2017, 1, 5), [
               {
                 'role': 'Member of Parliament',
                 'elections': [
@@ -161,20 +162,20 @@ class Election(models.Model):
                 ]
               }
             ]
-          },
+          ]),
         ]
 
         """
         from candidates.models import PostExtra
         result = [
-            {'current': True, 'roles': []},
+            {'current': True, 'dates': OrderedDict()},
         ]
         if include_noncurrent:
-            result.append({'current': False, 'roles': []})
+            result.append({'current': False, 'dates': OrderedDict()})
 
         role = None
         qs = cls.objects.order_by(
-            '-current', 'for_post_role', '-election_date', 'name'
+            'election_date', '-current', 'for_post_role', 'name',
         )
         # If we've been asked to include posts as well, add a prefetch
         # to the queryset:
@@ -194,7 +195,7 @@ class Election(models.Model):
         last_current = None
         for election in qs:
             current_index = 1 - int(election.current)
-            roles = result[current_index]['roles']
+            roles = result[current_index]['dates'].setdefault(election.election_date, [])
             # If the role has changed, or we've switched from current
             # elections to past elections, create a new array of
             # elections to append to:

--- a/elections/models.py
+++ b/elections/models.py
@@ -89,7 +89,8 @@ class Election(models.Model):
         return self.name
 
     @classmethod
-    def group_and_order_elections(cls, include_posts=False):
+    def group_and_order_elections(cls, include_posts=False,
+                                  include_noncurrent=True):
         """Group elections in a helpful order
 
         We should order and group elections in the following way:
@@ -167,8 +168,10 @@ class Election(models.Model):
         from candidates.models import PostExtra
         result = [
             {'current': True, 'roles': []},
-            {'current': False, 'roles': []},
         ]
+        if include_noncurrent:
+            result.append({'current': False, 'roles': []})
+
         role = None
         qs = cls.objects.order_by(
             '-current', 'for_post_role', '-election_date', 'name'
@@ -183,6 +186,8 @@ class Election(models.Model):
                         .order_by('base__label'),
                 )
             )
+        if not include_noncurrent:
+            qs = qs.filter(current=True)
         # The elections and posts are already sorted into the right
         # order, but now need to be grouped into the useful
         # data structure described in the docstring.


### PR DESCRIPTION
Might be best to see the commit messages for each. In short this changes the `Election.group_and_order_elections()` to group by (`current`, `date`, `election`, `post`) (Adding `date`).

This is because the output is confusing when there are current elections with more than one date, e.g. on the 'elections' page (`PostListView`).

In addition, I've added a kwarg to `group_and_order_elections` that removes non-current elections from the output. These elections were ignored in the template layer, so it may as well not be sent in the first place.