### PR TITLE
Render dates on /posts more typically for the UK

### DIFF
--- a/candidates/templates/candidates/posts.html
+++ b/candidates/templates/candidates/posts.html
@@ -14,7 +14,7 @@
   <p>{% trans "Follow one of the links below to see the known candidates for that post:" %}</p>
   {% for era in elections_and_posts %}
     {% for date, roles in era.dates.items %}
-      <h2>{{ date }}</h2>
+      <h2>{{ date|date }}</h2>
       {% for role_data in roles %}
         <h3>{{ role_data.role }}</h3>
         {% for election_data in role_data.elections %}

--- a/mysite/settings/conf.py
+++ b/mysite/settings/conf.py
@@ -505,4 +505,6 @@ def get_settings(conf_file_leafname, election_app=None, tests=False):
 
     result['RESULTS_FEATURE_ACTIVE'] = True
 
+    result['DATE_FORMAT'] = conf.get('DATE_FORMAT', "jS E Y")
+
     return result


### PR DESCRIPTION
@JoeMitchell says that "March, 2 2017" is more of an US style of date
(I guess because the way you'd say that out loud matches with MM/DD?).
This commit changes the date rendering on that page to, say,
"2nd March 2017":

![better-date-formats](https://cloud.githubusercontent.com/assets/7907/23102603/f26aef08-f6a3-11e6-93cd-041f44bca559.png)

Fixes #56 

n.b. I expect this test to fail:

  test_reports_top_page_json (cached_counts.tests.CachedCountTestCase)

... but there's a fix for that coming in https://github.com/DemocracyClub/yournextrepresentative/pull/54