### PR TITLE
Avoid a bad queryset union, which caused person updates to fail

### DIFF
--- a/candidates/forms.py
+++ b/candidates/forms.py
@@ -472,10 +472,10 @@ class UpdatePersonForm(AddElectionFieldsMixin, BasePersonForm):
 
     def __init__(self, *args, **kwargs):
         super(UpdatePersonForm, self).__init__(*args, **kwargs)
-        self.elections_with_fields = Election.objects.filter(
+        self.elections_with_fields = list(Election.objects.filter(
                 candidacies__base__person=self.initial['person'],
                 current=True
-            ).order_by('-election_date')
+            ).order_by('-election_date'))
         # The fields on this form depends on how many elections are
         # going on at the same time. (FIXME: this might be better done
         # with formsets?)
@@ -500,11 +500,12 @@ class UpdatePersonForm(AddElectionFieldsMixin, BasePersonForm):
     def clean(self):
         if 'extra_election_id' in self.data:
             # We're adding a new election
-            election = Election.objects.filter(
+            election = Election.objects.get(
                 slug=self.data['extra_election_id'])
 
             # Add this new election to elections_with_fields
-            self.elections_with_fields  = self.elections_with_fields | election
+            if election not in self.elections_with_fields:
+                self.elections_with_fields.append(election)
 
             # Then re-create the form with the new election in
             self.add_elections_fields(self.elections_with_fields)

--- a/candidates/forms.py
+++ b/candidates/forms.py
@@ -290,10 +290,7 @@ class NewPersonForm(BasePersonForm):
         self.fields['standing_' + election] = \
             forms.ChoiceField(**standing_field_kwargs)
 
-        self.elections_with_fields = [
-            election_data
-        ]
-
+        self.elections_with_fields = [election_data]
 
         post_field_kwargs = {
             'label': _("Post in the {election}").format(


### PR DESCRIPTION
This fixes #134.

The line:

    self.elections_with_fields  = self.elections_with_fields | election

... was doing a union of two querysets. The results of this are
non-obvious (or incorrect depending on how you look at it) - even though
evaluating self.elections_with_fields would return 1 Election, and
evaluating election would return 1 Election, evaluating the union of
those two querysets would return about 500 instances of the latter
Election. The queries being generated by each queryset were as follows:

The self.elections_with_fields query was:

    SELECT "elections_election".[...]
    FROM "elections_election"
    INNER JOIN "candidates_membershipextra"
       ON ( "elections_election"."id" = "candidates_membershipextra"."election_id" )
    INNER JOIN "popolo_membership"
       ON ( "candidates_membershipextra"."base_id" = "popolo_membership"."id" )
    WHERE ("elections_election"."current" = True AND "popolo_membership"."person_id" = 5664)
    ORDER BY "elections_election"."election_date" DESC

The election query was:

    SELECT "elections_election".[...]
    FROM "elections_election"
    WHERE "elections_election"."slug" = parl.2017-06-08'

But the query generated for the union of those two querysets is:

    SELECT "elections_election".[...]
    FROM "elections_election"
    LEFT OUTER JOIN "candidates_membershipextra"
        ON ( "elections_election"."id" = "candidates_membershipextra"."election_id" )
    LEFT OUTER JOIN "popolo_membership"
        ON ( "candidates_membershipextra"."base_id" = "popolo_membership"."id" )
    WHERE (("elections_election"."current" = True AND "popolo_membership"."person_id" = 5664)
           OR "elections_election"."slug" = parl.2017-06-08)
    ORDER BY "elections_election"."election_date" DESC

In other words, it's including one Election with slug parl.2017-06-08
for every membership of that election, in addition to the elections the
candidate is standing in.

These many additional fields for the same election were processed after
the standing_ field for that election had been pop()ped which triggered
the issue in bug #134.

This is easily avoided, since there is not reason not to evaluated these
querysets immediately. This commit introduces that change.