### PR TITLE
Update copy

### DIFF
--- a/candidates/templates/candidates/about.html
+++ b/candidates/templates/candidates/about.html
@@ -38,7 +38,7 @@ other contributors</a>, to whom we owe a great debt of gratitude.
 <p>{% blocktrans trimmed %}
 You can use the data from this site, via the
 <a href="{{ api_url }}">API or CSV download</a>, under the
-terms of the Creative Commons license
+terms of the Creative Commons licence
 <a href="https://creativecommons.org/licenses/by-sa/4.0/">Attribution-ShareAlike
 (CC-BY-SA)</a> with the exception of:
 {% endblocktrans %}</p>

--- a/candidates/templates/candidates/api.html
+++ b/candidates/templates/candidates/api.html
@@ -207,7 +207,7 @@ constituency.
 
 <p>
   {% blocktrans trimmed %}
-    Each of the <tt>memberships</tt> in that reponse links to a
+    Each of the <tt>memberships</tt> in that response links to a
     person who is a candidate in that constituency for any known
     election.  The <tt>election</tt> property of each membership
     tells you which election that candidacy is for.

--- a/candidates/templates/candidates/api.html
+++ b/candidates/templates/candidates/api.html
@@ -23,11 +23,11 @@ The data that's submitted to this site is available as a <a href="#csv">CSV/Exce
 <div class="panel callout radius">
   <h2>Using our data</h2>
   <p>The data on this site is provided under a <a href="https://creativecommons.org/licenses/by-sa/3.0/">
-    CC BY-SA license.</a></p>
+    CC BY-SA licence.</a></p>
   <p>This means you are free to reuse the data for any reason, as long as you give attribution to "Democracy Club"
-    and any reuse is shared under the same license.  <a href="https://creativecommons.org/licenses/by-sa/3.0/">
+    and any reuse is shared under the same licence.  <a href="https://creativecommons.org/licenses/by-sa/3.0/">
       Please read the full terms for more information.</a></p>
-  <p>This license excludes:</p>
+  <p>This licence excludes:</p>
   <ul>
     <li>The party logos, which are taken from the Electoral Commission's website</li>
     <li>Candidate photos, which are typically either submitted by the candidates themselves,

--- a/candidates/templates/candidates/ask-for-copyright-assignment.html
+++ b/candidates/templates/candidates/ask-for-copyright-assignment.html
@@ -65,7 +65,7 @@ or remove copyright restrictions by releasing into the public domain
     widely available as possible while preventing the hard work of
     contributors to {{ site_name }} being unfairly co-opted by
     companies building closed candidate databases. This also allows
-    us the flexibility to release the data under different open licenses
+    us the flexibility to release the data under different open licences
     in the future.
     {% endblocktrans %}
   </p>

--- a/candidates/templates/candidates/person-view.html
+++ b/candidates/templates/candidates/person-view.html
@@ -265,7 +265,7 @@
     {% url 'help-about' as about_url %}
     <p>{% blocktrans trimmed %}
       More details about getting <a href="{{ api_url }}">the data</a>
-      and <a href="{{ about_url }}">its license</a>.
+      and <a href="{{ about_url }}">its licence</a>.
       {% endblocktrans %}</p>
   </div>
 

--- a/elections/jamaica/templates/candidates/api.html
+++ b/elections/jamaica/templates/candidates/api.html
@@ -83,7 +83,7 @@ organizations.
 
 <p>
   {% blocktrans trimmed %}
-    Each of the <tt>memberships</tt> in that reponse links to a
+    Each of the <tt>memberships</tt> in that response links to a
     person who is a candidate in that constituency for any known
     election.  The <tt>election</tt> property of each membership
     tells you which election that candidacy is for.

--- a/elections/uk/templates/candidates/about.html
+++ b/elections/uk/templates/candidates/about.html
@@ -49,7 +49,7 @@ with many thanks.
 <p>{% blocktrans trimmed %}
 You can use the data from this site, via the
 <a href="{{ api_url }}">API or CSV download</a>, under the
-terms of the Creative Commons license
+terms of the Creative Commons licence
 <a href="https://creativecommons.org/licenses/by-sa/4.0/">Attribution-ShareAlike
 (CC-BY-SA)</a> with the exception of:
 {% endblocktrans %}</p>

--- a/elections/uk/templates/candidates/about.html
+++ b/elections/uk/templates/candidates/about.html
@@ -39,7 +39,7 @@ other contributors</a>, to whom we owe a debt of gratitude.
 {% endblocktrans %}</p>
 
 <p>{% blocktrans trimmed %}
-The data on candidates from the last UK general election in
+The data on candidates from the UK general election in
 2010 is all taken from Edmund von der
 Burg's <a href="http://www.yournextmp.com">YourNextMP.com</a>,
 with many thanks.

--- a/elections/uk/templates/candidates/person-view.html
+++ b/elections/uk/templates/candidates/person-view.html
@@ -277,7 +277,7 @@
     {% url 'help-about' as about_url %}
     <p>{% blocktrans trimmed %}
       More details about getting <a href="{{ api_url }}">the data</a>
-      and <a href="{{ about_url }}">its license</a>.
+      and <a href="{{ about_url }}">its licence</a>.
       {% endblocktrans %}</p>
   </div>
 


### PR DESCRIPTION
* Change the noun "license" to "licence" in public-facing pages.

* Delete "last" in "last UK general election in 2010", as the last one was in 2015, and soon the last will have been in 2017.

I've only edited locale/en/LC_MESSAGES/django.po.

Should the corresponding `msgid`s be changed in the other languages' django.po file as well?

https://candidates.democracyclub.org.uk/help/api also has lots of noun "licenses", but I couldn't find where to edit this. Please could you point me in the right direction?