### PR TITLE
Do not error on bulk_add page if no SOPN

### DIFF
--- a/bulk_adding/templates/bulk_add/add_form.html
+++ b/bulk_adding/templates/bulk_add/add_form.html
@@ -26,6 +26,13 @@
   <li>Bask in the glow of making democracy better for everyone.</li>
   <li>Return to the home page to do another one!</li>
 </ol>
+{% else %}
+<p>
+This post doesn't have a nomination paper.
+            Can you help us by
+            <a href="{% url 'upload_document_view' election=election post_id=post_extra.slug %}">uploading
+            the PDF of the Statement of Persons Nominated?</a>
+</p>
 {% endif %}
 {% if known_people %}
 <h3>There {{ known_people|pluralize:"is,are" }} {{ known_people|length|apnumber }} candidate{{ known_people|pluralize }} listed in this area already:</h3>

--- a/bulk_adding/templates/bulk_add/add_form.html
+++ b/bulk_adding/templates/bulk_add/add_form.html
@@ -26,14 +26,6 @@
   <li>Bask in the glow of making democracy better for everyone.</li>
   <li>Return to the home page to do another one!</li>
 </ol>
-{% else %}
-<p>
-This post doesn't have a nomination paper.
-            Can you help us by
-            <a href="{% url 'upload_document_view' election=election post_id=post_extra.slug %}">uploading
-            the PDF of the Statement of Persons Nominated?</a>
-</p>
-{% endif %}
 {% if known_people %}
 <h3>There {{ known_people|pluralize:"is,are" }} {{ known_people|length|apnumber }} candidate{{ known_people|pluralize }} listed in this area already:</h3>
 <p>If {{ known_people|pluralize:"this person is,any of these people are" }} not listed on the nomination paper, please press edit and mark them as not standing in this specific election.</p>
@@ -97,5 +89,13 @@ This post doesn't have a nomination paper.
     })
 
 </script>
+{% else %}
+<p>
+This post doesn't have a nomination paper.
+            Can you help us by
+            <a href="{% url 'upload_document_view' election=election post_id=post_extra.slug %}">uploading
+            the PDF of the Statement of Persons Nominated?</a>
+</p>
+{% endif %}
 
 {% endblock content %}

--- a/bulk_adding/tests.py
+++ b/bulk_adding/tests.py
@@ -1,3 +1,56 @@
-from django.test import TestCase
+from django_webtest import WebTest
+from candidates.tests.auth import TestUserMixin
 
-# Create your tests here.
+from official_documents.models import OfficialDocument
+
+from nose.plugins.attrib import attr
+from candidates.tests.uk_examples import UK2015ExamplesMixin
+
+
+@attr(country='uk')
+class TestBulkAdding(TestUserMixin, UK2015ExamplesMixin, WebTest):
+
+    def setUp(self):
+        super(TestBulkAdding, self).setUp()
+
+    def testNoFormIfNoSopn(self):
+        response = self.app.get(
+            '/bulk_adding/2015/65808/',
+            user=self.user_who_can_upload_documents
+        )
+
+        self.assertContains(
+            response,
+            "This post doesn't have a nomination paper"
+        )
+
+        self.assertNotContains(
+            response,
+            "Review"
+        )
+
+    def testFormIfSopn(self):
+        post = self.dulwich_post_extra
+
+        doc = OfficialDocument.objects.create(
+            election=self.election,
+            post=post.base,
+            source_url='http://example.com',
+            document_type=OfficialDocument.NOMINATION_PAPER,
+            uploaded_file="sopn.pdf"
+        )
+
+        response = self.app.get(
+            '/bulk_adding/2015/65808/',
+            user=self.user_who_can_upload_documents
+        )
+
+        self.assertNotContains(
+            response,
+            "This post doesn't have a nomination paper"
+        )
+
+        self.assertContains(
+            response,
+            "Review"
+        )

--- a/bulk_adding/views.py
+++ b/bulk_adding/views.py
@@ -62,11 +62,14 @@ class BulkAddView(BaseBulkAddView):
         context = super(BulkAddView, self).get_context_data(**kwargs)
         context.update(self.add_election_and_post_to_context(context))
 
-
         form_kwargs = {
             'parties': context['parties'],
-            'source': context['official_document'].source_url,
         }
+
+        if 'official_document' in context and \
+                context['official_document'] is not None:
+            form_kwargs['source'] = context['official_document'].source_url,
+
         if self.request.POST:
             context['formset'] = forms.BulkAddFormSet(
                 self.request.POST, **form_kwargs

--- a/elections/uk/views/redirects.py
+++ b/elections/uk/views/redirects.py
@@ -83,8 +83,11 @@ class HelpOutCTAView(RedirectView):
     def get_redirect_url(self, *args, **kwargs):
         pe_qs = PostExtraElection.objects.filter(
             election__current=True,
-            postextra__suggestedpostlock=None
-            ).exclude(postextra__candidates_locked=True)
+            postextra__suggestedpostlock=None,
+            postextra__base__officialdocument__isnull=False
+            ).exclude(
+            postextra__candidates_locked=True,
+            ).distinct()
 
         if pe_qs:
             random_offset = random.randrange(min(50, pe_qs.count()))


### PR DESCRIPTION
This updates the bulk add page to display a message that says the SOPN is missing for the post and a link to the upload form. Previously this page would error if it was missing.

It also updates `/get_involved/` to only redirect to the bulk add page for posts with a SOPN.

![Uploading Screen Shot 2017-04-24 at 15.19.47.png…]()

Fixes #123