### PR TITLE
"Don't ask people to fill in pointless forms" redux

### DIFF
--- a/moderation_queue/templates/moderation_queue/photo-review.html
+++ b/moderation_queue/templates/moderation_queue/photo-review.html
@@ -170,14 +170,18 @@
 
       </fieldset>
 
-      <fieldset class="rejection_reason">
-          {{ form.rejection_reason.errors }}
-          <label for="{{ form.rejection_reason.id_for_label }}">{% blocktrans trimmed %}
-            Reason for rejection (<strong>Warning:</strong> this will be
-            emailed to the user):{% endblocktrans %}
-          </label>
-          {{ form.rejection_reason }}
-      </fieldset>
+      {% if queued_image.user %}
+        <fieldset class="rejection_reason">
+            {{ form.rejection_reason.errors }}
+            <label for="{{ form.rejection_reason.id_for_label }}">{% blocktrans trimmed %}
+              Reason for rejection (<strong>Warning:</strong> this will be
+              emailed to the user):{% endblocktrans %}
+            </label>
+            {{ form.rejection_reason }}
+        </fieldset>
+      {% else %}
+        <input type="hidden" id="id_rejection_reason" name="rejection_reason" value="">
+      {% endif %}
 
       <input type="submit" id="decision-submit" class="button" value="{% trans "Submit" %}">
 


### PR DESCRIPTION
The photo moderation interface asked you to enter a reason for rejecting
an image, since if an image was uploaded by someone that we can't
approve for the site, it's only fair to email them the reason why.

However, now there is also a script that automatically imports Twitter
avatar images for candidates and adds them to the queue. In these cases
the uploading_user will be None and any reason for rejection is
discarded (since there is no address to email it to). So we shouldn't be
asking people to fill in a box a box with that reason pointlessly.

Thanks to @davidmiller for pointing out this problem. See also #130 