### PR TITLE
/numbers - Remove unhelpful comparisons with earlier elections

### DIFF
--- a/cached_counts/templates/reports.html
+++ b/cached_counts/templates/reports.html
@@ -41,37 +41,6 @@
                   <li><a href="{% url "parties_counts" election=election.id %}">{% trans "Candidates per party" %}</a></li>
                   <li><a href="{% url "constituencies-unlocked" election=election.id %}">{% trans "See progress towards locking all posts" %}</a></li>
                 </ul>
-                {% if election.prior_elections %}
-                  {% for prior_election in election.prior_elections %}
-                    {% with prior_election_name=prior_election.name %}
-                    <div "statistics-compared-to-prior-election">
-                      <h5>{% blocktrans %}Statistics compared to the {{ prior_election_name }}{% endblocktrans %}</h5>
-                      <ul>
-                        <li>{% blocktrans %}Total candidates in {{ prior_election_name }}:{% endblocktrans %}
-                          {{ prior_election.total }}
-                        </li>
-                        <li>{% blocktrans %}Percentage ({{ election_name }} / {{ prior_election_name }}):{% endblocktrans %}
-                          {{ prior_election.percentage|floatformat }}%
-                        </li>
-                        <li>{% blocktrans %}New candidates compared to the {{ prior_election_name }}:{% endblocktrans %}
-                          {{ prior_election.new_candidates|intcomma }}
-                        </li>
-                        <li>{% blocktrans %}Candidates standing again from the {{ prior_election_name }}:{% endblocktrans %}
-                          {{ prior_election.standing_again |intcomma }}
-                        </li>
-                        <li>{% blocktrans trimmed %}Candidates standing again from the {{ prior_election_name }}
-                          for the same party:{% endblocktrans %}
-                          {{ prior_election.standing_again_same_party|intcomma }}
-                        </li>
-                        <li>{% blocktrans trimmed %}Candidates standing again from the {{ prior_election_name }}
-                          for a different party:{% endblocktrans %}
-                          {{ prior_election.standing_again_different_party |intcomma }}
-                        </li>
-                      </ul>
-                    </div>
-                    {% endwith %}
-                  {% endfor %}
-                {% endif %}
               {% endwith %}
             </div>
           {% endfor %}

--- a/cached_counts/tests.py
+++ b/cached_counts/tests.py
@@ -100,16 +100,6 @@ class CachedCountTestCase(UK2015ExamplesMixin, WebTest):
                                         "html_id": "2015",
                                         "id": "2015",
                                         "name": "2015 General Election",
-                                        "prior_elections": [
-                                            {
-                                                "name": "2010 General Election",
-                                                "new_candidates": 16,
-                                                "percentage": 900.0,
-                                                "standing_again": 2,
-                                                "standing_again_different_party": 1,
-                                                "standing_again_same_party": 1
-                                            }
-                                        ],
                                         "total": 18
                                     }
                                 ],


### PR DESCRIPTION
These comparisons were introduced when we just had the 2010 and 2015
UK elections on the site. Unfortunately, the code doesn't work now that
there are also local election and by-elections in the database. It's
better to just remove this feature than to present bizarre comparisons
to users.  The implementation would need to be completely rethought,
and that's very low priority compared to the other things we're trying
to get done in time for the 2017 General Election.

This is an alternative to fixing the problems described in #106