### PR TITLE
Make it less likely that the Twitter avatar importer imports non-images

### DIFF
--- a/candidates/management/commands/candidates_add_twitter_images_to_queue.py
+++ b/candidates/management/commands/candidates_add_twitter_images_to_queue.py
@@ -12,6 +12,7 @@ from popolo.models import Person
 
 import requests
 
+from ..images import get_image_extension
 from ..twitter import TwitterAPIData
 
 
@@ -49,6 +50,13 @@ class Command(BaseCommand):
             return
         img_temp.write(r.content)
         img_temp.flush()
+
+        # Trying to get the image extension checks that this really is
+        # an image:
+        if get_image_extension(img_temp.name) is None:
+            msg = _("  The image at {url} wasn't of a know type")
+            verbose(msg.format(url=image_url))
+            return
 
         qi = QueuedImage(
             decision=QueuedImage.UNDECIDED,

--- a/candidates/management/commands/candidates_add_twitter_images_to_queue.py
+++ b/candidates/management/commands/candidates_add_twitter_images_to_queue.py
@@ -54,7 +54,7 @@ class Command(BaseCommand):
         # Trying to get the image extension checks that this really is
         # an image:
         if get_image_extension(img_temp.name) is None:
-            msg = _("  The image at {url} wasn't of a know type")
+            msg = _("  The image at {url} wasn't of a known type")
             verbose(msg.format(url=image_url))
             return
 

--- a/candidates/management/commands/candidates_add_twitter_images_to_queue.py
+++ b/candidates/management/commands/candidates_add_twitter_images_to_queue.py
@@ -41,7 +41,13 @@ class Command(BaseCommand):
         # Add a new queued image
         image_url = image_url.replace('_normal.', '.')
         img_temp = NamedTemporaryFile(delete=True)
-        img_temp.write(requests.get(image_url).content)
+        r = requests.get(image_url)
+        if r.status_code != 200:
+            msg = _("  Ignoring an image URL with non-200 status code "
+                    "({status_code}): {url}")
+            verbose(msg.format(status_code=r.status_code, url=image_url))
+            return
+        img_temp.write(r.content)
         img_temp.flush()
 
         qi = QueuedImage(

--- a/candidates/management/images.py
+++ b/candidates/management/images.py
@@ -2,6 +2,32 @@ from __future__ import unicode_literals
 
 import hashlib
 
+from PIL import Image as PillowImage
+
+
 def get_file_md5sum(filename):
     with open(filename, 'rb') as f:
         return hashlib.md5(f.read()).hexdigest()
+
+
+PILLOW_FORMAT_EXTENSIONS = {
+    'JPEG': 'jpg',
+    'MPO': 'jpg',
+    'PNG': 'png',
+    'GIF': 'gif',
+    'BMP': 'bmp',
+}
+
+
+def get_image_extension(image_filename):
+    with open(image_filename, 'rb') as f:
+        try:
+            pillow_image = PillowImage.open(f)
+        except IOError as e:
+            if 'cannot identify image file' in e.args[0]:
+                print("Ignoring a non-image file {0}".format(
+                    image_filename
+                ))
+                return None
+            raise
+        return PILLOW_FORMAT_EXTENSIONS[pillow_image.format]

--- a/candidates/tests/test_twitter_queue_images_command.py
+++ b/candidates/tests/test_twitter_queue_images_command.py
@@ -24,6 +24,8 @@ class TestTwitterImageQueueCommand(TestUserMixin, TestCase):
             dirname(__file__), '..', '..', 'moderation_queue', 'tests',
             'example-image.jpg'
         )
+        with open(self.image_filename, 'rb') as f:
+            self.example_image_binary_data = f.read()
 
         self.p_no_images = PersonExtraFactory.create(
             base__id='1',
@@ -118,7 +120,8 @@ class TestTwitterImageQueueCommand(TestUserMixin, TestCase):
             '1006': 'https://pbs.twimg.com/profile_images/mno/xyzzy.jpg',
         }
 
-        mock_requests.get.return_value = Mock(content=b'', status_code=200)
+        mock_requests.get.return_value = \
+            Mock(content=self.example_image_binary_data, status_code=200)
 
         call_command('candidates_add_twitter_images_to_queue')
 
@@ -150,7 +153,8 @@ class TestTwitterImageQueueCommand(TestUserMixin, TestCase):
             '1006': 'https://pbs.twimg.com/profile_images/mno/xyzzy.jpg',
         }
 
-        mock_requests.get.return_value = Mock(content=b'', status_code=200)
+        mock_requests.get.return_value = \
+            Mock(content=self.example_image_binary_data, status_code=200)
 
         with capture_output() as (out, err):
             call_command('candidates_add_twitter_images_to_queue', verbosity=3)
@@ -202,9 +206,9 @@ class TestTwitterImageQueueCommand(TestUserMixin, TestCase):
 
         def fake_get(url, *args, **kwargs):
             if url == 'https://pbs.twimg.com/profile_images/abc/foo.jpg':
-                return Mock(content=b'', status_code=404)
+                return Mock(content=self.example_image_binary_data, status_code=404)
             else:
-                return Mock(content=b'', status_code=200)
+                return Mock(content=self.example_image_binary_data, status_code=200)
 
         mock_requests.get.side_effect = fake_get
 

--- a/candidates/tests/test_twitter_queue_images_command.py
+++ b/candidates/tests/test_twitter_queue_images_command.py
@@ -118,7 +118,7 @@ class TestTwitterImageQueueCommand(TestUserMixin, TestCase):
             '1006': 'https://pbs.twimg.com/profile_images/mno/xyzzy.jpg',
         }
 
-        mock_requests.get.return_value = Mock(content=b'')
+        mock_requests.get.return_value = Mock(content=b'', status_code=200)
 
         call_command('candidates_add_twitter_images_to_queue')
 
@@ -150,7 +150,7 @@ class TestTwitterImageQueueCommand(TestUserMixin, TestCase):
             '1006': 'https://pbs.twimg.com/profile_images/mno/xyzzy.jpg',
         }
 
-        mock_requests.get.return_value = Mock(content=b'')
+        mock_requests.get.return_value = Mock(content=b'', status_code=200)
 
         with capture_output() as (out, err):
             call_command('candidates_add_twitter_images_to_queue', verbosity=3)
@@ -187,5 +187,41 @@ class TestTwitterImageQueueCommand(TestUserMixin, TestCase):
             ]
         )
 
+        self.assertEqual(new_queued_images.count(), 1)
+        new_queued_images.get(person=self.p_existing_image_but_none_in_queue)
+
+    def test_only_enqueue_from_200_status_code(self, mock_twitter_data, mock_requests):
+
+        mock_twitter_data.return_value.user_id_to_photo_url = {
+            '1001': 'https://pbs.twimg.com/profile_images/abc/foo.jpg',
+            '1002': 'https://pbs.twimg.com/profile_images/def/bar.jpg',
+            '1003': 'https://pbs.twimg.com/profile_images/ghi/baz.jpg',
+            '1005': 'https://pbs.twimg.com/profile_images/jkl/quux.jpg',
+            '1006': 'https://pbs.twimg.com/profile_images/mno/xyzzy.jpg',
+        }
+
+        def fake_get(url, *args, **kwargs):
+            if url == 'https://pbs.twimg.com/profile_images/abc/foo.jpg':
+                return Mock(content=b'', status_code=404)
+            else:
+                return Mock(content=b'', status_code=200)
+
+        mock_requests.get.side_effect = fake_get
+
+        call_command('candidates_add_twitter_images_to_queue')
+
+        new_queued_images = QueuedImage.objects.exclude(
+            id__in=self.existing_queued_image_ids)
+
+        self.assertEqual(
+            mock_requests.get.mock_calls,
+            [
+                call('https://pbs.twimg.com/profile_images/mno/xyzzy.jpg'),
+                call('https://pbs.twimg.com/profile_images/abc/foo.jpg'),
+            ]
+        )
+
+        # Out of the two URLs of images that were downloaded, only one
+        # had a 200 status code:
         self.assertEqual(new_queued_images.count(), 1)
         new_queued_images.get(person=self.p_existing_image_but_none_in_queue)

--- a/candidates/tests/test_twitter_queue_images_command.py
+++ b/candidates/tests/test_twitter_queue_images_command.py
@@ -229,3 +229,39 @@ class TestTwitterImageQueueCommand(TestUserMixin, TestCase):
         # had a 200 status code:
         self.assertEqual(new_queued_images.count(), 1)
         new_queued_images.get(person=self.p_existing_image_but_none_in_queue)
+
+    def test_only_enqueue_files_that_seem_to_be_images(self, mock_twitter_data, mock_requests):
+
+        mock_twitter_data.return_value.user_id_to_photo_url = {
+            '1001': 'https://pbs.twimg.com/profile_images/abc/foo.jpg',
+            '1002': 'https://pbs.twimg.com/profile_images/def/bar.jpg',
+            '1003': 'https://pbs.twimg.com/profile_images/ghi/baz.jpg',
+            '1005': 'https://pbs.twimg.com/profile_images/jkl/quux.jpg',
+            '1006': 'https://pbs.twimg.com/profile_images/mno/xyzzy.jpg',
+        }
+
+        def fake_get(url, *args, **kwargs):
+            if url == 'https://pbs.twimg.com/profile_images/abc/foo.jpg':
+                return Mock(content=b'I am not an image.', status_code=200)
+            else:
+                return Mock(content=self.example_image_binary_data, status_code=200)
+
+        mock_requests.get.side_effect = fake_get
+
+        call_command('candidates_add_twitter_images_to_queue')
+
+        new_queued_images = QueuedImage.objects.exclude(
+            id__in=self.existing_queued_image_ids)
+
+        self.assertEqual(
+            mock_requests.get.mock_calls,
+            [
+                call('https://pbs.twimg.com/profile_images/mno/xyzzy.jpg'),
+                call('https://pbs.twimg.com/profile_images/abc/foo.jpg'),
+            ]
+        )
+
+        # Out of the two URLs of images that were downloaded, only one
+        # had a 200 status code:
+        self.assertEqual(new_queued_images.count(), 1)
+        new_queued_images.get(person=self.p_existing_image_but_none_in_queue)


### PR DESCRIPTION
This is a partial fix for #145 - it changes the Twitter avatar importer command so that it will neither import images from non-200 HTTP status codes nor files that it can't identify as an image.