### PR TITLE
runtests: Suppress excessive output from logging with test failures

### DIFF
--- a/run-tests
+++ b/run-tests
@@ -34,9 +34,9 @@ for TEST_SETTINGS_MODULE in "${TEST_SETTINGS_MODULES[@]}"
 do
     if [ "$1" = "--coverage" ]
     then
-        COMMAND="coverage run -a --source=candidates,cached_counts,tasks,moderation_queue,elections --branch manage.py test  --noinput --settings=$TEST_SETTINGS_MODULE"
+        COMMAND="coverage run -a --source=candidates,cached_counts,tasks,moderation_queue,elections --branch manage.py test --nologcapture --noinput --settings=$TEST_SETTINGS_MODULE"
     else
-        COMMAND="./manage.py test --noinput --settings=$TEST_SETTINGS_MODULE"
+        COMMAND="./manage.py test --nologcapture --noinput --settings=$TEST_SETTINGS_MODULE"
     fi
     echo Running: $COMMAND
     $COMMAND


### PR DESCRIPTION
It's hard to read the output from Travis because of all the output from
logging, e.g.:

  factory.generate: DEBUG: BaseFactory: Generating candidates.tests.factories.CandidacyExtraFactory(base=<Membership: >, election=<Election: 2015 General Election>)

  urllib3.connectionpool: DEBUG: "POST /ynr-example_/modelresult/_bulk HTTP/1.1" 200 146

  elasticsearch: INFO: POST http://127.0.0.1:9200/ynr-example_/modelresult/_bulk [status:200 request:0.005s]

  django.db.backends: DEBUG: (0.001) SELECT "elections_election"."id" [...]

Adding --nologcapture to the invocations of ./manage.py tests in
runtests will suppress all output from logging. If people want to see
this output, they can run the tests without that option.