### PR TITLE
Expect IDs (slugs) for both elections and post[Extra]

### DIFF
--- a/candidates/management/commands/candidates_import_statements_of_persons_nominated.py
+++ b/candidates/management/commands/candidates_import_statements_of_persons_nominated.py
@@ -115,12 +115,12 @@ class Command(BaseCommand):
                 election_name = row['Election']
                 election = election_name_to_election.get(election_name)
                 if election is None:
-                    election = Election.objects.get(name=election_name)
+                    election = Election.objects.get(slug=election_name)
                     election_name_to_election[election_name] = election
 
             try:
                 post = Post.objects.get(
-                    label=name,
+                    extra__slug=name,
                     extra__elections=election,
                 )
             except Post.DoesNotExist:


### PR DESCRIPTION
When importing SOPNs we should use IDs rather than the text of the election or
post