### PR TITLE
Add format suggestions to name labels

### DIFF
--- a/bulk_adding/forms.py
+++ b/bulk_adding/forms.py
@@ -5,6 +5,7 @@ import json
 
 from django import forms
 from django.utils.safestring import SafeText
+from django.utils.translation import ugettext_lazy as _
 
 from candidates.views import search_person_by_name
 
@@ -80,7 +81,9 @@ class BaseBulkAddReviewFormSet(BaseBulkAddFormSet):
 
 
 class QuickAddSinglePersonForm(forms.Form):
-    name = forms.CharField(required=True)
+    name = forms.CharField(
+        label=_("Name (style: Ali Smith, not SMITH Ali)"),
+        required=True)
     source = forms.CharField(required=True)
 
 

--- a/bulk_adding/templates/bulk_add/add_form.html
+++ b/bulk_adding/templates/bulk_add/add_form.html
@@ -57,38 +57,6 @@
   <button type=submit>Review</button>
 </form>
 
-<script>
-    function toTitleCase(str)
-    {
-        return str.replace(/\w\S*/g, function(txt){return txt.charAt(0).toUpperCase() + txt.substr(1).toLowerCase();});
-    }
-
-    suggest_correction = function(el, suggestion) {
-
-        suggestion_el = $('<a class="suggested">Change to <span>' + suggestion + '</span>?</a>');
-        suggestion_el.click(function(clicked_el) {
-            var this_link = $(this);
-            this_link.prev('input').val($(this_link).find('span').text());
-            $('.suggested').remove();
-        })
-        $('.suggested').remove();
-        $(el).after(suggestion_el);
-
-    };
-
-    $('[name*=-name]').on('paste keyup', function(e) {
-        var name = e.target.value;
-        var upper_first_matcher = /([A-Z]+,? [A-Za-z]+)/g;
-        var match = upper_first_matcher.exec(name);
-        if (match) {
-            var name_parts = name.split(' ');
-            var last_name = name_parts.shift();
-            var name = name_parts.join(' ') + ' ' + toTitleCase(last_name);
-            suggest_correction(e.target, name);
-        }
-    })
-
-</script>
 {% else %}
 <p>
 This post doesn't have a nomination paper.

--- a/candidates/forms.py
+++ b/candidates/forms.py
@@ -152,6 +152,9 @@ class BasePersonForm(forms.Form):
                     campaign literature.""")
                 opts['label'] = _("Statement to voters")
 
+            if field.name == "name":
+                opts['label'] = _("Name (style: Ali Smith not SMITH Ali)")
+
             if field.info_type_key == 'url':
                 self.fields[field.name] = forms.URLField(**opts)
             elif field.info_type_key == 'email':

--- a/candidates/static/js/person_form.js
+++ b/candidates/static/js/person_form.js
@@ -169,6 +169,34 @@ function showElectionsForm() {
   });
 }
 
+function toTitleCase(str) {
+    return str.replace(/\w\S*/g, function(txt){return txt.charAt(0).toUpperCase() + txt.substr(1).toLowerCase();});
+}
+
+suggest_correction = function(el, suggestion) {
+
+    suggestion_el = $('<a class="suggested">Change to <span>' + suggestion + '</span>?</a>');
+    suggestion_el.click(function(clicked_el) {
+        var this_link = $(this);
+        this_link.prev('input').val($(this_link).find('span').text());
+        $('.suggested').remove();
+    })
+    $('.suggested').remove();
+    $(el).after(suggestion_el);
+
+};
+
+function checkNameFormat(e) {
+    var name = e.target.value;
+    var upper_first_matcher = /([A-Z]+,? [A-Za-z]+)/g;
+    var match = upper_first_matcher.exec(name);
+    if (match) {
+        var name_parts = name.split(' ');
+        var last_name = name_parts.shift();
+        var name = name_parts.join(' ') + ' ' + toTitleCase(last_name);
+        suggest_correction(e.target, name);
+    }
+}
 
 $(document).ready(function() {
   $.getJSON('/post-id-to-party-set.json', function(data) {
@@ -180,5 +208,7 @@ $(document).ready(function() {
       /* Now enable the "add an extra election" button if it's present */
       $('#add_election_button').on('click', showElectionsForm);
       $('.add_more_elections_field').hide();
+      $('[name=name]').on('paste keyup', checkNameFormat);
+      $('[name*=-name]').on('paste keyup', checkNameFormat);
   });
 });


### PR DESCRIPTION
Add some hints to the name labels on the bulk adding and the create new candidate form that we'd like First Last format names.

This is going to break translations and it might be quite UK specific.

This also shifts the handy "Do you mean First Last" JavaScript from the bulk adding interface into the standard JavaScript and runs it on all name fields.

Fixes #78