### PR TITLE
Split out the Twitter avatar queuing from the Twitter username updater

### DIFF
--- a/candidates/management/commands/candidates_add_twitter_images_to_queue.py
+++ b/candidates/management/commands/candidates_add_twitter_images_to_queue.py
@@ -1,0 +1,77 @@
+from __future__ import print_function, unicode_literals
+
+from django.core.files.temp import NamedTemporaryFile
+from django.core.files import File
+from django.core.management.base import BaseCommand
+from django.db import transaction
+from django.utils.translation import ugettext as _
+
+from candidates.models import MultipleTwitterIdentifiers
+from moderation_queue.models import QueuedImage, CopyrightOptions
+from popolo.models import Person
+
+import requests
+
+from ..twitter import TwitterAPIData
+
+
+VERBOSE = False
+
+
+def verbose(*args, **kwargs):
+    if VERBOSE:
+        print(*args, **kwargs)
+
+
+class Command(BaseCommand):
+
+    help = "Add Twitter avatars for candidates without images to the moderation queue"
+
+    def add_twitter_image_to_queue(self, person, image_url):
+        if person.queuedimage_set.exclude(decision="rejected").exists():
+            # Don't add an image to the queue if there is one already
+            # Ignoring rejected queued images
+            verbose(_("  That person already had in image, so skipping."))
+            return
+
+        verbose(_("  Adding that person's Twitter avatar to the moderation queue"))
+        # Add a new queued image
+        image_url = image_url.replace('_normal.', '.')
+        img_temp = NamedTemporaryFile(delete=True)
+        img_temp.write(requests.get(image_url).content)
+        img_temp.flush()
+
+        qi = QueuedImage(
+            decision=QueuedImage.UNDECIDED,
+            why_allowed=CopyrightOptions.PROFILE_PHOTO,
+            justification_for_use="Auto imported from Twitter",
+            person=person
+        )
+        qi.save()
+        qi.image.save(image_url, File(img_temp))
+        qi.save()
+
+    def handle_person(self, person):
+        try:
+            user_id, screen_name = person.extra.twitter_identifiers
+        except MultipleTwitterIdentifiers as e:
+            print(u"WARNING: {message}, skipping".format(message=e))
+            return
+        if user_id and user_id in self.twitter_data.user_id_to_photo_url:
+            msg = "Considering adding a photo for {person} with Twitter " \
+                  "user ID: {user_id}"
+            verbose(_(msg).format(person=person, user_id=user_id))
+            self.add_twitter_image_to_queue(
+                person, self.twitter_data.user_id_to_photo_url[user_id])
+
+    def handle(self, *args, **options):
+        global VERBOSE
+        VERBOSE = int(options['verbosity']) > 1
+        self.twitter_data = TwitterAPIData()
+        self.twitter_data.update_from_api()
+        # Now go through every person in the database and see if we
+        # should add their Twitter avatar to the image moderation
+        # queue:
+        for person in Person.objects.select_related('extra'):
+            with transaction.atomic():
+                self.handle_person(person)

--- a/candidates/management/commands/candidates_update_twitter_usernames.py
+++ b/candidates/management/commands/candidates_update_twitter_usernames.py
@@ -88,7 +88,7 @@ class Command(BaseCommand):
                 return
             correct_screen_name = self.twitter_data.user_id_to_screen_name[user_id]
             if (screen_name is None) or (screen_name != correct_screen_name):
-                verbose(_("Correcting the screen name from {old_screen_name} to {correct_screen_name}").format(
+                print(_("Correcting the screen name from {old_screen_name} to {correct_screen_name}").format(
                     old_screen_name=screen_name,
                     correct_screen_name=correct_screen_name
                 ))
@@ -119,7 +119,7 @@ class Command(BaseCommand):
                 ))
                 self.remove_twitter_screen_name(person, screen_name)
                 return
-            verbose(_("Adding the user ID {user_id}").format(
+            print(_("Adding the user ID {user_id}").format(
                 user_id=self.twitter_data.screen_name_to_user_id[screen_name.lower()]
             ))
             person.identifiers.create(

--- a/candidates/management/commands/candidates_update_twitter_usernames.py
+++ b/candidates/management/commands/candidates_update_twitter_usernames.py
@@ -12,6 +12,7 @@ from django.utils.six import text_type
 from django.core.files.temp import NamedTemporaryFile
 from django.core.files import File
 
+from candidates.models import MultipleTwitterIdentifiers
 from popolo.models import ContactDetail, Identifier, Person
 from moderation_queue.models import QueuedImage, CopyrightOptions
 import requests
@@ -87,26 +88,10 @@ class Command(BaseCommand):
         )
 
     def handle_person(self, person):
-        # Get the Twitter screen name and user ID if they exist:
         try:
-            screen_name = person.contact_details \
-                .get(contact_type='twitter').value
-        except ContactDetail.DoesNotExist:
-            screen_name = None
-        except ContactDetail.MultipleObjectsReturned:
-            print(_("WARNING: multiple Twitter screen names found for {name} ({id}), skipping.").format(
-                name=person.name, id=person.id
-            ))
-            return
-        try:
-            user_id = person.identifiers \
-                .get(scheme='twitter').identifier
-        except Identifier.DoesNotExist:
-            user_id = None
-        except Identifier.MultipleObjectsReturned:
-            print(_("WARNING: multiple Twitter user IDs found for {name} ({id}), skipping.").format(
-                name=person.name, id=person.id
-            ))
+            user_id, screen_name = person.extra.twitter_identifiers
+        except MultipleTwitterIdentifiers as e:
+            print(u"WARNING: {message}, skipping".format(message=e))
             return
         # If they have a Twitter user ID, then check to see if we
         # need to update the screen name from that; if so, update

--- a/candidates/management/commands/candidates_update_twitter_usernames.py
+++ b/candidates/management/commands/candidates_update_twitter_usernames.py
@@ -5,19 +5,15 @@ from random import randint
 import sys
 
 from django.db import transaction
-from django.conf import settings
-from django.core.management.base import BaseCommand, CommandError
+from django.core.management.base import BaseCommand
 from django.utils.translation import ugettext as _
-from django.utils.six import text_type
-from django.core.files.temp import NamedTemporaryFile
-from django.core.files import File
 
 from candidates.models import MultipleTwitterIdentifiers
-from popolo.models import ContactDetail, Identifier, Person
-from moderation_queue.models import QueuedImage, CopyrightOptions
-import requests
+from popolo.models import Person
 
-MAX_IN_A_REQUEST = 100
+from ..twitter import TwitterAPIData
+
+
 VERBOSE = False
 
 
@@ -42,28 +38,6 @@ class Command(BaseCommand):
             }
         )
         person.extra.save()
-
-    def add_twitter_image_to_queue(self, person, image_url):
-        if person.queuedimage_set.exclude(decision="rejected").exists():
-            # Don't add an image to the queue if there is one already
-            # Ignoring rejected queued images
-            return
-
-        # Add a new queued image
-        image_url = image_url.replace('_normal.', '.')
-        img_temp = NamedTemporaryFile(delete=True)
-        img_temp.write(requests.get(image_url).content)
-        img_temp.flush()
-
-        qi = QueuedImage(
-            decision=QueuedImage.UNDECIDED,
-            why_allowed=CopyrightOptions.PROFILE_PHOTO,
-            justification_for_use="Auto imported from Twitter",
-            person=person
-        )
-        qi.save()
-        qi.image.save(image_url, File(img_temp))
-        qi.save()
 
     def remove_twitter_screen_name(self, person, twitter_screen_name):
         person.contact_details.get(
@@ -104,7 +78,7 @@ class Command(BaseCommand):
             verbose(_("{person} has a Twitter user ID: {user_id}").format(
                 person=person, user_id=user_id
             ))
-            if user_id not in self.user_id_to_screen_name:
+            if user_id not in self.twitter_data.user_id_to_screen_name:
                 print(_("Removing user ID {user_id} for {person_name} as it is not a valid Twitter user ID. {person_url}").format(
                     user_id=user_id,
                     person_name=person.name,
@@ -112,7 +86,7 @@ class Command(BaseCommand):
                 ))
                 self.remove_twitter_user_id(person, user_id)
                 return
-            correct_screen_name = self.user_id_to_screen_name[user_id]
+            correct_screen_name = self.twitter_data.user_id_to_screen_name[user_id]
             if (screen_name is None) or (screen_name != correct_screen_name):
                 verbose(_("Correcting the screen name from {old_screen_name} to {correct_screen_name}").format(
                     old_screen_name=screen_name,
@@ -128,9 +102,6 @@ class Command(BaseCommand):
                     screen_name=screen_name
                 ))
 
-            if user_id in self.user_id_to_photo_url:
-                self.add_twitter_image_to_queue(
-                    person, self.user_id_to_photo_url[user_id])
         # Otherwise, if they have a Twitter screen name (but no
         # user ID, since we already dealt with that case) then
         # find their Twitter user ID and set that as an identifier.
@@ -140,7 +111,7 @@ class Command(BaseCommand):
             verbose(_("{person} has Twitter screen name ({screen_name}) but no user ID").format(
                 person=person, screen_name=screen_name
             ))
-            if screen_name.lower() not in self.screen_name_to_user_id:
+            if screen_name.lower() not in self.twitter_data.screen_name_to_user_id:
                 print(_("Removing screen name {screen_name} for {person_name} as it is not a valid Twitter screen name. {person_url}").format(
                     screen_name=screen_name,
                     person_name=person.name,
@@ -149,11 +120,11 @@ class Command(BaseCommand):
                 self.remove_twitter_screen_name(person, screen_name)
                 return
             verbose(_("Adding the user ID {user_id}").format(
-                user_id=self.screen_name_to_user_id[screen_name.lower()]
+                user_id=self.twitter_data.screen_name_to_user_id[screen_name.lower()]
             ))
             person.identifiers.create(
                 scheme='twitter',
-                identifier=self.screen_name_to_user_id[screen_name.lower()]
+                identifier=self.twitter_data.screen_name_to_user_id[screen_name.lower()]
             )
             self.record_new_version(person)
         else:
@@ -164,63 +135,8 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
         global VERBOSE
         VERBOSE = int(options['verbosity']) > 1
-        token = settings.TWITTER_APP_ONLY_BEARER_TOKEN
-        if not token:
-            raise CommandError(_("TWITTER_APP_ONLY_BEARER_TOKEN was not set"))
-        headers = {'Authorization': 'Bearer {token}'.format(token=token)}
-
-        # Find all unique Twitter screen names in the database:
-        all_screen_names = list(
-            ContactDetail.objects.filter(contact_type='twitter'). \
-                values_list('value', flat=True).distinct()
-        )
-
-        # Find all unique Twitter identifiers in the database:
-        all_user_ids = list(
-            Identifier.objects.filter(scheme='twitter'). \
-                values_list('identifier', flat=True).distinct()
-        )
-
-        self.screen_name_to_user_id = {}
-        self.user_id_to_screen_name = {}
-        self.user_id_to_photo_url = {}
-        for i in range(0, len(all_screen_names), MAX_IN_A_REQUEST):
-            screen_names = all_screen_names[i:(i + MAX_IN_A_REQUEST)]
-            r = requests.post(
-                'https://api.twitter.com/1.1/users/lookup.json',
-                data={
-                    'screen_name': ','.join(screen_names)
-                },
-                headers=headers,
-            )
-            for d in r.json():
-                user_id = text_type(d['id'])
-                self.screen_name_to_user_id[d['screen_name'].lower()] = user_id
-                self.user_id_to_screen_name[user_id] = d['screen_name']
-                self.user_id_to_photo_url[user_id] = \
-                    d['profile_image_url_https']
-
-
-        # Now look for any user IDs in the database that weren't found
-        # from the above query:
-        remaining_user_ids = list(
-            set(all_user_ids) - set(self.user_id_to_screen_name.keys())
-        )
-        for i in range(0, len(remaining_user_ids), MAX_IN_A_REQUEST):
-            user_ids = remaining_user_ids[i:(i + MAX_IN_A_REQUEST)]
-            r = requests.post(
-                'https://api.twitter.com/1.1/users/lookup.json',
-                data={
-                    'user_id': ','.join(user_ids)
-                },
-                headers=headers,
-            )
-            for d in r.json():
-                user_id = text_type(d['id'])
-                self.screen_name_to_user_id[d['screen_name'].lower()] = user_id
-                self.user_id_to_screen_name[user_id] = d['screen_name']
-                self.user_id_to_photo_url[user_id] = \
-                    d['profile_image_url_https']
+        self.twitter_data = TwitterAPIData()
+        self.twitter_data.update_from_api()
         # Now go through every person in the database and check their
         # Twitter details:
         for person in Person.objects.select_related('extra'):

--- a/candidates/management/twitter.py
+++ b/candidates/management/twitter.py
@@ -1,0 +1,87 @@
+from __future__ import print_function, unicode_literals
+
+from django.conf import settings
+from django.utils.six import text_type
+from django.utils.translation import ugettext as _
+
+from popolo.models import ContactDetail, Identifier
+import requests
+
+
+def none_found_error(parsed_result):
+    msg = "Unknown error from the Twitter API: {0}"
+    if 'errors' not in parsed_result:
+        return False
+    errors = parsed_result['errors']
+    if len(errors) != 1:
+        raise Exception(msg.format(errors))
+    error = errors[0]
+    if error['code'] == 17:
+        return True
+    raise Exception(msg.format(errors))
+
+
+class TwitterAPIData(object):
+
+    MAX_IN_A_REQUEST = 100
+
+    def __init__(self):
+        self.token = settings.TWITTER_APP_ONLY_BEARER_TOKEN
+        if not self.token:
+            raise Exception(_("TWITTER_APP_ONLY_BEARER_TOKEN was not set"))
+        self.headers = {
+            'Authorization': 'Bearer {token}'.format(token=self.token)
+        }
+        self.screen_name_to_user_id = {}
+        self.user_id_to_screen_name = {}
+        self.user_id_to_photo_url = {}
+
+    def update_id_mapping(self, data):
+        user_id = text_type(data['id'])
+        screen_name = data['screen_name']
+        self.screen_name_to_user_id[screen_name.lower()] = user_id
+        self.user_id_to_screen_name[user_id] = screen_name
+        self.user_id_to_photo_url[user_id] = data['profile_image_url_https']
+
+    def update_from_api(self):
+        for data in self.twitter_results('screen_name', self.all_screen_names):
+            self.update_id_mapping(data)
+        # Now look for any user IDs in the database that weren't found
+        # from the above query:
+        remaining_user_ids = list(
+            set(self.all_user_ids) - set(self.user_id_to_screen_name.keys())
+        )
+        for data in self.twitter_results('user_id', remaining_user_ids):
+            self.update_id_mapping(data)
+
+    @property
+    def all_screen_names(self):
+        '''Find all unique Twitter screen names in the database'''
+        return set(
+            ContactDetail.objects.filter(contact_type='twitter'). \
+            values_list('value', flat=True)
+        )
+
+    @property
+    def all_user_ids(self):
+        '''Find all unique Twitter identifiers in the database'''
+        return set(
+            Identifier.objects.filter(scheme='twitter'). \
+                values_list('identifier', flat=True)
+        )
+
+    def twitter_results(self, key, values):
+        sorted_values = sorted(values)
+        for i in range(0, len(sorted_values), self.MAX_IN_A_REQUEST):
+            some_values = sorted_values[i:(i + self.MAX_IN_A_REQUEST)]
+            r = requests.post(
+                'https://api.twitter.com/1.1/users/lookup.json',
+                data={
+                    key: ','.join(some_values)
+                },
+                headers=self.headers,
+            )
+            parsed_result = r.json()
+            if not none_found_error(parsed_result):
+                for data in parsed_result:
+                    yield data

--- a/candidates/models/__init__.py
+++ b/candidates/models/__init__.py
@@ -9,6 +9,7 @@ from .constraints import check_membership_elections_consistent
 from .merge import merge_popit_people
 
 from .popolo_extra import AreaExtra
+from .popolo_extra import MultipleTwitterIdentifiers
 from .popolo_extra import PersonExtra
 from .popolo_extra import OrganizationExtra
 from .popolo_extra import PostExtra

--- a/candidates/tests/output.py
+++ b/candidates/tests/output.py
@@ -1,0 +1,18 @@
+from contextlib import contextmanager
+import sys
+
+from django.utils import six
+
+@contextmanager
+def capture_output():
+    # Suggested here: http://stackoverflow.com/a/17981937/223092
+    new_out, new_err = six.StringIO(), six.StringIO()
+    old_out, old_err = sys.stdout, sys.stderr
+    try:
+        sys.stdout, sys.stderr = new_out, new_err
+        yield new_out, new_err
+    finally:
+        sys.stdout, sys.stderr = old_out, old_err
+
+def split_output(stringio_output):
+    return stringio_output.getvalue().strip().splitlines()

--- a/candidates/tests/test_twitter_data.py
+++ b/candidates/tests/test_twitter_data.py
@@ -1,0 +1,215 @@
+from __future__ import print_function, unicode_literals
+
+from mock import Mock, PropertyMock,call, patch
+
+from django.test import TestCase, override_settings
+
+from candidates.management.twitter import TwitterAPIData
+
+from .factories import PersonExtraFactory
+
+
+def fake_twitter_api_post(*args, **kwargs):
+    data = kwargs['data']
+    mock_result = Mock()
+    if 'screen_name' in data:
+        if data['screen_name'] == 'mhl20,struan':
+            mock_result.json.return_value = [
+                {'id': 1234, 'screen_name': 'mhl20'},
+                {'id': 5678, 'screen_name': 'struan'},
+            ]
+            return mock_result
+        elif data['screen_name'] == 'symroe':
+            mock_result.json.return_value = [
+                {'id': 9012, 'screen_name': 'symroe'}
+            ]
+            return mock_result
+        elif data['screen_name'] == 'onlynonexistent':
+            mock_result.json.return_value = {
+                "errors": [
+                    {
+                        "code": 17,
+                        "message": "No user matches for specified terms."
+                    }
+                ]
+            }
+            return mock_result
+    elif 'user_id' in data:
+        if data['user_id'] == '42':
+            mock_result.json.return_value = [
+                {'id': 42, 'screen_name': 'FooBarBazQuux'}
+            ]
+            return mock_result
+        if data['user_id'] == '13984716923847632':
+            mock_result.json.return_value = {
+                "errors": [
+                    {
+                        "code": 17,
+                        "message": "No user matches for specified terms."
+                    }
+                ]
+            }
+            return mock_result
+    raise Exception("No Twitter API stub for {0} {1}".format(args, kwargs))
+
+
+class TestTwitterData(TestCase):
+
+    def test_error_on_missing_token(self):
+        with self.assertRaisesRegexp(
+                Exception,
+                r'TWITTER_APP_ONLY_BEARER_TOKEN was not set'):
+            TwitterAPIData()
+
+    @override_settings(TWITTER_APP_ONLY_BEARER_TOKEN='madeuptoken')
+    @patch('candidates.management.twitter.requests')
+    def test_makes_requests(self, mock_requests):
+        TwitterAPIData.MAX_IN_A_REQUEST = 2
+        twitter_data = TwitterAPIData()
+        mock_requests.post.side_effect = fake_twitter_api_post
+        twitter_results = list(twitter_data.twitter_results(
+            'screen_name',
+            ['mhl20', 'struan', 'symroe']))
+        self.assertEqual(
+            mock_requests.post.mock_calls,
+            [
+                call(
+                    'https://api.twitter.com/1.1/users/lookup.json',
+                    headers={u'Authorization': u'Bearer madeuptoken'},
+                    data={u'screen_name': u'mhl20,struan'}),
+                call(
+                    'https://api.twitter.com/1.1/users/lookup.json',
+                    headers={u'Authorization': u'Bearer madeuptoken'},
+                    data={u'screen_name': u'symroe'}),
+            ]
+        )
+        self.assertEqual(
+            twitter_results,
+            [
+                {'id': 1234, 'screen_name': 'mhl20'},
+                {'id': 5678, 'screen_name': 'struan'},
+                {'id': 9012, 'screen_name': 'symroe'},
+            ]
+        )
+
+    @override_settings(TWITTER_APP_ONLY_BEARER_TOKEN='madeuptoken')
+    @patch('candidates.management.twitter.requests')
+    def test_zero_results_for_screen_name_lookup(self, mock_requests):
+        twitter_data = TwitterAPIData()
+        mock_requests.post.side_effect = fake_twitter_api_post
+        twitter_results = list(twitter_data.twitter_results(
+            'screen_name',
+            ['onlynonexistent']))
+        self.assertEqual(twitter_results, [])
+
+    @override_settings(TWITTER_APP_ONLY_BEARER_TOKEN='madeuptoken')
+    @patch('candidates.management.twitter.requests')
+    def test_zero_results_for_user_id_lookup(self, mock_requests):
+        twitter_data = TwitterAPIData()
+        mock_requests.post.side_effect = fake_twitter_api_post
+        twitter_results = list(twitter_data.twitter_results(
+            'user_id',
+            ['13984716923847632']))
+        self.assertEqual(twitter_results, [])
+
+    @override_settings(TWITTER_APP_ONLY_BEARER_TOKEN='madeuptoken')
+    def test_all_screen_names(self):
+        joe = PersonExtraFactory.create(
+            base__id='1',
+            base__name='Joe Bloggs').base
+        joe.contact_details.create(
+            value='joenotreallyatwitteraccount',
+            contact_type='twitter',
+        )
+        jane = PersonExtraFactory.create(
+            base__id='2',
+            base__name='Jane Bloggs').base
+        jane.contact_details.create(
+            value='janenotreallyatwitteraccount',
+            contact_type='twitter')
+        twitter_data = TwitterAPIData()
+        self.assertEqual(
+            ['janenotreallyatwitteraccount', 'joenotreallyatwitteraccount'],
+            sorted(twitter_data.all_screen_names)
+        )
+
+    @override_settings(TWITTER_APP_ONLY_BEARER_TOKEN='madeuptoken')
+    def tests_all_user_ids(self):
+        joe = PersonExtraFactory.create(
+            base__id='1',
+            base__name='Joe Bloggs').base
+        joe.identifiers.create(
+            identifier='246',
+            scheme='twitter',
+        )
+        jane = PersonExtraFactory.create(
+            base__id='2',
+            base__name='Jane Bloggs').base
+        jane.identifiers.create(
+            identifier='357',
+            scheme='twitter')
+        twitter_data = TwitterAPIData()
+        self.assertEqual(
+            ['246', '357'],
+            sorted(twitter_data.all_user_ids)
+        )
+
+    @override_settings(TWITTER_APP_ONLY_BEARER_TOKEN='madeuptoken')
+    def test_update_individual_data(self):
+        twitter_data = TwitterAPIData()
+        twitter_data.update_id_mapping(
+            {
+                'id': 42,
+                'screen_name': 'FooBarBazQuux',
+                'profile_image_url_https': 'https://example.com/foo.jpg',
+            }
+        )
+        self.assertEqual(
+            twitter_data.screen_name_to_user_id,
+            {'foobarbazquux': '42'})
+        self.assertEqual(
+            twitter_data.user_id_to_screen_name,
+            {'42': 'FooBarBazQuux'})
+        self.assertEqual(
+            twitter_data.user_id_to_photo_url,
+            {'42': 'https://example.com/foo.jpg'})
+
+    @override_settings(TWITTER_APP_ONLY_BEARER_TOKEN='madeuptoken')
+    @patch('candidates.management.twitter.requests')
+    @patch('candidates.management.twitter.TwitterAPIData.update_id_mapping')
+    @patch('candidates.management.twitter.TwitterAPIData.all_user_ids', new_callable=PropertyMock)
+    @patch('candidates.management.twitter.TwitterAPIData.all_screen_names', new_callable=PropertyMock)
+    def test_update_from_api(
+            self,
+            mock_all_screen_names,
+            mock_all_user_ids,
+            mock_update_id_mapping,
+            mock_requests):
+        mock_requests.post.side_effect = fake_twitter_api_post
+        twitter_data = TwitterAPIData()
+        mock_all_user_ids.return_value = ['1234', '42']
+        mock_all_screen_names.return_value = ['mhl20', 'struan', 'symroe']
+        twitter_data.user_id_to_screen_name = {
+            '1234': 'mhl20',
+        }
+        twitter_data.update_from_api()
+        self.assertEqual(
+            mock_update_id_mapping.mock_calls,
+            [
+                call({'id': 1234, 'screen_name': 'mhl20'}),
+                call({'id': 5678, 'screen_name': 'struan'}),
+                call({'id': 9012, 'screen_name': 'symroe'}),
+                call({'id': 42, 'screen_name': 'FooBarBazQuux'}),
+            ]
+        )
+
+    @override_settings(TWITTER_APP_ONLY_BEARER_TOKEN='madeuptoken')
+    @patch('candidates.management.twitter.requests')
+    def test_unfaked_urls_raise_exception(self, mock_requests):
+        TwitterAPIData.MAX_IN_A_REQUEST = 2
+        twitter_data = TwitterAPIData()
+        mock_requests.post.side_effect = fake_twitter_api_post
+        with self.assertRaises(Exception):
+            list(twitter_data.twitter_results(
+                'screen_name',
+                ['foo', 'bar']))

--- a/candidates/tests/test_twitter_queue_images_command.py
+++ b/candidates/tests/test_twitter_queue_images_command.py
@@ -1,0 +1,137 @@
+from __future__ import print_function, unicode_literals
+
+from mock import Mock, call, patch
+
+from django.core.management import call_command
+from django.test import TestCase
+
+from moderation_queue.models import QueuedImage
+from .auth import TestUserMixin
+from .factories import PersonExtraFactory
+from .output import capture_output, split_output
+
+
+@patch('candidates.management.commands.candidates_add_twitter_images_to_queue.requests')
+@patch('candidates.management.commands.candidates_add_twitter_images_to_queue.TwitterAPIData')
+class TestTwitterImageQueueCommand(TestUserMixin, TestCase):
+
+    # Note that these tests test the existing behaviour of the
+    # command, which doesn't seem quite right to me. It only considers
+    # if there are non-rejected images for the person in the image
+    # queue, when perhaps it should also consider if there are any
+    # images in person.extra.images.
+
+    def setUp(self):
+        self.p_no_images = PersonExtraFactory.create(
+            base__id='1',
+            base__name='Person With No Existing Images').base
+        self.p_no_images.identifiers.create(
+            identifier='1001',
+            scheme='twitter')
+
+        p_existing_image = PersonExtraFactory.create(
+            base__id='2',
+            base__name='Person With An Existing Image').base
+        self.existing_undecided_image = p_existing_image.queuedimage_set.create(
+            decision=QueuedImage.UNDECIDED,
+            user=self.user,
+        )
+        p_existing_image.identifiers.create(
+            identifier='1002',
+            scheme='twitter')
+
+        self.p_only_rejected_in_queue = PersonExtraFactory.create(
+            base__id='3',
+            base__name='Person With Only Rejected Images In The Queue').base
+        self.existing_rejected_image = self.p_only_rejected_in_queue.queuedimage_set.create(
+            decision=QueuedImage.REJECTED,
+            user=self.user,
+        )
+        self.p_only_rejected_in_queue.identifiers.create(
+            identifier='1003',
+            scheme='twitter')
+
+        PersonExtraFactory.create(
+            base__id='4',
+            base__name='Person With No Twitter User ID')
+
+
+    def test_command(self, mock_twitter_data, mock_requests):
+
+        mock_twitter_data.return_value.user_id_to_photo_url = {
+            '1001': 'https://pbs.twimg.com/profile_images/abc/foo.jpg',
+            '1002': 'https://pbs.twimg.com/profile_images/def/bar.jpg',
+            '1003': 'https://pbs.twimg.com/profile_images/ghi/baz.jpg',
+        }
+
+        mock_requests.get.return_value = Mock(content=b'')
+
+        call_command('candidates_add_twitter_images_to_queue')
+
+        new_queued_images = QueuedImage.objects.exclude(
+            id__in=[
+                self.existing_undecided_image.id,
+                self.existing_rejected_image.id
+            ]
+        )
+
+        self.assertEqual(
+            mock_requests.get.mock_calls,
+            [
+                call('https://pbs.twimg.com/profile_images/abc/foo.jpg'),
+                call('https://pbs.twimg.com/profile_images/ghi/baz.jpg'),
+            ]
+        )
+
+        self.assertEqual(new_queued_images.count(), 2)
+        new_queued_images.get(person=self.p_no_images)
+        new_queued_images.get(person=self.p_only_rejected_in_queue)
+
+    def test_multiple_twitter_identifiers(self, mock_twitter_data, mock_requests):
+        self.p_no_images.identifiers.create(
+            identifier='1001',
+            scheme='twitter')
+
+        mock_twitter_data.return_value.user_id_to_photo_url = {
+            '1001': 'https://pbs.twimg.com/profile_images/abc/foo.jpg',
+            '1002': 'https://pbs.twimg.com/profile_images/def/bar.jpg',
+            '1003': 'https://pbs.twimg.com/profile_images/ghi/baz.jpg',
+        }
+
+        mock_requests.get.return_value = Mock(content=b'')
+
+        with capture_output() as (out, err):
+            call_command('candidates_add_twitter_images_to_queue', verbosity=3)
+
+        self.assertEqual(
+            split_output(out),
+            [
+                'WARNING: Multiple Twitter user IDs found for Person ' \
+                'With No Existing Images ({0}), skipping'.format(
+                    self.p_no_images.id),
+                'Considering adding a photo for Person With An Existing ' \
+                'Image with Twitter user ID: 1002',
+                '  That person already had in image, so skipping.',
+                'Considering adding a photo for Person With Only Rejected ' \
+                'Images In The Queue with Twitter user ID: 1003',
+                '  Adding that person\'s Twitter avatar to the moderation ' \
+                'queue'
+            ]
+        )
+
+        new_queued_images = QueuedImage.objects.exclude(
+            id__in=[
+                self.existing_undecided_image.id,
+                self.existing_rejected_image.id
+            ]
+        )
+
+        self.assertEqual(
+            mock_requests.get.mock_calls,
+            [
+                call('https://pbs.twimg.com/profile_images/ghi/baz.jpg'),
+            ]
+        )
+
+        self.assertEqual(new_queued_images.count(), 1)
+        new_queued_images.get(person=self.p_only_rejected_in_queue)

--- a/candidates/tests/test_twitter_update_usernames_command.py
+++ b/candidates/tests/test_twitter_update_usernames_command.py
@@ -1,0 +1,317 @@
+from __future__ import print_function, unicode_literals
+
+from mock import Mock, patch
+
+from django.core.management import call_command
+from django.test import TestCase, override_settings
+
+from .auth import TestUserMixin
+from .factories import PersonExtraFactory
+from .output import capture_output, split_output
+
+
+def fake_post_for_username_updater(*args, **kwargs):
+    data = kwargs['data']
+    mock_result = Mock()
+    if 'screen_name' in data:
+        if data['screen_name'] == 'notatwitteraccounteither,notreallyatwitteraccount':
+            mock_result.json.return_value = [
+                {
+                    'id': 321,
+                    'screen_name': 'notreallyatwitteraccount',
+                    'profile_image_url_https': 'https://example.com/a.jpg',
+                },
+                {
+                    'id': 765,
+                    'screen_name': 'notatwitteraccounteither',
+                    'profile_image_url_https': 'https://example.com/b.jpg',
+                },
+            ]
+            return mock_result
+    if 'user_id' in data:
+        if data['user_id'] == '987':
+            mock_result.json.return_value = [
+                {
+                    'id': 987,
+                    'screen_name': 'ascreennamewewereunawareof',
+                    'profile_image_url_https': 'https://example.com/c.jpg',
+                }
+            ]
+            return mock_result
+    raise Exception("No Twitter API stub for {0} {1}".format(args, kwargs))
+
+
+@patch('candidates.management.twitter.requests')
+class TestUpdateTwitterUsernamesCommand(TestUserMixin, TestCase):
+
+    def setUp(self):
+        for person_details in [
+            {
+                'attr': 'no_twitter',
+                'name': 'Person with no Twitter details',
+            },
+            {
+                'attr': 'just_userid',
+                'name': 'Person with just a Twitter user ID',
+                'user_id': '987',
+            },
+            {
+                'attr': 'just_screen_name',
+                'name': 'Person with just a Twitter screen name',
+                # We'll get the API to return 321 for their user_id
+                'screen_name': 'notreallyatwitteraccount',
+            },
+            {
+                'attr': 'screen_name_and_user_id',
+                'name': 'Someone with a Twitter screen name and user ID',
+                'user_id': '765',
+                'screen_name': 'notatwitteraccounteither',
+            }
+        ]:
+            person = PersonExtraFactory.create(
+                base__name=person_details['name']
+            ).base
+            setattr(self, person_details['attr'], person)
+            if 'user_id' in person_details:
+                person.identifiers.create(
+                    identifier=person_details['user_id'],
+                    scheme='twitter')
+            if 'screen_name' in person_details:
+                person.contact_details.create(
+                    value=person_details['screen_name'],
+                    contact_type='twitter')
+
+    @override_settings(TWITTER_APP_ONLY_BEARER_TOKEN='madeuptoken')
+    def test_commmand_warns_on_multiple_screen_names(self, mock_requests):
+
+        self.just_screen_name.contact_details.create(
+            value='notatwitteraccounteither',
+            contact_type='twitter'
+        )
+
+        mock_requests.post.side_effect = fake_post_for_username_updater
+
+        with capture_output() as (out, err):
+            call_command('candidates_update_twitter_usernames')
+
+        self.assertIn(
+            'WARNING: Multiple Twitter screen names found for Person with ' \
+            'just a Twitter screen name ({0}), skipping'.format(
+                self.just_screen_name.id),
+            split_output(out))
+
+    @override_settings(TWITTER_APP_ONLY_BEARER_TOKEN='madeuptoken')
+    def test_commmand_warns_on_multiple_user_ids(self, mock_requests):
+
+        self.just_userid.identifiers.create(
+            identifier='765',
+            scheme='twitter'
+        )
+
+        mock_requests.post.side_effect = fake_post_for_username_updater
+
+        with capture_output() as (out, err):
+            call_command('candidates_update_twitter_usernames')
+
+        self.assertIn(
+            'WARNING: Multiple Twitter user IDs found for Person with ' \
+            'just a Twitter user ID ({0}), skipping'.format(
+                self.just_userid.id),
+            split_output(out))
+
+    @override_settings(TWITTER_APP_ONLY_BEARER_TOKEN='madeuptoken')
+    def test_commmand_verbose_output(self, mock_requests):
+
+        mock_requests.post.side_effect = fake_post_for_username_updater
+
+        with capture_output() as (out, err):
+            call_command('candidates_update_twitter_usernames', verbosity=3)
+
+        self.assertEqual(
+            split_output(out),
+            ['Person with no Twitter details had no Twitter account information',
+             'Person with just a Twitter user ID has a Twitter user ID: 987',
+             'Correcting the screen name from None to ascreennamewewereunawareof',
+             'Person with just a Twitter screen name has Twitter screen name (notreallyatwitteraccount) but no user ID',
+             'Adding the user ID 321',
+             'Someone with a Twitter screen name and user ID has a Twitter user ID: 765',
+             'The screen name (notatwitteraccounteither) was already correct'])
+
+    @override_settings(TWITTER_APP_ONLY_BEARER_TOKEN='madeuptoken')
+    def test_commmand_adds_screen_name(self, mock_requests):
+
+        mock_requests.post.side_effect = fake_post_for_username_updater
+
+        with capture_output() as (out, err):
+            call_command('candidates_update_twitter_usernames')
+
+        self.assertEqual(
+            self.just_userid.contact_details.get(contact_type='twitter').value,
+            'ascreennamewewereunawareof')
+
+        self.assertEqual(split_output(out), [])
+
+    @override_settings(TWITTER_APP_ONLY_BEARER_TOKEN='madeuptoken')
+    def test_commmand_adds_user_id(self, mock_requests):
+
+        mock_requests.post.side_effect = fake_post_for_username_updater
+
+        with capture_output() as (out, err):
+            call_command('candidates_update_twitter_usernames')
+
+        self.assertEqual(
+            self.just_screen_name.identifiers.get(scheme='twitter').identifier,
+            '321')
+
+        self.assertEqual(split_output(out), [])
+
+    @override_settings(TWITTER_APP_ONLY_BEARER_TOKEN='madeuptoken')
+    def test_commmand_screen_name_was_wrong(self, mock_requests):
+
+        def fake_post_screen_name_wrong(*args, **kwargs):
+            data = kwargs['data']
+            mock_result = Mock()
+            if 'screen_name' in data:
+                if data['screen_name'] == 'notatwitteraccounteither,notreallyatwitteraccount':
+                    mock_result.json.return_value = [
+                        {
+                            'id': 321,
+                            'screen_name': 'notreallyatwitteraccount',
+                            'profile_image_url_https': 'https://example.com/a.jpg',
+                        },
+                    ]
+                    return mock_result
+            if 'user_id' in data:
+                if data['user_id'] == '765,987':
+                    mock_result.json.return_value = [
+                        {
+                            'id': 987,
+                            'screen_name': 'ascreennamewewereunawareof',
+                            'profile_image_url_https': 'https://example.com/c.jpg',
+                        },
+                        {
+                            'id': 765,
+                            'screen_name': 'changedscreenname',
+                            'profile_image_url_https': 'https://example.com/b.jpg',
+                        },
+                    ]
+                    return mock_result
+            raise Exception("No Twitter API stub for {0} {1}".format(args, kwargs))
+
+        mock_requests.post.side_effect = fake_post_screen_name_wrong
+
+        with capture_output() as (out, err):
+            call_command('candidates_update_twitter_usernames')
+
+        self.assertEqual(
+            self.screen_name_and_user_id.contact_details.get(contact_type='twitter').value,
+            'changedscreenname')
+
+        self.assertEqual(split_output(out), [])
+
+    @override_settings(TWITTER_APP_ONLY_BEARER_TOKEN='madeuptoken')
+    def test_commmand_screen_name_disappeared(self, mock_requests):
+
+        def fake_post_screen_name_disappeared(*args, **kwargs):
+            data = kwargs['data']
+            mock_result = Mock()
+            if 'screen_name' in data:
+                if data['screen_name'] == 'notatwitteraccounteither,notreallyatwitteraccount':
+                    mock_result.json.return_value = [
+                        {
+                            'id': 765,
+                            'screen_name': 'notatwitteraccounteither',
+                            'profile_image_url_https': 'https://example.com/b.jpg',
+                        },
+                    ]
+                    return mock_result
+            if 'user_id' in data:
+                if data['user_id'] == '987':
+                    mock_result.json.return_value = [
+                        {
+                            'id': 987,
+                            'screen_name': 'ascreennamewewereunawareof',
+                            'profile_image_url_https': 'https://example.com/c.jpg',
+                        }
+                    ]
+                    return mock_result
+            raise Exception("No Twitter API stub for {0} {1}".format(args, kwargs))
+
+        mock_requests.post.side_effect = fake_post_screen_name_disappeared
+
+        with capture_output() as (out, err):
+            call_command('candidates_update_twitter_usernames')
+
+        self.assertEqual(
+            self.just_screen_name.contact_details.filter(contact_type='twitter').count(),
+            0)
+        self.assertEqual(
+            self.just_screen_name.identifiers.filter(scheme='twitter').count(),
+            0)
+
+        self.assertEqual(
+            split_output(out),
+            [
+                'Removing screen name notreallyatwitteraccount for Person ' \
+                'with just a Twitter screen name as it is not a valid ' \
+                'Twitter screen name. ' \
+                '/person/{0}/person-with-just-a-twitter-screen-name'.format(
+                    self.just_screen_name.id)
+            ]
+        )
+
+    @override_settings(TWITTER_APP_ONLY_BEARER_TOKEN='madeuptoken')
+    def test_commmand_user_id_disappeared(self, mock_requests):
+
+        def fake_post_user_id_disappeared(*args, **kwargs):
+            data = kwargs['data']
+            mock_result = Mock()
+            if 'screen_name' in data:
+                if data['screen_name'] == 'notatwitteraccounteither,notreallyatwitteraccount':
+                    mock_result.json.return_value = [
+                        {
+                            'id': 321,
+                            'screen_name': 'notreallyatwitteraccount',
+                            'profile_image_url_https': 'https://example.com/a.jpg',
+                        },
+                        {
+                            'id': 765,
+                            'screen_name': 'notatwitteraccounteither',
+                            'profile_image_url_https': 'https://example.com/b.jpg',
+                        },
+                    ]
+                    return mock_result
+            if 'user_id' in data:
+                if data['user_id'] == '987':
+                    mock_result.json.return_value = {
+                        "errors": [
+                            {
+                                "code": 17,
+                                "message": "No user matches for specified terms."
+                            }
+                        ]
+                    }
+                    return mock_result
+            raise Exception("No Twitter API stub for {0} {1}".format(args, kwargs))
+
+        mock_requests.post.side_effect = fake_post_user_id_disappeared
+
+        with capture_output() as (out, err):
+            call_command('candidates_update_twitter_usernames')
+
+        self.assertEqual(
+            self.just_userid.contact_details.filter(contact_type='twitter').count(),
+            0)
+        self.assertEqual(
+            self.just_userid.identifiers.filter(scheme='twitter').count(),
+            0)
+
+        self.assertEqual(
+            split_output(out),
+            [
+                'Removing user ID 987 for Person with just a Twitter user ID ' \
+                'as it is not a valid Twitter user ID. '
+                '/person/{0}/person-with-just-a-twitter-user-id'.format(
+                    self.just_userid.id)
+            ]
+        )

--- a/candidates/tests/test_twitter_update_usernames_command.py
+++ b/candidates/tests/test_twitter_update_usernames_command.py
@@ -149,7 +149,13 @@ class TestUpdateTwitterUsernamesCommand(TestUserMixin, TestCase):
             self.just_userid.contact_details.get(contact_type='twitter').value,
             'ascreennamewewereunawareof')
 
-        self.assertEqual(split_output(out), [])
+        self.assertEqual(
+            split_output(out),
+            [
+                'Correcting the screen name from None to ascreennamewewereunawareof',
+                'Adding the user ID 321',
+            ]
+        )
 
     @override_settings(TWITTER_APP_ONLY_BEARER_TOKEN='madeuptoken')
     def test_commmand_adds_user_id(self, mock_requests):
@@ -163,7 +169,13 @@ class TestUpdateTwitterUsernamesCommand(TestUserMixin, TestCase):
             self.just_screen_name.identifiers.get(scheme='twitter').identifier,
             '321')
 
-        self.assertEqual(split_output(out), [])
+        self.assertEqual(
+            split_output(out),
+            [
+                'Correcting the screen name from None to ascreennamewewereunawareof',
+                'Adding the user ID 321',
+            ]
+        )
 
     @override_settings(TWITTER_APP_ONLY_BEARER_TOKEN='madeuptoken')
     def test_commmand_screen_name_was_wrong(self, mock_requests):
@@ -207,7 +219,14 @@ class TestUpdateTwitterUsernamesCommand(TestUserMixin, TestCase):
             self.screen_name_and_user_id.contact_details.get(contact_type='twitter').value,
             'changedscreenname')
 
-        self.assertEqual(split_output(out), [])
+        self.assertEqual(
+            split_output(out),
+            [
+                'Correcting the screen name from None to ascreennamewewereunawareof',
+                'Adding the user ID 321',
+                'Correcting the screen name from notatwitteraccounteither to changedscreenname',
+            ]
+        )
 
     @override_settings(TWITTER_APP_ONLY_BEARER_TOKEN='madeuptoken')
     def test_commmand_screen_name_disappeared(self, mock_requests):
@@ -252,11 +271,12 @@ class TestUpdateTwitterUsernamesCommand(TestUserMixin, TestCase):
         self.assertEqual(
             split_output(out),
             [
+                'Correcting the screen name from None to ascreennamewewereunawareof',
                 'Removing screen name notreallyatwitteraccount for Person ' \
                 'with just a Twitter screen name as it is not a valid ' \
                 'Twitter screen name. ' \
                 '/person/{0}/person-with-just-a-twitter-screen-name'.format(
-                    self.just_screen_name.id)
+                    self.just_screen_name.id),
             ]
         )
 
@@ -312,6 +332,7 @@ class TestUpdateTwitterUsernamesCommand(TestUserMixin, TestCase):
                 'Removing user ID 987 for Person with just a Twitter user ID ' \
                 'as it is not a valid Twitter user ID. '
                 '/person/{0}/person-with-just-a-twitter-user-id'.format(
-                    self.just_userid.id)
+                    self.just_userid.id),
+                'Adding the user ID 321',
             ]
         )


### PR DESCRIPTION
The command for checking whether Twitter screen names have changed
had had code added to it to also import Twitter avatars of candidates into
the photo moderation queue. This is problematic because the latter task is
something that is only run occasionally, whereas the screen name
checker should be run every day to spot any changes of screen name
around elections.

This pull request separated that command into two commands, adds test
coverage for both, and fixes some minor bugs. It also tidies up the code for
interacting with the Twitter API consderably, removing some repetition.