### PR TITLE
Allow either username or email to be used for login

### DIFF
--- a/mysite/forms.py
+++ b/mysite/forms.py
@@ -1,0 +1,14 @@
+from __future__ import unicode_literals
+
+from django import forms
+
+from allauth.account.forms import LoginForm
+
+from django.utils.translation import ugettext_lazy as _
+
+
+class CustomLoginForm(LoginForm):
+
+    def __init__(self, *args, **kwargs):
+        super(CustomLoginForm, self).__init__(*args, **kwargs)
+        self.fields['login'].label = _('Username or email address')

--- a/mysite/settings/conf.py
+++ b/mysite/settings/conf.py
@@ -285,6 +285,7 @@ def get_settings(conf_file_leafname, election_app=None, tests=False):
             'facebook': {'SCOPE': ['email',]},
         },
         'LOGIN_REDIRECT_URL': '/',
+        'ACCOUNT_AUTHENTICATION_METHOD': 'username_email',
         'ACCOUNT_EMAIL_VERIFICATION': 'mandatory',
         'ACCOUNT_EMAIL_REQUIRED': True,
         'ACCOUNT_USERNAME_REQUIRED': True,

--- a/mysite/settings/conf.py
+++ b/mysite/settings/conf.py
@@ -288,6 +288,9 @@ def get_settings(conf_file_leafname, election_app=None, tests=False):
         'ACCOUNT_AUTHENTICATION_METHOD': 'username_email',
         'ACCOUNT_EMAIL_VERIFICATION': 'mandatory',
         'ACCOUNT_EMAIL_REQUIRED': True,
+        'ACCOUNT_FORMS': {
+            'login': 'mysite.forms.CustomLoginForm',
+        },
         'ACCOUNT_USERNAME_REQUIRED': True,
         'ACCOUNT_USERNAME_VALIDATORS': 'mysite.helpers.allauth_validators',
         'SOCIALACCOUNT_AUTO_SIGNUP': True,


### PR DESCRIPTION
This change was committed earlier in the history, but looks like it
might have been accidentally reverted. This pull request also adds
a customization that @JoeMitchell requested: changing the label
of the 'login' field to say "Username or email address".