### PR TITLE
Treat MPO files as JPEGs when importing from the live site

### DIFF
--- a/candidates/management/commands/candidates_import_from_live_site.py
+++ b/candidates/management/commands/candidates_import_from_live_site.py
@@ -31,6 +31,7 @@ CACHE_DIRECTORY = join(dirname(__file__), '.download-cache')
 
 PILLOW_FORMAT_EXTENSIONS = {
     'JPEG': 'jpg',
+    'MPO': 'jpg',
     'PNG': 'png',
     'GIF': 'gif',
     'BMP': 'bmp',


### PR DESCRIPTION
There's at least one logo image file from the electoral commission which
is an MPO file [1] - the file is:

   Emblem_2303.jpe [sic]

This file can be treated a JPEG, though, so tell the importer to do so.

[1] https://en.wikipedia.org/wiki/JPEG#JPEG_Multi-Picture_Format