### PR TITLE
Add checks to prevent conflicting not_standing and MembershipExtra data

### DIFF
--- a/candidates/models/constraints.py
+++ b/candidates/models/constraints.py
@@ -71,3 +71,13 @@ def check_membership_elections_consistent():
                     post_extra_slug=post_extra.slug,
                     election_slug=me.election.slug))
     return errors
+
+
+def check_no_candidancy_for_election(person, election):
+    if election.candidacies.filter(
+            base__person=person,
+            base__role=election.candidate_membership_role).exists():
+        msg = 'There was an existing candidacy for {person} ({person_id}) ' \
+            'in the election "{election}"'
+        raise Exception(msg.format(
+            person=person, person_id=person.id, election=election.name))

--- a/candidates/models/popolo_extra.py
+++ b/candidates/models/popolo_extra.py
@@ -663,6 +663,14 @@ class MembershipExtra(models.Model):
                 msg = 'Trying to create a candidacy for post {postextra} ' \
                       'and election {election} that aren\'t linked'
                 raise Exception(msg.format(**required))
+            if self.election in self.base.person.extra.not_standing.all():
+                msg = 'Trying to add a MembershipExtra with an election ' \
+                      '"{election}", but that\'s in {person} ' \
+                      '({person_id})\'s not_standing list.'
+                raise Exception(msg.format(
+                    election=self.election,
+                    person=self.base.person.name,
+                    person_id=self.base.person.id))
         super(MembershipExtra, self).save(*args, **kwargs)
 
 

--- a/candidates/models/popolo_extra.py
+++ b/candidates/models/popolo_extra.py
@@ -118,6 +118,8 @@ def update_person_from_form(person, person_extra, form):
                 elected=elected_saved.get(election_data.slug)
             )
         elif standing == 'not-standing':
+            from .constraints import check_no_candidancy_for_election
+            check_no_candidancy_for_election(person, election_data)
             person_extra.not_standing.add(election_data)
 
 

--- a/candidates/views/candidacies.py
+++ b/candidates/views/candidacies.py
@@ -11,6 +11,7 @@ from auth_helpers.views import user_in_group
 
 from popolo.models import Membership, Person, Post
 from candidates.models import MembershipExtra
+from candidates.models.constraints import check_no_candidancy_for_election
 
 from elections.mixins import ElectionMixin
 
@@ -115,6 +116,7 @@ class CandidacyDeleteView(ElectionMixin, LoginRequiredMixin, FormView):
                 extra__election=self.election_data,
             ).delete()
 
+            check_no_candidancy_for_election(person, self.election_data)
             person.extra.not_standing.add(self.election_data)
 
             person.extra.record_version(change_metadata)

--- a/candidates/views/candidacies.py
+++ b/candidates/views/candidacies.py
@@ -60,6 +60,8 @@ class CandidacyView(ElectionMixin, LoginRequiredMixin, FormView):
                 extra__election=self.election_data
             ).exists()
 
+            person.extra.not_standing.remove(self.election_data)
+
             if not membership_exists:
                 membership = Membership.objects.create(
                     person=person,
@@ -71,8 +73,6 @@ class CandidacyView(ElectionMixin, LoginRequiredMixin, FormView):
                     base=membership,
                     election=self.election_data
                 )
-
-            person.extra.not_standing.remove(self.election_data)
 
             person.extra.record_version(change_metadata)
             person.extra.save()


### PR DESCRIPTION
As discussed in Slack, we don't understand how it's arising that some people
are ending up with a candidancy linked to an election via MembershipExtra.election
while that election is also in their PersonExtra.not_standing relation. This pull
request adds checks that will throw an exception in any code path where that
situation could be created, so we both stop such bad data being created and get
a backtrace to help understand how that's happening.