### PR TITLE
Make the Twitter-related commands handle people in a predictable order

### DIFF
--- a/candidates/management/commands/candidates_add_twitter_images_to_queue.py
+++ b/candidates/management/commands/candidates_add_twitter_images_to_queue.py
@@ -75,6 +75,6 @@ class Command(BaseCommand):
         # Now go through every person in the database and see if we
         # should add their Twitter avatar to the image moderation
         # queue:
-        for person in Person.objects.select_related('extra'):
+        for person in Person.objects.select_related('extra').order_by('name'):
             with transaction.atomic():
                 self.handle_person(person)

--- a/candidates/management/commands/candidates_update_twitter_usernames.py
+++ b/candidates/management/commands/candidates_update_twitter_usernames.py
@@ -139,6 +139,6 @@ class Command(BaseCommand):
         self.twitter_data.update_from_api()
         # Now go through every person in the database and check their
         # Twitter details:
-        for person in Person.objects.select_related('extra'):
+        for person in Person.objects.select_related('extra').order_by('name'):
             with transaction.atomic():
                 self.handle_person(person)

--- a/candidates/tests/test_twitter_queue_images_command.py
+++ b/candidates/tests/test_twitter_queue_images_command.py
@@ -125,13 +125,11 @@ class TestTwitterImageQueueCommand(TestUserMixin, TestCase):
         new_queued_images = QueuedImage.objects.exclude(
             id__in=self.existing_queued_image_ids)
 
-        self.assertEqual(
-            set(c[1] for c in mock_requests.get.mock_calls),
-            {
-                ('https://pbs.twimg.com/profile_images/abc/foo.jpg',),
-                ('https://pbs.twimg.com/profile_images/mno/xyzzy.jpg',),
-            }
-        )
+        mock_requests.get.mock_calls,
+        [
+            call('https://pbs.twimg.com/profile_images/abc/foo.jpg'),
+            call('https://pbs.twimg.com/profile_images/ghi/baz.jpg'),
+        ]
 
         self.assertEqual(new_queued_images.count(), 2)
         new_queued_images.get(person=self.p_no_images)
@@ -158,22 +156,22 @@ class TestTwitterImageQueueCommand(TestUserMixin, TestCase):
         self.assertEqual(
             split_output(out),
             [
-                'WARNING: Multiple Twitter user IDs found for Person ' \
-                'With No Existing Images ({0}), skipping'.format(
-                    self.p_no_images.id),
-                'Considering adding a photo for Person With An Existing ' \
-                'Image with Twitter user ID: 1002',
-                '  That person already had an image in the queue, so skipping.',
-                'Considering adding a photo for Person With Only Rejected ' \
-                'Images In The Queue with Twitter user ID: 1003',
-                '  That person already had an image in the queue, so skipping.',
                 'Considering adding a photo for Person With An Accepted ' \
                 'Image In The Queue with Twitter user ID: 1005',
                 '  That person already had an image in the queue, so skipping.',
                 'Considering adding a photo for Person With An Existing ' \
+                'Image with Twitter user ID: 1002',
+                '  That person already had an image in the queue, so skipping.',
+                'Considering adding a photo for Person With An Existing ' \
                 'Image But None In The Queue with Twitter user ID: 1006',
                 '  Adding that person\'s Twitter avatar to the moderation ' \
-                'queue'
+                'queue',
+                'WARNING: Multiple Twitter user IDs found for Person ' \
+                'With No Existing Images ({0}), skipping'.format(
+                    self.p_no_images.id),
+                'Considering adding a photo for Person With Only Rejected ' \
+                'Images In The Queue with Twitter user ID: 1003',
+                '  That person already had an image in the queue, so skipping.',
             ]
         )
 

--- a/candidates/tests/test_twitter_queue_images_command.py
+++ b/candidates/tests/test_twitter_queue_images_command.py
@@ -17,6 +17,8 @@ from .output import capture_output, split_output
 @patch('candidates.management.commands.candidates_add_twitter_images_to_queue.TwitterAPIData')
 class TestTwitterImageQueueCommand(TestUserMixin, TestCase):
 
+    maxDiff = None
+
     def setUp(self):
         self.image_filename = join(
             dirname(__file__), '..', '..', 'moderation_queue', 'tests',

--- a/candidates/tests/test_twitter_update_usernames_command.py
+++ b/candidates/tests/test_twitter_update_usernames_command.py
@@ -47,8 +47,10 @@ class TestUpdateTwitterUsernamesCommand(TestUserMixin, TestCase):
     def setUp(self):
         for person_details in [
             {
-                'attr': 'no_twitter',
-                'name': 'Person with no Twitter details',
+                'attr': 'just_screen_name',
+                'name': 'Person with just a Twitter screen name',
+                # We'll get the API to return 321 for their user_id
+                'screen_name': 'notreallyatwitteraccount',
             },
             {
                 'attr': 'just_userid',
@@ -56,10 +58,8 @@ class TestUpdateTwitterUsernamesCommand(TestUserMixin, TestCase):
                 'user_id': '987',
             },
             {
-                'attr': 'just_screen_name',
-                'name': 'Person with just a Twitter screen name',
-                # We'll get the API to return 321 for their user_id
-                'screen_name': 'notreallyatwitteraccount',
+                'attr': 'no_twitter',
+                'name': 'Person with no Twitter details',
             },
             {
                 'attr': 'screen_name_and_user_id',
@@ -129,11 +129,11 @@ class TestUpdateTwitterUsernamesCommand(TestUserMixin, TestCase):
 
         self.assertEqual(
             split_output(out),
-            ['Person with no Twitter details had no Twitter account information',
+            ['Person with just a Twitter screen name has Twitter screen name (notreallyatwitteraccount) but no user ID',
+             'Adding the user ID 321',
              'Person with just a Twitter user ID has a Twitter user ID: 987',
              'Correcting the screen name from None to ascreennamewewereunawareof',
-             'Person with just a Twitter screen name has Twitter screen name (notreallyatwitteraccount) but no user ID',
-             'Adding the user ID 321',
+             'Person with no Twitter details had no Twitter account information',
              'Someone with a Twitter screen name and user ID has a Twitter user ID: 765',
              'The screen name (notatwitteraccounteither) was already correct'])
 
@@ -152,8 +152,8 @@ class TestUpdateTwitterUsernamesCommand(TestUserMixin, TestCase):
         self.assertEqual(
             split_output(out),
             [
-                'Correcting the screen name from None to ascreennamewewereunawareof',
                 'Adding the user ID 321',
+                'Correcting the screen name from None to ascreennamewewereunawareof',
             ]
         )
 
@@ -172,8 +172,8 @@ class TestUpdateTwitterUsernamesCommand(TestUserMixin, TestCase):
         self.assertEqual(
             split_output(out),
             [
-                'Correcting the screen name from None to ascreennamewewereunawareof',
                 'Adding the user ID 321',
+                'Correcting the screen name from None to ascreennamewewereunawareof',
             ]
         )
 
@@ -222,8 +222,8 @@ class TestUpdateTwitterUsernamesCommand(TestUserMixin, TestCase):
         self.assertEqual(
             split_output(out),
             [
-                'Correcting the screen name from None to ascreennamewewereunawareof',
                 'Adding the user ID 321',
+                'Correcting the screen name from None to ascreennamewewereunawareof',
                 'Correcting the screen name from notatwitteraccounteither to changedscreenname',
             ]
         )
@@ -271,12 +271,12 @@ class TestUpdateTwitterUsernamesCommand(TestUserMixin, TestCase):
         self.assertEqual(
             split_output(out),
             [
-                'Correcting the screen name from None to ascreennamewewereunawareof',
                 'Removing screen name notreallyatwitteraccount for Person ' \
                 'with just a Twitter screen name as it is not a valid ' \
                 'Twitter screen name. ' \
                 '/person/{0}/person-with-just-a-twitter-screen-name'.format(
                     self.just_screen_name.id),
+                'Correcting the screen name from None to ascreennamewewereunawareof',
             ]
         )
 
@@ -329,10 +329,10 @@ class TestUpdateTwitterUsernamesCommand(TestUserMixin, TestCase):
         self.assertEqual(
             split_output(out),
             [
+                'Adding the user ID 321',
                 'Removing user ID 987 for Person with just a Twitter user ID ' \
                 'as it is not a valid Twitter user ID. '
                 '/person/{0}/person-with-just-a-twitter-user-id'.format(
                     self.just_userid.id),
-                'Adding the user ID 321',
             ]
         )


### PR DESCRIPTION
The tests of the two commands that use the Twitter API would randomly
fail because they relied on the order in which the commands handled
Person objects. This commit changes those commands to process people in
alphabetical order and adjusts the test expectations to match that
order. (The time it takes to order people by name is neglible compared
to the running time of those commands.)
