### PR TITLE
Add tests that I hoped would reproduce a data loss on merge issue

### DIFF
--- a/candidates/tests/factories.py
+++ b/candidates/tests/factories.py
@@ -144,6 +144,17 @@ class PostExtraFactory(factory.DjangoModelFactory):
                 )
 
 
+class OrganizationFactory(factory.DjangoModelFactory):
+    class Meta:
+        model = 'popolo.Organization'
+
+
+class OrganizationExtraFactory(factory.DjangoModelFactory):
+    class Meta:
+        model = 'candidates.OrganizationExtra'
+    base = factory.SubFactory(OrganizationFactory)
+
+
 class PartyFactory(factory.DjangoModelFactory):
 
     class Meta:

--- a/candidates/tests/test_merge_people.py
+++ b/candidates/tests/test_merge_people.py
@@ -55,21 +55,6 @@ class TestMergePeople(TestCase):
             }
         )
 
-    def test_merge_array_primary_null(self):
-        primary = {
-            'some-list': None,
-        }
-        secondary = {
-            'some-list': ['a', 'b', 'c'],
-        }
-        merged = merge_popit_people(primary, secondary)
-        self.assertEqual(
-            merged,
-            {
-                'some-list': ['a', 'b', 'c'],
-            }
-        )
-
     def test_merge_array_secondary_null(self):
         primary = {
             'some-list': ['a', 'b', 'c'],

--- a/candidates/tests/test_merge_people.py
+++ b/candidates/tests/test_merge_people.py
@@ -6,6 +6,8 @@ from ..models import merge_popit_people
 
 class TestMergePeople(TestCase):
 
+    maxDiff = None
+
     def test_merge_basic_unknown_details(self):
         primary = {
             'foo': 'bar',
@@ -356,4 +358,145 @@ class TestMergePeople(TestCase):
                     },
                 ]
             }
+        )
+
+    def test_regression_merge_losing_memberships(self):
+        # Stuart Jeffery has had various IDs:
+        #    2111 (the current, canonical ID, originally created on 21st of December 2014)
+        #    4850 (a later one, created on 13th of December 2014)
+        #    12207 (latest, created on 13th April 2017)
+        #
+        # Two merges were done:
+        #
+        #    4850 (secondary) was merged into 2111 (primary) on 25th January 2015
+        #    12207 (secondary) was merged into 2111 (primary) on 1st May 2016
+        #
+        # The first merge appeared to work fine, but the second lost
+        # the 2010 and 2015 candidacies. That's the one we want to
+        # reproduce, so we need the last version with ID 12207 as the
+        # secondary. That is:
+        secondary = {
+            "birth_date": "",
+            "email": "",
+            "facebook_page_url": "",
+            "facebook_personal_url": "",
+            "gender": "",
+            "homepage_url": "",
+            "honorific_prefix": "",
+            "honorific_suffix": "",
+            "id": "12207",
+            "image": None,
+            "linkedin_url": "",
+            "name": "Stuart Robert Jeffery",
+            "other_names": [],
+            "party_memberships": {
+                "local.maidstone.2016-05-05": {
+                    "id": "party:63",
+                    "name": "Green Party"
+                }
+            },
+            "party_ppc_page_url": "",
+            "standing_in": {
+                "local.maidstone.2016-05-05": {
+                    "elected": False,
+                    "name": "Shepway South ward",
+                    "post_id": "DIW:E05005004"
+                }
+            },
+            "twitter_username": "",
+            "wikipedia_url": "",
+        }
+        # And the primary is the last version with ID 2111 before the merge:
+        primary = {
+            "birth_date": "1967-12-22",
+            "email": "sjeffery@fmail.co.uk",
+            "facebook_page_url": "",
+            "facebook_personal_url": "",
+            "gender": "male",
+            "homepage_url": "http://www.stuartjeffery.net/",
+            "honorific_prefix": "",
+            "honorific_suffix": "",
+            "id": "2111",
+            "identifiers": [
+                {
+                    "identifier": "2111",
+                    "scheme": "popit-person"
+                },
+                {
+                    "identifier": "3476",
+                    "scheme": "yournextmp-candidate"
+                },
+                {
+                    "identifier": "15712527",
+                    "scheme": "twitter"
+                }
+            ],
+            "image": "http://yournextmp.popit.mysociety.org/persons/2111/image/54bc790ecb19ebca71e2af8e",
+            "linkedin_url": "",
+            "name": "Stuart Jeffery",
+            "other_names": [],
+            "party_memberships": {
+                "2010": {
+                    "id": "party:63",
+                    "name": "Green Party"
+                },
+                "2015": {
+                    "id": "party:63",
+                    "name": "Green Party"
+                }
+            },
+            "party_ppc_page_url": "https://my.greenparty.org.uk/candidates/105873",
+            "standing_in": {
+                "2010": {
+                    "name": "Maidstone and The Weald",
+                    "post_id": "65936"
+                },
+                "2015": {
+                    "elected": False,
+                    "name": "Canterbury",
+                    "post_id": "65878"
+                }
+            },
+            "twitter_username": "stuartjeffery",
+            "wikipedia_url": ""
+        }
+        # What we observed from was that this merge lost the 2010 and
+        # 2015 memberships.
+        merged = merge_popit_people(primary, secondary)
+        self.assertEqual(
+            merged,
+            {'birth_date': '1967-12-22',
+             'email': 'sjeffery@fmail.co.uk',
+             'facebook_page_url': '',
+             'facebook_personal_url': '',
+             'gender': 'male',
+             'homepage_url': 'http://www.stuartjeffery.net/',
+             'honorific_prefix': '',
+             'honorific_suffix': '',
+             'id': '2111',
+             'identifiers': [{'identifier': '2111', 'scheme': 'popit-person'},
+                              {'identifier': '3476',
+                               'scheme': 'yournextmp-candidate'},
+                              {'identifier': '15712527', 'scheme': 'twitter'}],
+             'image': 'http://yournextmp.popit.mysociety.org/persons/2111/image/54bc790ecb19ebca71e2af8e',
+             'linkedin_url': '',
+             'name': 'Stuart Jeffery',
+             'other_names': [{'name': 'Stuart Robert Jeffery'}],
+             'party_memberships': {'2010': {'id': 'party:63',
+                                              'name': 'Green Party'},
+                                    '2015': {'id': 'party:63',
+                                              'name': 'Green Party'},
+                                    'local.maidstone.2016-05-05': {'id': 'party:63',
+                                                                    'name': 'Green Party'}},
+             'party_ppc_page_url': 'https://my.greenparty.org.uk/candidates/105873',
+             'standing_in': {'2010': {'name': 'Maidstone and The Weald',
+                                        'post_id': '65936'},
+                              '2015': {'elected': False,
+                                        'name': 'Canterbury',
+                                        'post_id': '65878'},
+                              'local.maidstone.2016-05-05': {'elected': False,
+                                                              'name': 'Shepway South ward',
+                                                              'post_id': 'DIW:E05005004'}},
+             'twitter_username': 'stuartjeffery',
+             'wikipedia_url': ''}
         )


### PR DESCRIPTION
I added these tests in an attempt to reproduce the problem seen in #118.
These don't reproduce the problem, unfortunately. My hope is that since
that broken merge was done some time ago (and in particular before merging
happened in a transaction) this problem may have been fixed by one of the
changes to the codebase since then. These tests may add some value in
the future, however, either by adding more involved examples of merging,
or by providing tests we can tweak to reproduce the problem if it's
still present and we understand why it happened.

Alternatively, this commit could be useful for cherry-picking back to an
earlier version of the code to try to reproduce the problem.
