### PR TITLE
Ensure we don't to add a Twitter avatar to the moderation queue twice

### DIFF
--- a/candidates/management/commands/candidates_add_twitter_images_to_queue.py
+++ b/candidates/management/commands/candidates_add_twitter_images_to_queue.py
@@ -28,10 +28,13 @@ class Command(BaseCommand):
     help = "Add Twitter avatars for candidates without images to the moderation queue"
 
     def add_twitter_image_to_queue(self, person, image_url):
-        if person.queuedimage_set.exclude(decision="rejected").exists():
+        if person.queuedimage_set.exists():
             # Don't add an image to the queue if there is one already
-            # Ignoring rejected queued images
-            verbose(_("  That person already had in image, so skipping."))
+            # in the queue. It doesn't matter if that queued image has
+            # been moderated or not, or whether it's been rejected or
+            # not. At the moment we just want to be really careful not
+            # to make people check the same Twitter avatar twice.
+            verbose(_("  That person already had an image in the queue, so skipping."))
             return
 
         verbose(_("  Adding that person's Twitter avatar to the moderation queue"))

--- a/candidates/tests/test_twitter_queue_images_command.py
+++ b/candidates/tests/test_twitter_queue_images_command.py
@@ -1,10 +1,12 @@
 from __future__ import print_function, unicode_literals
 
 from mock import Mock, call, patch
+from os.path import dirname, join
 
 from django.core.management import call_command
 from django.test import TestCase
 
+from candidates.models import ImageExtra
 from moderation_queue.models import QueuedImage
 from .auth import TestUserMixin
 from .factories import PersonExtraFactory
@@ -15,13 +17,12 @@ from .output import capture_output, split_output
 @patch('candidates.management.commands.candidates_add_twitter_images_to_queue.TwitterAPIData')
 class TestTwitterImageQueueCommand(TestUserMixin, TestCase):
 
-    # Note that these tests test the existing behaviour of the
-    # command, which doesn't seem quite right to me. It only considers
-    # if there are non-rejected images for the person in the image
-    # queue, when perhaps it should also consider if there are any
-    # images in person.extra.images.
-
     def setUp(self):
+        self.image_filename = join(
+            dirname(__file__), '..', '..', 'moderation_queue', 'tests',
+            'example-image.jpg'
+        )
+
         self.p_no_images = PersonExtraFactory.create(
             base__id='1',
             base__name='Person With No Existing Images').base
@@ -55,6 +56,53 @@ class TestTwitterImageQueueCommand(TestUserMixin, TestCase):
             base__id='4',
             base__name='Person With No Twitter User ID')
 
+        self.p_accepted_image_in_queue = PersonExtraFactory.create(
+            base__id='5',
+            base__name='Person With An Accepted Image In The Queue').base
+        self.existing_accepted_image = self.p_accepted_image_in_queue.queuedimage_set.create(
+            decision=QueuedImage.APPROVED,
+            user=self.user,
+        )
+        self.p_accepted_image_in_queue.identifiers.create(
+            identifier='1005',
+            scheme='twitter')
+        # If they've had an image accepted, they'll probably have an
+        # Image too, so create that:
+        self.image_create_from_queue = ImageExtra.objects.create_from_file(
+            self.image_filename,
+            'images/person-accepted.jpg',
+            base_kwargs={
+                'content_object': self.p_accepted_image_in_queue,
+                'is_primary': True,
+                'source': 'From Flickr, used as an example image',
+            },
+            extra_kwargs={
+                'copyright': 'example-license',
+                'uploading_user': self.user,
+                'user_notes': 'Here is a photo for you!',
+            }
+        )
+
+        self.p_existing_image_but_none_in_queue = PersonExtraFactory.create(
+            base__id='6',
+            base__name='Person With An Existing Image But None In The Queue').base
+        self.p_existing_image_but_none_in_queue.identifiers.create(
+            identifier='1006',
+            scheme='twitter')
+        self.image_create_from_queue = ImageExtra.objects.create_from_file(
+            self.image_filename,
+            'images/person-existing-image.jpg',
+            base_kwargs={
+                'content_object': self.p_existing_image_but_none_in_queue,
+                'is_primary': True,
+                'source': 'From Flickr, used as an example image',
+            },
+            extra_kwargs={
+                'copyright': 'example-license',
+                'uploading_user': self.user,
+                'user_notes': 'Photo from their party page, say',
+            }
+        )
         self.existing_queued_image_ids = \
             list(QueuedImage.objects.values_list('pk', flat=True))
 
@@ -64,6 +112,8 @@ class TestTwitterImageQueueCommand(TestUserMixin, TestCase):
             '1001': 'https://pbs.twimg.com/profile_images/abc/foo.jpg',
             '1002': 'https://pbs.twimg.com/profile_images/def/bar.jpg',
             '1003': 'https://pbs.twimg.com/profile_images/ghi/baz.jpg',
+            '1005': 'https://pbs.twimg.com/profile_images/jkl/quux.jpg',
+            '1006': 'https://pbs.twimg.com/profile_images/mno/xyzzy.jpg',
         }
 
         mock_requests.get.return_value = Mock(content=b'')
@@ -74,16 +124,16 @@ class TestTwitterImageQueueCommand(TestUserMixin, TestCase):
             id__in=self.existing_queued_image_ids)
 
         self.assertEqual(
-            mock_requests.get.mock_calls,
-            [
-                call('https://pbs.twimg.com/profile_images/abc/foo.jpg'),
-                call('https://pbs.twimg.com/profile_images/ghi/baz.jpg'),
-            ]
+            set(c[1] for c in mock_requests.get.mock_calls),
+            {
+                ('https://pbs.twimg.com/profile_images/abc/foo.jpg',),
+                ('https://pbs.twimg.com/profile_images/mno/xyzzy.jpg',),
+            }
         )
 
         self.assertEqual(new_queued_images.count(), 2)
         new_queued_images.get(person=self.p_no_images)
-        new_queued_images.get(person=self.p_only_rejected_in_queue)
+        new_queued_images.get(person=self.p_existing_image_but_none_in_queue)
 
     def test_multiple_twitter_identifiers(self, mock_twitter_data, mock_requests):
         self.p_no_images.identifiers.create(
@@ -94,6 +144,8 @@ class TestTwitterImageQueueCommand(TestUserMixin, TestCase):
             '1001': 'https://pbs.twimg.com/profile_images/abc/foo.jpg',
             '1002': 'https://pbs.twimg.com/profile_images/def/bar.jpg',
             '1003': 'https://pbs.twimg.com/profile_images/ghi/baz.jpg',
+            '1005': 'https://pbs.twimg.com/profile_images/jkl/quux.jpg',
+            '1006': 'https://pbs.twimg.com/profile_images/mno/xyzzy.jpg',
         }
 
         mock_requests.get.return_value = Mock(content=b'')
@@ -109,9 +161,15 @@ class TestTwitterImageQueueCommand(TestUserMixin, TestCase):
                     self.p_no_images.id),
                 'Considering adding a photo for Person With An Existing ' \
                 'Image with Twitter user ID: 1002',
-                '  That person already had in image, so skipping.',
+                '  That person already had an image in the queue, so skipping.',
                 'Considering adding a photo for Person With Only Rejected ' \
                 'Images In The Queue with Twitter user ID: 1003',
+                '  That person already had an image in the queue, so skipping.',
+                'Considering adding a photo for Person With An Accepted ' \
+                'Image In The Queue with Twitter user ID: 1005',
+                '  That person already had an image in the queue, so skipping.',
+                'Considering adding a photo for Person With An Existing ' \
+                'Image But None In The Queue with Twitter user ID: 1006',
                 '  Adding that person\'s Twitter avatar to the moderation ' \
                 'queue'
             ]
@@ -123,9 +181,9 @@ class TestTwitterImageQueueCommand(TestUserMixin, TestCase):
         self.assertEqual(
             mock_requests.get.mock_calls,
             [
-                call('https://pbs.twimg.com/profile_images/ghi/baz.jpg'),
+                call('https://pbs.twimg.com/profile_images/mno/xyzzy.jpg'),
             ]
         )
 
         self.assertEqual(new_queued_images.count(), 1)
-        new_queued_images.get(person=self.p_only_rejected_in_queue)
+        new_queued_images.get(person=self.p_existing_image_but_none_in_queue)

--- a/candidates/tests/test_twitter_queue_images_command.py
+++ b/candidates/tests/test_twitter_queue_images_command.py
@@ -55,6 +55,8 @@ class TestTwitterImageQueueCommand(TestUserMixin, TestCase):
             base__id='4',
             base__name='Person With No Twitter User ID')
 
+        self.existing_queued_image_ids = \
+            list(QueuedImage.objects.values_list('pk', flat=True))
 
     def test_command(self, mock_twitter_data, mock_requests):
 
@@ -69,11 +71,7 @@ class TestTwitterImageQueueCommand(TestUserMixin, TestCase):
         call_command('candidates_add_twitter_images_to_queue')
 
         new_queued_images = QueuedImage.objects.exclude(
-            id__in=[
-                self.existing_undecided_image.id,
-                self.existing_rejected_image.id
-            ]
-        )
+            id__in=self.existing_queued_image_ids)
 
         self.assertEqual(
             mock_requests.get.mock_calls,
@@ -120,11 +118,7 @@ class TestTwitterImageQueueCommand(TestUserMixin, TestCase):
         )
 
         new_queued_images = QueuedImage.objects.exclude(
-            id__in=[
-                self.existing_undecided_image.id,
-                self.existing_rejected_image.id
-            ]
-        )
+            id__in=self.existing_queued_image_ids)
 
         self.assertEqual(
             mock_requests.get.mock_calls,


### PR DESCRIPTION
This changes the candidates_add_twitter_images_to_queue command to be
much more conservative about when it will enqueue a Twitter avatar for
moderation. It used to be that we enqueued a Twitter avatar for anyone
who didn't already have a rejected image in the moderation queue. This
meant, however, that if you'd rejected a Twitter avatar image from the
moderation queue, or it was still awaiting moderation, this command
would still requeue the image. This means that we can't run the command
from a cron job every night, or it would keep adding already moderated
images to the queue.

A more accurate way to deal with this would be to record a hash of
the images which are added to the moderation queue, and only enqueue
an image that hasn't already been queued for that person based on its
hash. However, that's a more involved change that the one in this
commit, which should nonetheless allow us to run the command from
cron without a risk of enqueuing duplicates.

Note that this command will still enqueue a Twitter avatar image for a
person who has an image already associated with them, so long as they
have never had an image in the moderation queue. This seems OK to me -
the Twitter avatar might well be a better or more up-to-date image than
whatever manually uploaded one we have, and it should be up to the
moderator to decide which should be their primary image.

Fixes #105 