### PR TITLE
UK: preserve any CandidateResult objects on merging people

### DIFF
--- a/candidates/election_specific.py
+++ b/candidates/election_specific.py
@@ -1,5 +1,7 @@
 from __future__ import unicode_literals
 
+from contextlib import contextmanager
+
 from django.conf import settings
 from candidates.mapit import get_areas_from_coords
 
@@ -9,6 +11,12 @@ def default_fetch_area_ids(**kwargs):
         areas = get_areas_from_coords(kwargs['coords'])
 
     return areas
+
+
+@contextmanager
+def default_additional_merge_actions(primary_person, secondary_person):
+    yield
+
 
 # This is actually taken from Pombola's country-specific code package
 # in pombola/country/__init__.py. You should add to this list anything
@@ -20,6 +28,7 @@ imports_and_defaults = (
     ('shorten_post_label', lambda post_label: post_label),
     ('get_extra_csv_values', lambda person, election, post: {}),
     ('fetch_area_ids', default_fetch_area_ids),
+    ('additional_merge_actions', default_additional_merge_actions),
 )
 
 # Note that one could do this without the dynamic import and use of

--- a/elections/uk/lib.py
+++ b/elections/uk/lib.py
@@ -1,10 +1,13 @@
 from __future__ import unicode_literals
 
+from contextlib import contextmanager
 import re
 
 from django.core.exceptions import ObjectDoesNotExist
 
 from popolo.models import Post
+
+from uk_results.models import CandidateResult
 
 from .mapit import get_areas_from_postcode, get_areas_from_coords
 
@@ -107,5 +110,33 @@ def is_valid_postcode(postcode):
     return True
 
 
+@contextmanager
 def additional_merge_actions(primary_person, secondary_person):
+    # Before merging, save any CandidateResult objects that were
+    # attached to either person's memberships. (All the memberships
+    # are recreated as part when merging.)
+    saved_crs = [
+        (
+            cr,
+            {
+                'post': cr.membership.post,
+                'role': cr.membership.role,
+                'extra__election': cr.membership.extra.election,
+                'organization': cr.membership.organization,
+                'on_behalf_of': cr.membership.on_behalf_of,
+            }
+        )
+        for cr in
+        CandidateResult.objects.filter(
+            membership__person__in=(primary_person, secondary_person)
+        )
+    ]
+    # Then do the merge as normal:
     yield
+    # Now reassociate any saved CandidateResult objects with the
+    # appropriate membership on the primary person:
+    for saved_cr, membership_attrs in saved_crs:
+        primary_membership = primary_person.memberships.get(
+            **membership_attrs)
+        saved_cr.membership = primary_membership
+        saved_cr.save()

--- a/elections/uk/lib.py
+++ b/elections/uk/lib.py
@@ -105,3 +105,7 @@ def is_valid_postcode(postcode):
     if not postcode_regex.search(postcode):
         return False
     return True
+
+
+def additional_merge_actions(primary_person, secondary_person):
+    yield

--- a/elections/uk/tests/test_country_specific.py
+++ b/elections/uk/tests/test_country_specific.py
@@ -1,0 +1,18 @@
+from mock import patch
+
+from django.test import TestCase
+
+from nose.plugins.attrib import attr
+
+from candidates.election_specific import additional_merge_actions
+from candidates.tests import factories
+
+@attr(country='uk')
+class TestUKSpecificOverride(TestCase):
+
+    @patch('elections.uk.lib.additional_merge_actions')
+    def test_uk_version_is_actually_called(self, mock_additional_merge_actions):
+        primary = factories.PersonExtraFactory(base__name='Alice')
+        secondary = factories.PersonExtraFactory(base__name='Bob')
+        additional_merge_actions(primary, secondary)
+        mock_additional_merge_actions.assert_called

--- a/elections/uk/tests/test_custom_merge.py
+++ b/elections/uk/tests/test_custom_merge.py
@@ -1,0 +1,150 @@
+from django_webtest import WebTest
+from nose.plugins.attrib import attr
+from popolo.models import Person
+
+from candidates.tests import factories
+from candidates.tests.auth import TestUserMixin
+from candidates.tests.uk_examples import UK2015ExamplesMixin
+
+from uk_results.models import CandidateResult, PostResult, ResultSet
+
+
+@attr(country='uk')
+class TestUKResultsPreserved(TestUserMixin, UK2015ExamplesMixin, WebTest):
+
+    def setUp(self):
+        super(TestUKResultsPreserved, self).setUp()
+        self.primary_person = factories.PersonExtraFactory.create(
+            base__id='3885',
+            base__name='Harriet Harman'
+        ).base
+        self.secondary_person = factories.PersonExtraFactory.create(
+            base__id='10000',
+            base__name='Harriet Ruth Harman',
+        ).base
+        # And an extra election to create a candidacy of:
+        local_council = factories.OrganizationExtraFactory.create(
+            base__name='Maidstone',
+            slug='local-authority:maidstone',
+        ).base
+        self.local_election = factories.ElectionFactory.create(
+            slug='local.maidstone.2016-05-05',
+            organization=local_council,
+        )
+        self.local_post = factories.PostExtraFactory.create(
+            elections=(self.local_election,),
+            slug='DIW:E05005004',
+            base__label='Shepway South Ward',
+            party_set=self.gb_parties,
+            base__organization=local_council,
+        )
+
+    def test_uk_results_for_secondary_preserved(self):
+        factories.CandidacyExtraFactory.create(
+            election=self.earlier_election,
+            base__person=self.primary_person,
+            base__post=self.camberwell_post_extra.base,
+            base__on_behalf_of=self.labour_party_extra.base,
+        )
+        factories.CandidacyExtraFactory.create(
+            election=self.local_election,
+            base__person=self.secondary_person,
+            base__post=self.local_post.base,
+            base__on_behalf_of=self.labour_party_extra.base,
+        )
+        secondary_membership_extra = factories.CandidacyExtraFactory.create(
+            election=self.election,
+            base__person=self.secondary_person,
+            base__post=self.camberwell_post_extra.base,
+            base__on_behalf_of=self.labour_party_extra.base,
+        )
+
+        # Now attach a vote count to the secondary person's candidacy:
+        post_result = PostResult.objects.create(
+            post=secondary_membership_extra.base.post,
+            confirmed=False,
+        )
+        result_set = ResultSet.objects.create(
+            post_result=post_result,
+            num_turnout_reported=51561,
+            num_spoilt_ballots=42,
+            ip_address='127.0.0.1',
+        )
+        CandidateResult.objects.create(
+            result_set=result_set,
+            membership=secondary_membership_extra.base,
+            num_ballots_reported=32614,
+            is_winner=True,
+        )
+        # Now try the merge:
+        response = self.app.get(
+            '/person/3885/update',
+            user=self.user_who_can_merge)
+        merge_form = response.forms['person-merge']
+        merge_form['other'] = '10000'
+        response = merge_form.submit()
+
+        self.assertEqual(CandidateResult.objects.count(), 1)
+
+        # Now reget the original person and her candidacy - check it
+        # has a result attached.
+        after_merging = Person.objects.get(pk=3885)
+        membership = after_merging.memberships.get(
+            extra__election=self.election)
+        candidate_result = membership.result.get()
+        self.assertEqual(candidate_result.num_ballots_reported, 32614)
+
+    def test_uk_results_for_primary_preserved(self):
+        primary_membership_extra = factories.CandidacyExtraFactory.create(
+            election=self.earlier_election,
+            base__person=self.primary_person,
+            base__post=self.camberwell_post_extra.base,
+            base__on_behalf_of=self.labour_party_extra.base,
+        )
+        factories.CandidacyExtraFactory.create(
+            election=self.local_election,
+            base__person=self.secondary_person,
+            base__post=self.local_post.base,
+            base__on_behalf_of=self.labour_party_extra.base,
+        )
+        factories.CandidacyExtraFactory.create(
+            election=self.election,
+            base__person=self.secondary_person,
+            base__post=self.camberwell_post_extra.base,
+            base__on_behalf_of=self.labour_party_extra.base,
+        )
+
+        # Now attach a vote count to the primary person's candidacy:
+        post_result = PostResult.objects.create(
+            post=primary_membership_extra.base.post,
+            confirmed=False,
+        )
+        result_set = ResultSet.objects.create(
+            post_result=post_result,
+            num_turnout_reported=46659,
+            num_spoilt_ballots=42,
+            ip_address='127.0.0.1',
+        )
+        CandidateResult.objects.create(
+            result_set=result_set,
+            membership=primary_membership_extra.base,
+            num_ballots_reported=27619,
+            is_winner=True,
+        )
+        # Now try the merge:
+        response = self.app.get(
+            '/person/3885/update',
+            user=self.user_who_can_merge)
+        merge_form = response.forms['person-merge']
+        merge_form['other'] = '10000'
+        response = merge_form.submit()
+
+        self.assertEqual(CandidateResult.objects.count(), 1)
+
+        # Now reget the original person and her candidacy - check it
+        # has a result attached.
+        after_merging = Person.objects.get(pk=3885)
+        membership = after_merging.memberships.get(
+            extra__election=self.earlier_election)
+        candidate_result = membership.result.get()
+        self.assertEqual(candidate_result.num_ballots_reported, 27619)


### PR DESCRIPTION
When people are merged all the memberships of the primary person are
recreated - since CandidateResult objects from uk_results are associated
with Membership objects, this meant that they were being lost from both
the primary and secondary person on merging. This commit adds some
UK-specific merge logic that preserves any CandidateResult objects.

Fixes #76
