### PR TITLE
Improve the admin page for elections

### DIFF
--- a/elections/admin.py
+++ b/elections/admin.py
@@ -6,7 +6,7 @@ from .models import AreaType, Election
 class ElectionAdmin(admin.ModelAdmin):
     list_display = ('name', 'election_date', 'description', 'current')
     search_fields = ('name', 'slug')
-    ordering = ('election_date', 'name')
+    ordering = ('-election_date', 'name')
 
 class AreaTypeAdmin(admin.ModelAdmin):
     list_display = ('name', 'source')

--- a/elections/admin.py
+++ b/elections/admin.py
@@ -4,7 +4,7 @@ from django.contrib import admin
 from .models import AreaType, Election
 
 class ElectionAdmin(admin.ModelAdmin):
-    list_display = ('name', 'description', 'current')
+    list_display = ('name', 'election_date', 'description', 'current')
     search_fields = ('name', 'slug')
     ordering = ('election_date', 'name')
 


### PR DESCRIPTION
These changes add a column for the election date, and show the most recent elections first, not the oldest.

(Screenshot from an old database)

![election-dates](https://cloud.githubusercontent.com/assets/7907/22625361/3874c4ba-eb8c-11e6-9526-fa98f08888c3.png)
