### PR TITLE
Remove space before closing bracket

### DIFF
--- a/candidates/templates/candidates/person-view.html
+++ b/candidates/templates/candidates/person-view.html
@@ -192,11 +192,9 @@
                     use it if the LANGUAGE is English.
                   {% endcomment %}
                   {% if LANGUAGE_CODE|slice:":2" == 'en' %}
-                    ({% blocktrans trimmed with dob=person.extra.dob_as_date|date:"jS E Y" %}Date of birth: {{ dob }}
-                     {% endblocktrans %})
+                    ({% blocktrans trimmed with dob=person.extra.dob_as_date|date:"jS E Y" %}Date of birth: {{ dob }}{% endblocktrans %})
                   {% else %}
-                    ({% blocktrans trimmed with dob=person.extra.dob_as_date|date:"j E Y" %}Date of birth: {{ dob }}
-                     {% endblocktrans %})
+                    ({% blocktrans trimmed with dob=person.extra.dob_as_date|date:"j E Y" %}Date of birth: {{ dob }}{% endblocktrans %})
                   {% endif %}
                 </small>
             {% endif %}


### PR DESCRIPTION
For example: https://candidates.democracyclub.org.uk/person/5544/mike-kane

There's a space between the year and closing bracket:

---

![image](https://cloud.githubusercontent.com/assets/1324225/25404737/bb3c6d38-2a09-11e7-8bed-16f91fbcf383.png)

---

I've not tested this, but this looks like a likely fix, especially as pages with just a year don't have this problem and have `endblocktrans` with no line break.