### PR TITLE
shift candidates_locked to being a property of PostExtraElection

### DIFF
--- a/bulk_adding/views.py
+++ b/bulk_adding/views.py
@@ -262,13 +262,16 @@ class UnlockedWithDocumentsView(TemplateView):
             UnlockedWithDocumentsView, self).get_context_data(**kwargs)
 
         SOPNs_qs = OfficialDocument.objects.filter(
-            election__current=True).select_related('election', 'post__extra')
+            election__current=True).select_related(
+                'election', 'post__extra',
+                'post__extra__postextraelection'
+            )
 
         SOPNs_qs = SOPNs_qs.exclude(
             post__in=SuggestedPostLock.objects.all().values(
                 'post_extra__base'))
 
         context['unlocked_sopns'] = SOPNs_qs.filter(
-            post__extra__candidates_locked=False)
+            post__extra__postextraelection__candidates_locked=False)
 
         return context

--- a/candidates/management/commands/candidates_import_from_live_site.py
+++ b/candidates/management/commands/candidates_import_from_live_site.py
@@ -299,7 +299,6 @@ class Command(BaseCommand):
                 pe = models.PostExtra(
                     base=p,
                     slug=post_data['id'],
-                    candidates_locked=post_data['candidates_locked'],
                     group=post_data['group'],
                 )
                 if post_data.get('party_set'):
@@ -312,7 +311,8 @@ class Command(BaseCommand):
                         emodels.Election.objects.get(slug=election_data['id'])
                     models.PostExtraElection.objects.get_or_create(
                         postextra=pe,
-                        election=election
+                        election=election,
+                        candidates_locked=election_data['candidates_locked'],
                     )
         extra_fields = {
             ef.key: ef for ef in models.ExtraField.objects.all()

--- a/candidates/migrations/0033_postextraelection_candidates_locked.py
+++ b/candidates/migrations/0033_postextraelection_candidates_locked.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('candidates', '0032_migrate_org_slugs'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='postextraelection',
+            name='candidates_locked',
+            field=models.BooleanField(default=False),
+        ),
+    ]

--- a/candidates/migrations/0034_candidates_locked_data.py
+++ b/candidates/migrations/0034_candidates_locked_data.py
@@ -1,0 +1,58 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+import os
+from django.db import migrations
+
+
+def move_candidates_locked_to_postextraelection(apps, schema_editor):
+    PostExtra = apps.get_model('candidates', 'PostExtra')
+    PostExtraElection = apps.get_model('candidates', 'PostExtraElection')
+
+    locks = PostExtra.objects.filter(candidates_locked=True)
+    for lock in locks:
+        for election in lock.elections.all():
+            new_lock = PostExtraElection.objects.get(
+                postextra=lock,
+                election=election
+            )
+            new_lock.candidates_locked = True
+            new_lock.save()
+
+
+def move_candidates_locked_to_postextra(apps, schema_editor):
+    """
+    Because this locks at a post level it means the reverse migration
+    is potentially lossy. In cases where a post has been in more than one
+    election and not all of them are locked that data will be lost.
+    However, it seemed better to be permissive in locking as I think it's
+    easier to spot "Hey, why can't I edit this" that "Hey, I should not be
+    able to edit this". Hopefully. Regardless, if you want to do this
+    you need to set an env variable `ALLOW_LOSSY_REVERSE_MIGRATIONS=1`
+    """
+    if os.environ.get('ALLOW_LOSSY_REVERSE_MIGRATIONS') != '1':
+        raise Exception(
+            'Cannot reverse 0034_candidates_locked_data migration as it will \
+            lose data. See the migration file for more details.'
+        )
+    PostExtraElection = apps.get_model('candidates', 'PostExtraElection')
+
+    locks = PostExtraElection.objects.filter(candidates_locked=True)
+    for lock in locks:
+        pe = lock.postextra
+        pe.candidates_locked = True
+        pe.save()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('candidates', '0033_postextraelection_candidates_locked'),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            move_candidates_locked_to_postextraelection,
+            move_candidates_locked_to_postextra
+        )
+    ]

--- a/candidates/migrations/0035_remove_postextra_candidates_locked.py
+++ b/candidates/migrations/0035_remove_postextra_candidates_locked.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('candidates', '0034_candidates_locked_data'),
+    ]
+
+    operations = [
+        migrations.RemoveField(
+            model_name='postextra',
+            name='candidates_locked',
+        ),
+    ]

--- a/candidates/migrations/0036_postextra_election_unique_togther.py
+++ b/candidates/migrations/0036_postextra_election_unique_togther.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('candidates', '0035_remove_postextra_candidates_locked'),
+    ]
+
+    operations = [
+        migrations.AlterUniqueTogether(
+            name='postextraelection',
+            unique_together=set([('election', 'postextra')]),
+        ),
+    ]

--- a/candidates/models/__init__.py
+++ b/candidates/models/__init__.py
@@ -1,6 +1,7 @@
 from .auth import get_constituency_lock
 from .auth import get_constituency_lock_from_person_data
 from .auth import get_edits_allowed
+from .auth import is_post_locked
 
 from .constraints import check_constraints
 from .constraints import check_paired_models

--- a/candidates/models/popolo_extra.py
+++ b/candidates/models/popolo_extra.py
@@ -295,7 +295,7 @@ class PersonExtra(HasImageMixin, models.Model):
         result = self.base.memberships.filter(
             extra__election__current=True,
             role=models.F('extra__election__candidate_membership_role')
-        ).select_related('person', 'on_behalf_of', 'post') \
+        ).select_related('person', 'on_behalf_of', 'post', 'extra') \
             .prefetch_related('post__extra')
         return list(result)
 

--- a/candidates/models/popolo_extra.py
+++ b/candidates/models/popolo_extra.py
@@ -673,6 +673,7 @@ class PostExtraElection(models.Model):
     postextra = models.ForeignKey(PostExtra)
     election = models.ForeignKey(Election)
 
+    candidates_locked = models.BooleanField(default=False)
     winner_count = models.IntegerField(blank=True, null=True)
 
 

--- a/candidates/models/popolo_extra.py
+++ b/candidates/models/popolo_extra.py
@@ -675,6 +675,9 @@ class PostExtraElection(models.Model):
     candidates_locked = models.BooleanField(default=False)
     winner_count = models.IntegerField(blank=True, null=True)
 
+    class Meta:
+        unique_together = ('election', 'postextra')
+
 
 class MembershipExtra(models.Model):
     base = models.OneToOneField(Membership, related_name='extra')

--- a/candidates/models/popolo_extra.py
+++ b/candidates/models/popolo_extra.py
@@ -648,7 +648,6 @@ class PostExtra(HasImageMixin, models.Model):
     base = models.OneToOneField(Post, related_name='extra')
     slug = models.CharField(max_length=256, blank=True, unique=True)
 
-    candidates_locked = models.BooleanField(default=False)
     elections = models.ManyToManyField(
         Election,
         related_name='posts',

--- a/candidates/serializers.py
+++ b/candidates/serializers.py
@@ -390,6 +390,7 @@ class EmbeddedPostElectionSerializer(serializers.HyperlinkedModelSerializer):
         model = candidates_models.PostExtraElection
         fields= (
             'winner_count',
+            'candidates_locked',
             'name',
             'id',
             'url',
@@ -407,7 +408,6 @@ class PostExtraSerializer(MinimalPostExtraSerializer):
             'label',
             'role',
             'group',
-            'candidates_locked',
             'party_set',
             'organization',
             'area',

--- a/candidates/templates/candidates/constituencies.html
+++ b/candidates/templates/candidates/constituencies.html
@@ -18,13 +18,13 @@ Follow one of the links below to see the known candidates
 for that post:{% endblocktrans %}</p>
 
 <ul>
-  {% for post_extra in all_constituencies %}
+  {% for postextraelection in all_constituencies %}
     <li>
-     <a href="{% url 'constituency' election=election post_id=post_extra.slug ignored_slug=post_extra.base.label|slugify %}">
-        {{ post_extra.base.label }}</a>
-        {% if post_extra.candidates_locked %}
+     <a href="{% url 'constituency' election=election post_id=postextraelection.postextra.slug ignored_slug=postextraelection.postextra.base.label|slugify %}">
+        {{ postextraelection.postextra.base.label }}</a>
+        {% if postextraelection.candidates_locked %}
          - <abbr title="Candidates verified and post locked">🔒</abbr>
-        {% elif post_extra.suggestedpostlock_set.exists %}
+        {% elif postextraelection.postextra.suggestedpostlock_set.exists %}
         - <abbr title="Someone suggested locking this post">🔓</abbr>
         {% endif %}
     </li>  {% endfor %}

--- a/candidates/templates/candidates/posts.html
+++ b/candidates/templates/candidates/posts.html
@@ -21,13 +21,13 @@
           {% with election=election_data.election %}
             <h4><a href="{% url 'constituencies' election=election.slug %}">{{ election.name }}</a></h4>
             <ul>
-              {% for p in election_data.posts %}
+              {% for p in election_data.postextraelections %}
                 <li>
-                 <a href="{% url 'constituency' election=election.slug post_id=p.slug ignored_slug=p.short_label|slugify %}">{{ p.base.label }}</a>
+                 <a href="{% url 'constituency' election=election.slug post_id=p.postextra.slug ignored_slug=p.postextra.short_label|slugify %}">{{ p.postextra.base.label }}</a>
 
                  {% if p.candidates_locked %}
                   - <abbr title="Candidates verified and post locked">🔒</abbr>
-                 {% elif p.suggestedpostlock_set.exists %}
+                 {% elif p.postextra.suggestedpostlock_set.exists %}
                  - <abbr title="Someone suggested locking this post">🔓</abbr>
                  {% endif %}
 

--- a/candidates/tests/test_areas_view.py
+++ b/candidates/tests/test_areas_view.py
@@ -41,8 +41,11 @@ class TestAreasView(TestUserMixin, UK2015ExamplesMixin, WebTest):
             base__label='Member of Parliament for Aldershot',
             party_set=self.gb_parties,
         )
-        self.camberwell_post_extra.candidates_locked = True
-        self.camberwell_post_extra.save()
+        postextraelection = self.camberwell_post_extra.postextraelection_set.get(
+            election=self.election
+        )
+        postextraelection.candidates_locked = True
+        postextraelection.save()
 
     def test_any_area_page_without_login(self):
         response = self.app.get('/areas/WMC--65808/dulwich-and-west-norwood')

--- a/candidates/tests/test_group_elections.py
+++ b/candidates/tests/test_group_elections.py
@@ -9,6 +9,12 @@ from .uk_examples import UK2015ExamplesMixin
 from .factories import ElectionFactory
 
 
+def get_election_extra(postextra, election):
+    return postextra.postextraelection_set.get(
+        election=election
+    )
+
+
 class TestElectionGrouping(UK2015ExamplesMixin, TestCase):
 
     def setUp(self):
@@ -70,9 +76,33 @@ class TestElectionGrouping(UK2015ExamplesMixin, TestCase):
             )
 
     def test_election_grouping_with_posts(self):
-        with self.assertNumQueries(3):
+        camberwell_postextraelection = get_election_extra(
+            self.camberwell_post_extra, self.election
+        )
+        dulwich_postextraelection = get_election_extra(
+            self.dulwich_post_extra, self.election
+        )
+        edinburgh_east_postextraelection = get_election_extra(
+            self.edinburgh_east_post_extra, self.election
+        )
+        edinburgh_north_postextraelection = get_election_extra(
+            self.edinburgh_north_post_extra, self.election
+        )
+        camberwell_earlier = get_election_extra(
+            self.camberwell_post_extra, self.earlier_election
+        )
+        dulwich_earlier = get_election_extra(
+            self.dulwich_post_extra, self.earlier_election
+        )
+        edinburgh_east_earlier = get_election_extra(
+            self.edinburgh_east_post_extra, self.earlier_election
+        )
+        edinburgh_north_earlier = get_election_extra(
+            self.edinburgh_north_post_extra, self.earlier_election
+        )
+        with self.assertNumQueries(4):
             self.assertEqual(
-                Election.group_and_order_elections(include_posts=True),
+                Election.group_and_order_elections(include_postextraelections=True),
                 [
                     {
                         'current': True,
@@ -81,11 +111,11 @@ class TestElectionGrouping(UK2015ExamplesMixin, TestCase):
                                 'role': 'Member of the Scottish Parliament',
                                 'elections': [
                                     {
-                                        'posts': [],
+                                        'postextraelections': [],
                                         'election': self.sp_c_election
                                     },
                                     {
-                                        'posts': [],
+                                        'postextraelections': [],
                                         'election': self.sp_r_election
                                     }
                                 ]
@@ -94,11 +124,11 @@ class TestElectionGrouping(UK2015ExamplesMixin, TestCase):
                                 'role': 'Member of Parliament',
                                 'elections': [
                                     {
-                                        'posts': [
-                                            self.camberwell_post_extra,
-                                            self.dulwich_post_extra,
-                                            self.edinburgh_east_post_extra,
-                                            self.edinburgh_north_post_extra,
+                                        'postextraelections': [
+                                            camberwell_postextraelection,
+                                            dulwich_postextraelection,
+                                            edinburgh_east_postextraelection,
+                                            edinburgh_north_postextraelection,
                                         ],
                                         'election': self.election
                                     }
@@ -113,11 +143,11 @@ class TestElectionGrouping(UK2015ExamplesMixin, TestCase):
                                 'role': 'Member of Parliament',
                                 'elections': [
                                     {
-                                        'posts': [
-                                            self.camberwell_post_extra,
-                                            self.dulwich_post_extra,
-                                            self.edinburgh_east_post_extra,
-                                            self.edinburgh_north_post_extra,
+                                        'postextraelections': [
+                                            camberwell_earlier,
+                                            dulwich_earlier,
+                                            edinburgh_east_earlier,
+                                            edinburgh_north_earlier,
                                         ],
                                         'election': self.earlier_election
                                     }

--- a/candidates/tests/test_merge_view.py
+++ b/candidates/tests/test_merge_view.py
@@ -433,16 +433,14 @@ class TestMergePeopleView(TestUserMixin, UK2015ExamplesMixin, WebTest):
             slug='65878',
             base__label='Canterbury',
             party_set=self.gb_parties,
-            base__organization=self.commons,
-            candidates_locked=True,
+            base__organization=self.commons
         )
         factories.PostExtraFactory.create(
             elections=(self.election, self.earlier_election),
             slug='65936',
             base__label='Maidstone and The Weald',
             party_set=self.gb_parties,
-            base__organization=self.commons,
-            candidates_locked=True,
+            base__organization=self.commons
         )
 
         # Update each of them from the versions that were merged, and merged badly:

--- a/candidates/views/areas.py
+++ b/candidates/views/areas.py
@@ -13,7 +13,7 @@ from django.utils.translation import ugettext as _
 from django.shortcuts import get_object_or_404
 
 from candidates.models import AreaExtra, MembershipExtra
-from candidates.models.auth import get_edits_allowed
+from candidates.models.auth import get_edits_allowed, is_post_locked
 
 from elections.models import AreaType, Election
 
@@ -66,7 +66,7 @@ class AreasView(TemplateView):
                         continue
                     else:
                         posts_seen.add(post.id)
-                    locked = post_extra.candidates_locked
+                    locked = is_post_locked(post, election)
                     extra_qs = MembershipExtra.objects.select_related('election')
                     current_candidacies, _ = split_candidacies(
                         election,

--- a/candidates/views/constituencies.py
+++ b/candidates/views/constituencies.py
@@ -28,7 +28,7 @@ from .version_data import get_client_ip, get_change_metadata
 from ..csv_helpers import list_to_csv
 from ..forms import NewPersonForm, ToggleLockForm, ConstituencyRecordWinnerForm
 from ..models import (
-    TRUSTED_TO_LOCK_GROUP_NAME, get_edits_allowed,
+    TRUSTED_TO_LOCK_GROUP_NAME, get_edits_allowed, is_post_locked,
     RESULT_RECORDERS_GROUP_NAME, LoggedAction, PostExtra, OrganizationExtra,
     MembershipExtra, PartySet, SimplePopoloField, ExtraField, PostExtraElection
 )
@@ -103,14 +103,12 @@ class ConstituencyDetailView(ElectionMixin, TemplateView):
             'label': mp_post.label
         }
 
-        context['candidates_locked'] = False
+        context['candidates_locked'] = is_post_locked(mp_post, self.election_data)
 
         if hasattr(mp_post, 'extra'):
             context['has_lock_suggestion'] = any(
                 [spl.election_for_suggestion for spl in
                 SuggestedPostLock.objects.filter(post_extra=mp_post.extra)])
-
-            context['candidates_locked'] = mp_post.extra.candidates_locked
 
             context['suggest_lock_form'] = SuggestedPostLockForm(
                 initial={
@@ -287,10 +285,11 @@ class ConstituencyListView(ElectionMixin, TemplateView):
     def get_context_data(self, **kwargs):
         context = super(ConstituencyListView, self).get_context_data(**kwargs)
         context['all_constituencies'] = \
-            PostExtra.objects.filter(
-                elections__slug=self.election
-            ).order_by('base__label').select_related('base') \
-            .prefetch_related('suggestedpostlock_set')
+            PostExtraElection.objects.filter(
+                election=self.election_data
+            ).order_by('postextra__base__label') \
+            .select_related('postextra__base') \
+            .prefetch_related('postextra__suggestedpostlock_set')
 
         return context
 
@@ -307,8 +306,12 @@ class ConstituencyLockView(ElectionMixin, GroupRequiredMixin, View):
             with transaction.atomic():
                 post = get_object_or_404(Post, extra__slug=post_id)
                 lock = form.cleaned_data['lock']
-                post.extra.candidates_locked = lock
-                post.extra.save()
+                extra_election = PostExtraElection.objects.get(
+                    postextra__base=post,
+                    election__slug=self.election
+                )
+                extra_election.candidates_locked = lock
+                extra_election.save()
                 post_name = post.extra.short_label
                 if lock:
                     suffix = '-lock'
@@ -348,20 +351,20 @@ class ConstituenciesUnlockedListView(ElectionMixin, TemplateView):
         keys = ('locked', 'unlocked')
         for k in keys:
             context[k] = []
-        posts = Post.objects.filter(
-            extra__elections=self.election_data
-        ).select_related('extra').all()
-        for post in posts:
+        postextraelections = PostExtraElection.objects.filter(
+            election=self.election_data
+        ).select_related('postextra').all()
+        for postextraelection in postextraelections:
             total_constituencies += 1
-            if post.extra.candidates_locked:
+            if postextraelection.candidates_locked:
                 context_field = 'locked'
                 total_locked += 1
             else:
                 context_field = 'unlocked'
             context[context_field].append(
                 {
-                    'id': post.extra.slug,
-                    'name': post.extra.short_label,
+                    'id': postextraelection.postextra.slug,
+                    'name': postextraelection.postextra.short_label,
                 }
             )
         for k in keys:
@@ -606,7 +609,7 @@ class OrderedPartyListView(ElectionMixin, TemplateView):
             'label': mp_post.label
         }
 
-        context['candidates_locked'] = mp_post.extra.candidates_locked
+        context['candidates_locked'] = is_post_locked(mp_post, self.election_data)
         context['lock_form'] = ToggleLockForm(
             initial={
                 'post_id': post_id,

--- a/candidates/views/helpers.py
+++ b/candidates/views/helpers.py
@@ -12,7 +12,7 @@ from slugify import slugify
 
 from ..models import (
     MembershipExtra, PartySet, SimplePopoloField, ExtraField,
-    ComplexPopoloField
+    ComplexPopoloField, PostExtraElection
 )
 
 

--- a/candidates/views/posts.py
+++ b/candidates/views/posts.py
@@ -11,5 +11,5 @@ class PostListView(TemplateView):
         context = super(PostListView, self).get_context_data(**kwargs)
         context['elections_and_posts'] = \
             Election.group_and_order_elections(
-                include_posts=True, include_noncurrent=False)
+                include_postextraelections=True, include_noncurrent=False)
         return context

--- a/elections/st_paul_municipal_2015/templates/candidates/posts.html
+++ b/elections/st_paul_municipal_2015/templates/candidates/posts.html
@@ -21,9 +21,9 @@
           {% with election=election_data.election %}
             <h4>{{ election.name }}</h4>
             <ul>
-              {% for p in election_data.posts %}
+              {% for p in election_data.postextraelections %}
                 <li>
-                 <a href="{% url 'constituency' election=election.slug post_id=p.slug ignored_slug=p.short_label|slugify %}">{{ p.base.label }}</a>
+                 <a href="{% url 'constituency' election=election.slug post_id=p.postextra.slug ignored_slug=p.postextra.short_label|slugify %}">{{ p.postextra.base.label }}</a>
                 </li>
               {% endfor %}
             </ul>

--- a/elections/st_paul_municipal_2015/views/areas.py
+++ b/elections/st_paul_municipal_2015/views/areas.py
@@ -54,7 +54,7 @@ class StPaulAreasView(TemplateView):
             for post in area.posts.all():
                 post_extra = post.extra
                 election = post_extra.elections.get(current=True)
-                locked = post_extra.candidates_locked
+                locked = post_extra.postextraelection_set.get(election=election).candidates_locked
                 extra_qs = MembershipExtra.objects.select_related('election')
                 current_candidacies, created = split_candidacies(
                     election,

--- a/elections/uk/views/frontpage.py
+++ b/elections/uk/views/frontpage.py
@@ -79,7 +79,17 @@ class ConstituencyPostcodeFinderView(ContributorsMixin, FormView):
             return context
 
         context['posts_total'] = pe_qs.count()
-        context['posts_locked'] = pe_qs.filter(candidates_locked=True).count()
+        if election_qs:
+            pe_qs = pe_qs.filter(
+                postextraelection__candidates_locked=True,
+                postextraelection__election__in=election_qs
+            )
+        else:
+            pe_qs = pe_qs.filter(
+                postextraelection__candidates_locked=True,
+                postextraelection__election__slug__startswith=election_slug
+            )
+        context['posts_locked'] = pe_qs.count()
         context['posts_locked_percent'] = round(
                 float(context['posts_locked']) /
                 float(context['posts_total'])

--- a/elections/uk/views/redirects.py
+++ b/elections/uk/views/redirects.py
@@ -86,7 +86,7 @@ class HelpOutCTAView(RedirectView):
             postextra__suggestedpostlock=None,
             postextra__base__officialdocument__isnull=False
             ).exclude(
-            postextra__candidates_locked=True,
+            candidates_locked=True,
             ).distinct()
 
         if pe_qs:

--- a/moderation_queue/views.py
+++ b/moderation_queue/views.py
@@ -483,7 +483,7 @@ class SuggestLockReviewListView(ListView):
 
     def get_queryset(self):
         return SuggestedPostLock.objects.filter(
-            post_extra__candidates_locked=False).select_related(
+            post_extra__postextraelection__candidates_locked=False).select_related(
                 'user', 'post_extra__base',
             ).prefetch_related('post_extra__elections')
 
@@ -498,7 +498,7 @@ class SOPNReviewRequiredView(ListView):
         return PostExtraElection.objects.exclude(
             postextra__base__officialdocument=None).filter(
                 postextra__suggestedpostlock=None,
-                postextra__candidates_locked=False,
+                candidates_locked=False,
                 election__current=True).select_related(
                     'postextra__base', 'election').order_by(
                         'election', 'postextra__base__label')

--- a/mysite/context_processors.py
+++ b/mysite/context_processors.py
@@ -69,7 +69,7 @@ def add_notification_data(request):
         result['photos_for_review'] = \
             QueuedImage.objects.filter(decision='undecided').count()
         result['suggestions_to_lock'] = \
-            SuggestedPostLock.objects.filter(post_extra__candidates_locked=False).count()
+            SuggestedPostLock.objects.filter(post_extra__postextraelection__candidates_locked=False).count()
     return result
 
 

--- a/official_documents/templates/official_documents/posts_for_document.html
+++ b/official_documents/templates/official_documents/posts_for_document.html
@@ -15,11 +15,11 @@
     area{{ document_posts.count|pluralize }}.</p>
 
 <ul>
-  {% for document in document_posts %}
+  {% for document, locked in document_posts %}
     <li>
      <a href="{% url 'constituency' election=document.election.slug post_id=document.post.extra.slug ignored_slug=document.post.extra.base.label|slugify %}">
         {{ document.post.extra.base.label }}</a>
-        {% if document.post.extra.candidates_locked %}
+        {% if locked %}
          - <abbr title="Candidates verified and post locked">🔒</abbr>
         {% elif document.post.extra.suggestedpostlock_set.exists %}
         - <abbr title="Someone suggested locking this post">🔓</abbr>


### PR DESCRIPTION
At the moment candidates_locked is a property on PostExtra which means if a post is in more than on election we have to lock it for all or none of the elections it is in. Moving the candidates_locked flag to PostExtraElection means we can lock on a per election basis.

At the moment there's lots of commits in here just to make it a bit easier to see what's going on however I'd propose that it all gets squashed down to a few for the migrations and one large "do the transition" commit before merging.

Note that the reverse migration for this is potentially destructive so you need to set an environment variable to run it. It's destructive in as much as it you and a post that is in two elections and in one it is locked and the other it is unlocked then running the reverse migration will result in both of them being locked rather than neither of them.