### PR TITLE
Avoid a division-by-zero on the homepage

### DIFF
--- a/elections/uk/views/frontpage.py
+++ b/elections/uk/views/frontpage.py
@@ -66,11 +66,13 @@ class ConstituencyPostcodeFinderView(ContributorsMixin, FormView):
         context['council_confirmed'] = CouncilElection.objects.filter(
             confirmed=True).count()
 
-        context['council_election_percent'] = round(
-            float(context['council_confirmed']) /
-            float(context['council_total'])
-            * 100)
-
+        if context['council_total']:
+            context['council_election_percent'] = round(
+                float(context['council_confirmed']) /
+                float(context['council_total'])
+                * 100)
+        else:
+            context['council_election_percent'] = 0
 
         from candidates.models import PostExtra
         from uk_results.models import PostResult


### PR DESCRIPTION
If you've just created a dev instance of the site over the API there'll
be no council results data, and the homepage will throw a divide-by-zero
exception. This commit checks and only does the division if there is
some council results data.