### PR TITLE
The constituency page should 404 if the post & election aren't linked

### DIFF
--- a/candidates/views/constituencies.py
+++ b/candidates/views/constituencies.py
@@ -70,7 +70,8 @@ class ConstituencyDetailView(ElectionMixin, TemplateView):
         context['post_id'] = post_id = kwargs['post_id']
         mp_post = get_object_or_404(
             Post.objects.select_related('extra'),
-            extra__slug=post_id
+            extra__slug=post_id,
+            extra__elections__slug=self.election,
         )
         context['post_obj'] = mp_post
 


### PR DESCRIPTION
The constituency detail view page has a URL of the form:

  /election/ELECTION-ID/post/POST-ID/ARBITRARY-SLUG

Previously, if the POST-ID referred to a Post that wasn't associated
with the Election with ID ELECTION-ID, you'd just see an empty page.
This should really 404 instead as a more helpful signal to a user (who
might have been just been editing the URL - that's how this came up).

Thanks to Andy Lulham (@andylolz) for spotting this.