### PR TITLE
Improve rendering of differences between past versions

### DIFF
--- a/alerts/templates/alerts/pretty_diff.txt
+++ b/alerts/templates/alerts/pretty_diff.txt
@@ -10,13 +10,13 @@ Changes made compared to parent {{ parent_version_id }}
 {% endblocktrans %}{% else %}{% trans "Changes made in initial version" %}{% endif %}
 {% for operation in parent_data.parent_diff %}
   {% if operation.op == 'add' %}
-     {% trans 'Added:' %} {{ operation.path }} => {{ operation.value }}
+     {% trans 'Added:' %} {{ operation.path }} => {{ operation.value|safe }}
   {% elif operation.op == 'remove' %}
      {% trans 'Removed:' %} {{ operation.path }}
-     {% blocktrans with previous=operation.previous %}(previously it was {{ previous }}){% endblocktrans %}
+     {% blocktrans with previous=operation.previous %}(previously it was {{ previous|safe }}){% endblocktrans %}
   {% elif operation.op == 'replace' %}
      {% blocktrans trimmed with field=operation.path previous=operation.previous_value current=operation.value %}
-     At {{ field }} replaced {{ previous }} with {{ current|safe }}{% endblocktrans %}
+     At {{ field }} replaced {{ previous|safe }} with {{ current|safe }}{% endblocktrans %}
   {% else %}
     {% trans 'UNEXPECTED OPERATION' %}: {{ operation }}
   {% endif %}

--- a/alerts/templates/alerts/pretty_diff.txt
+++ b/alerts/templates/alerts/pretty_diff.txt
@@ -4,8 +4,11 @@
 {% trans 'User' %}: {{ changes.username }}
 {% trans 'Time' %}: {{ changes.timestamp }}
 {% trans 'Source' %}: {{ changes.information_source }}
-{% trans 'Changes made' %}:
-{% for operation in changes.diff %}
+{% for parent_data in changes.diffs %}{% with diff=parent_data.parent_diff parent_version_id=parent_data.parent_version_id %}
+{% if parent_version_id %}{% blocktrans trimmed %}
+Changes made compared to parent {{ parent_version_id }}
+{% endblocktrans %}{% else %}{% trans "Changes made in initial version" %}{% endif %}
+{% for operation in parent_data.parent_diff %}
   {% if operation.op == 'add' %}
      {% trans 'Added:' %} {{ operation.path }} => {{ operation.value }}
   {% elif operation.op == 'remove' %}
@@ -13,8 +16,9 @@
      {% blocktrans with previous=operation.previous %}(previously it was {{ previous }}){% endblocktrans %}
   {% elif operation.op == 'replace' %}
      {% blocktrans trimmed with field=operation.path previous=operation.previous_value current=operation.value %}
-     At {{ field }} replaced {{ previous }} with {{ current }}{% endblocktrans %}
+     At {{ field }} replaced {{ previous }} with {{ current|safe }}{% endblocktrans %}
   {% else %}
     {% trans 'UNEXPECTED OPERATION' %}: {{ operation }}
   {% endif %}
 {% endfor %}
+{% endwith %}{% endfor %}

--- a/candidates/diffs.py
+++ b/candidates/diffs.py
@@ -12,6 +12,7 @@ from django.http import Http404
 import jsonpatch
 import jsonpointer
 
+from candidates.models.versions import get_versions_parent_map
 from elections.models import Election
 
 
@@ -189,6 +190,7 @@ def get_version_diff(from_data, to_data):
     return result
 
 def clean_version_data(data):
+    data = data.copy()
     for election_slug, standing_in in data.get('standing_in', {}).items():
         if standing_in:
             standing_in.pop('mapit_url', None)
@@ -200,6 +202,13 @@ def clean_version_data(data):
     data.pop('last_party', None)
     data.pop('proxy_image', None)
     data.pop('date_of_birth', None)
+    return data
+
+def get_parents_version_data(parents, id_to_version):
+    if parents:
+        return [(p, id_to_version[p]['data']) for p in parents]
+    # If there are no parents, then compare to an empty dictionary
+    return [(None, {})]
 
 def get_version_diffs(versions):
     """Add a diff to each of an array of version dicts
@@ -207,18 +216,25 @@ def get_version_diffs(versions):
     The first version is the most recent; the last is the original
     version."""
 
+    id_to_parent_ids = get_versions_parent_map(versions)
+    id_to_version = {v['version_id']: v for v in versions}
     result = []
-    n = len(versions)
-    for i, v in enumerate(versions):
-        to_version_data = versions[i]['data']
-        if i == (n - 1):
-            from_version_data = {}
-        else:
-            from_version_data = versions[i + 1]['data']
-        clean_version_data(to_version_data)
-        clean_version_data(from_version_data)
-        version_with_diff = versions[i].copy()
-        version_with_diff['diff'] = \
-            get_version_diff(from_version_data, to_version_data)
-        result.append(version_with_diff)
+    for v in versions:
+        version_id = v['version_id']
+        version_with_diffs = v.copy()
+        version_with_diffs['data'] = clean_version_data(
+            version_with_diffs['data'])
+        version_with_diffs['parent_version_ids'] = id_to_parent_ids[version_id]
+        version_with_diffs['diffs'] = [
+            {
+                'parent_version_id': parent_with_data[0],
+                'parent_diff': get_version_diff(
+                    clean_version_data(parent_with_data[1]),
+                    version_with_diffs['data']
+                )
+            } for parent_with_data in
+            get_parents_version_data(
+                id_to_parent_ids[version_id], id_to_version)
+        ]
+        result.append(version_with_diffs)
     return result

--- a/candidates/diffs.py
+++ b/candidates/diffs.py
@@ -210,16 +210,10 @@ def get_version_diffs(versions):
     result = []
     n = len(versions)
     for i, v in enumerate(versions):
-        # to_version_data = replace_empty_with_none(
-        #     versions[i]['data']
-        # )
         to_version_data = versions[i]['data']
         if i == (n - 1):
             from_version_data = {}
         else:
-            # from_version_data = replace_empty_with_none(
-            #     versions[i + 1]['data']
-            # )
             from_version_data = versions[i + 1]['data']
         clean_version_data(to_version_data)
         clean_version_data(from_version_data)

--- a/candidates/diffs.py
+++ b/candidates/diffs.py
@@ -221,6 +221,7 @@ def get_version_diffs(versions):
     result = []
     for v in versions:
         version_id = v['version_id']
+        v['parent_version_ids'] = id_to_parent_ids[version_id]
         version_with_diffs = v.copy()
         version_with_diffs['data'] = clean_version_data(
             version_with_diffs['data'])

--- a/candidates/templates/candidates/person-versions.html
+++ b/candidates/templates/candidates/person-versions.html
@@ -17,26 +17,36 @@
           <dd>{{ version.timestamp }}</dd>
           <dt>{% trans "Source" %}</dt>
           <dd>{{ version.information_source }}</dd>
-          <dt>{% trans "Changes made" %}</dt>
-          <dd>
-            <p class="version-diff">
-              {% for operation in version.diff %}
-                {% if operation.op == 'add' %}
-                   <span class="version-op-add">{% trans "Added:" %} {{ operation.path }} => {{ operation.value|prettyjson }}</span>
-                {% elif operation.op == 'remove' %}
-                   <span class="version-op-remove">{% trans "Removed:" %} {{ operation.path }}
-                    {% blocktrans trimmed with previous=operation.previous_value|prettyjson %}
-                    (previously it was {{ previous }}){% endblocktrans %}</span>
-                {% elif operation.op == 'replace' %}
-                   <span class="version-op-replace">{% blocktrans trimmed with field=operation.path previous=operation.previous_value|prettyjson current=operation.value|prettyjson %}
-                   At {{ field }} replaced {{ previous }} with {{ current }}</span>
-                   {% endblocktrans %}
-                {% else %}
-                   <span class="version-op-unknown">{% trans "UNEXPECTED OPERATION:" %} {{ operation|prettyjson }}</span>
-                {% endif %}<br/>
-              {% endfor %}
-            </p>
-          </dd>
+          {% for parent_data in version.diffs %}
+            {% with diff=parent_data.parent_diff parent_version_id=parent_data.parent_version_id %}
+              {% if parent_version_id %}
+                <dt>{% blocktrans trimmed %}
+                  Changes made compared to parent {{ parent_version_id }}
+                {% endblocktrans %}</dt>
+              {% else %}
+                <dt>{% trans "Changes made in initial version" %}</dt>
+              {% endif %}
+              <dd>
+                <p class="version-diff">
+                  {% for operation in diff %}
+                    {% if operation.op == 'add' %}
+                       <span class="version-op-add">{% trans "Added:" %} {{ operation.path }} => {{ operation.value|prettyjson }}</span>
+                    {% elif operation.op == 'remove' %}
+                       <span class="version-op-remove">{% trans "Removed:" %} {{ operation.path }}
+                        {% blocktrans trimmed with previous=operation.previous_value|prettyjson %}
+                        (previously it was {{ previous }}){% endblocktrans %}</span>
+                    {% elif operation.op == 'replace' %}
+                       <span class="version-op-replace">{% blocktrans trimmed with field=operation.path previous=operation.previous_value|prettyjson current=operation.value|prettyjson %}
+                       At {{ field }} replaced {{ previous }} with {{ current }}</span>
+                       {% endblocktrans %}
+                    {% else %}
+                       <span class="version-op-unknown">{% trans "UNEXPECTED OPERATION:" %} {{ operation|prettyjson }}</span>
+                    {% endif %}<br/>
+                  {% endfor %}
+                </p>
+              </dd>
+            {% endwith %}
+          {% endfor %}
           {% if user.is_authenticated and not forloop.first %}
           <dt>{% trans "Revert to this" %}</dt>
           <dd>

--- a/candidates/templates/candidates/person-versions.html
+++ b/candidates/templates/candidates/person-versions.html
@@ -4,7 +4,7 @@
 <div class="person__versions">
     <h2>{% trans "All versions" %}</h2>
     {% for version in person.extra.version_diffs %}
-      <div class="version">
+      <div class="version" id="version-{{ version.version_id }}" data-parent-version-ids="{{ version.parent_version_ids|join:' ' }}">
         <dl>
           <dt>{% trans "Version" %}</dt>
           <dd>

--- a/candidates/tests/test_version_diffs.py
+++ b/candidates/tests/test_version_diffs.py
@@ -15,6 +15,8 @@ def sort_operations_for_comparison(versions_with_diffs):
 
 class TestVersionDiffs(UK2015ExamplesMixin, TestCase):
 
+    maxDiff = None
+
     def setUp(self):
         super(TestVersionDiffs, self).setUp()
 

--- a/candidates/tests/test_version_diffs.py
+++ b/candidates/tests/test_version_diffs.py
@@ -69,6 +69,7 @@ class TestVersionDiffs(UK2015ExamplesMixin, TestCase):
                 'information_source': 'Manual correction by a user',
                 'timestamp': '2015-06-10T05:35:15.297559',
                 'version_id': '8aa71db8f2f20bf8',
+                'parent_version_ids': ['643dc3343880f168'],
                 'data': {
                     'id': '24680',
                     'a': 'alpha',
@@ -100,6 +101,7 @@ class TestVersionDiffs(UK2015ExamplesMixin, TestCase):
                 'information_source': 'Updated by a script',
                 'timestamp': '2015-05-08T01:52:27.061038',
                 'version_id': '643dc3343880f168',
+                'parent_version_ids': ['42648e36ff699179'],
                 'data': {
                     'id': '24680',
                     'a': 'alpha',
@@ -138,6 +140,7 @@ class TestVersionDiffs(UK2015ExamplesMixin, TestCase):
                 'information_source': 'Original imported data',
                 'timestamp': '2015-03-07T05:35:15.297559',
                 'version_id': '42648e36ff699179',
+                'parent_version_ids': [],
                 'data': {
                     'id': '24680',
                     'a': 'alpha',
@@ -218,6 +221,7 @@ class TestVersionDiffs(UK2015ExamplesMixin, TestCase):
                 'information_source': 'After clicking "Standing again"',
                 'timestamp': '2015-05-08T01:52:27.061038',
                 'version_id': '3aa8d7da968e10fa',
+                'parent_version_ids': ['fd105d1cf3b5ed0f'],
                 'data': {
                     'id': '24680',
                     'standing_in': {
@@ -248,6 +252,7 @@ class TestVersionDiffs(UK2015ExamplesMixin, TestCase):
                 'information_source': 'Original imported data',
                 'timestamp': '2015-03-10T05:35:15.297559',
                 'version_id': 'fd105d1cf3b5ed0f',
+                'parent_version_ids': [],
                 'data': {
                     'id': '24680',
                     'standing_in': {
@@ -323,6 +328,7 @@ class TestVersionDiffs(UK2015ExamplesMixin, TestCase):
                 'information_source': 'After clicking "Not standing again"',
                 'timestamp': '2015-05-08T01:52:27.061038',
                 'version_id': '698ae05960970b60',
+                'parent_version_ids': ['d1fd9c3830d8d722'],
                 'data': {
                     'id': '24680',
                     'standing_in': {
@@ -350,6 +356,7 @@ class TestVersionDiffs(UK2015ExamplesMixin, TestCase):
                 'information_source': 'Original imported data',
                 'timestamp': '2015-03-10T05:35:15.297559',
                 'version_id': 'd1fd9c3830d8d722',
+                'parent_version_ids': [],
                 'data': {
                     'id': '24680',
                     'standing_in': {
@@ -429,6 +436,7 @@ class TestVersionDiffs(UK2015ExamplesMixin, TestCase):
                 'information_source': 'After clicking "Not standing again"',
                 'timestamp': '2015-05-08T01:52:27.061038',
                 'version_id': '95ac9c97c1d72ebb',
+                'parent_version_ids': ['10fcaee60b9f5203'],
                 'data': {
                     'id': '24680',
                     'party_memberships': {
@@ -466,6 +474,7 @@ class TestVersionDiffs(UK2015ExamplesMixin, TestCase):
                 'information_source': 'Original imported data',
                 'timestamp': '2015-03-10T05:35:15.297559',
                 'version_id': '10fcaee60b9f5203',
+                'parent_version_ids': [],
                 'data': {
                     'id': '24680',
                     'party_memberships': {
@@ -541,6 +550,7 @@ class TestVersionDiffs(UK2015ExamplesMixin, TestCase):
                 'information_source': 'After clicking "Not standing again"',
                 'timestamp': '2015-05-08T01:52:27.061038',
                 'version_id': '65c16b93a0f41b00',
+                'parent_version_ids': ['1a5144605b4c1498'],
                 'data': {
                     'id': '24680',
                     'standing_in': {
@@ -572,6 +582,7 @@ class TestVersionDiffs(UK2015ExamplesMixin, TestCase):
                 'information_source': 'Original imported data',
                 'timestamp': '2015-03-10T05:35:15.297559',
                 'version_id': '1a5144605b4c1498',
+                'parent_version_ids': [],
                 'data': {
                     'id': '24680',
                     "standing_in": {
@@ -665,6 +676,7 @@ class TestVersionDiffs(UK2015ExamplesMixin, TestCase):
                 'information_source': 'Manual correction by a user',
                 'timestamp': '2015-04-12T05:35:15.297559',
                 'version_id': 'e6dcd55bb903499e',
+                'parent_version_ids': ['788a3291f1103de5'],
                 'data': {
                     'id': '24680',
                     'identifiers': [
@@ -700,6 +712,7 @@ class TestVersionDiffs(UK2015ExamplesMixin, TestCase):
                 'information_source': 'Updated by a script',
                 'timestamp': '2015-03-10T05:35:15.297559',
                 'version_id': '788a3291f1103de5',
+                'parent_version_ids': [],
                 'data': {
                     'id': '24680',
                     'identifiers': [
@@ -839,6 +852,7 @@ class TestVersionDiffs(UK2015ExamplesMixin, TestCase):
                 'information_source': 'Manual correction by a user',
                 'timestamp': '2015-04-12T05:35:15.297559',
                 'version_id': 'a2fd462d7b9ea219',
+                'parent_version_ids': ['66b78855c5f19197'],
                 'diffs': [
                     {
                         'parent_version_id': '66b78855c5f19197',
@@ -900,6 +914,7 @@ class TestVersionDiffs(UK2015ExamplesMixin, TestCase):
                 'information_source': 'Updated by a script',
                 'timestamp': '2015-03-10T05:35:15.297559',
                 'version_id': '66b78855c5f19197',
+                'parent_version_ids': [],
                 'diffs': [
                     {
                         'parent_version_id': None,
@@ -1059,6 +1074,7 @@ class TestVersionDiffs(UK2015ExamplesMixin, TestCase):
                 'information_source': 'Manual correction by a user',
                 'timestamp': '2015-05-08T01:52:27.061038',
                 'version_id': '1d33caabf421c656',
+                'parent_version_ids': ['f7cc564751d31a2b'],
                 'diffs': [
                     {
                         'parent_version_id': 'f7cc564751d31a2b',
@@ -1120,6 +1136,7 @@ class TestVersionDiffs(UK2015ExamplesMixin, TestCase):
                 'information_source': 'Updated by a script',
                 'timestamp': '2015-03-10T05:35:15.297559',
                 'version_id': 'f7cc564751d31a2b',
+                'parent_version_ids': [],
                 'diffs': [
                     {
                         'parent_version_id': None,
@@ -1267,6 +1284,7 @@ class TestVersionDiffs(UK2015ExamplesMixin, TestCase):
             'username': 'test',
             'timestamp': '2015-05-08T01:52:27.061038',
             'version_id': '3fc494d54f61a157',
+            'parent_version_ids': ['2f07734529a83242'],
             'diffs': [
                 {
                     'parent_version_id': '2f07734529a83242',
@@ -1303,6 +1321,7 @@ class TestVersionDiffs(UK2015ExamplesMixin, TestCase):
             'username': 'test',
             'timestamp': '2015-03-10T05:35:15.297559',
             'version_id': '2f07734529a83242',
+            'parent_version_ids': [],
             'diffs': [
                 {
                     'parent_version_id': None,

--- a/candidates/tests/test_version_diffs.py
+++ b/candidates/tests/test_version_diffs.py
@@ -8,7 +8,9 @@ from .uk_examples import UK2015ExamplesMixin
 
 def sort_operations_for_comparison(versions_with_diffs):
     for v in versions_with_diffs:
-        v['diff'].sort(key=lambda o: (o['op'], o['path']))
+        v['diffs'].sort(key=lambda pd: pd['parent_version_id'])
+        for parent_data in v['diffs']:
+            parent_data['parent_diff'].sort(key=lambda o: (o['op'], o['path']))
 
 
 class TestVersionDiffs(UK2015ExamplesMixin, TestCase):
@@ -21,7 +23,10 @@ class TestVersionDiffs(UK2015ExamplesMixin, TestCase):
             {
                 'user': 'john',
                 'information_source': 'Manual correction by a user',
+                'timestamp': '2015-06-10T05:35:15.297559',
+                'version_id': '8aa71db8f2f20bf8',
                 'data': {
+                    'id': '24680',
                     'a': 'alpha',
                     'b': 'beta',
                     'g': '',
@@ -31,7 +36,10 @@ class TestVersionDiffs(UK2015ExamplesMixin, TestCase):
             },
             {
                 'information_source': 'Updated by a script',
+                'timestamp': '2015-05-08T01:52:27.061038',
+                'version_id': '643dc3343880f168',
                 'data': {
+                    'id': '24680',
                     'a': 'alpha',
                     'b': 'LATIN SMALL LETTER B',
                     'd': 'delta',
@@ -42,7 +50,10 @@ class TestVersionDiffs(UK2015ExamplesMixin, TestCase):
             },
             {
                 'information_source': 'Original imported data',
+                'timestamp': '2015-03-07T05:35:15.297559',
+                'version_id': '42648e36ff699179',
                 'data': {
+                    'id': '24680',
                     'a': 'alpha',
                     'b': 'beta',
                     'l': None,
@@ -54,30 +65,41 @@ class TestVersionDiffs(UK2015ExamplesMixin, TestCase):
             {
                 'user': 'john',
                 'information_source': 'Manual correction by a user',
+                'timestamp': '2015-06-10T05:35:15.297559',
+                'version_id': '8aa71db8f2f20bf8',
                 'data': {
+                    'id': '24680',
                     'a': 'alpha',
                     'b': 'beta',
                     'g': '',
                     'h': None,
                     'l': 'lambda',
                 },
-                'diff': [
+                'diffs': [
                     {
-                        'op': 'remove',
-                        'path': 'd',
-                        'previous_value': 'delta',
-                    },
-                    {
-                        'op': 'replace',
-                        'path': 'b',
-                        'previous_value': 'LATIN SMALL LETTER B',
-                        'value': 'beta',
+                        'parent_version_id': '643dc3343880f168',
+                        'parent_diff': [
+                            {
+                                'op': 'remove',
+                                'path': 'd',
+                                'previous_value': 'delta',
+                            },
+                            {
+                                'op': 'replace',
+                                'path': 'b',
+                                'previous_value': 'LATIN SMALL LETTER B',
+                                'value': 'beta',
+                            }
+                        ]
                     }
                 ]
             },
             {
                 'information_source': 'Updated by a script',
+                'timestamp': '2015-05-08T01:52:27.061038',
+                'version_id': '643dc3343880f168',
                 'data': {
+                    'id': '24680',
                     'a': 'alpha',
                     'b': 'LATIN SMALL LETTER B',
                     'd': 'delta',
@@ -85,45 +107,63 @@ class TestVersionDiffs(UK2015ExamplesMixin, TestCase):
                     'h': '',
                     'l': 'lambda',
                 },
-                'diff': [
+                'diffs': [
                     {
-                        'op': 'add',
-                        'path': 'd',
-                        'value': 'delta',
-                    },
-                    {
-                        'op': 'add',
-                        'path': 'l',
-                        'previous_value': None,
-                        'value': 'lambda',
-                    },
-                    {
-                        'op': 'replace',
-                        'path': 'b',
-                        'previous_value': 'beta',
-                        'value': 'LATIN SMALL LETTER B',
-                    },
+                        'parent_version_id': '42648e36ff699179',
+                        'parent_diff': [
+                            {
+                                'op': 'add',
+                                'path': 'd',
+                                'value': 'delta',
+                            },
+                            {
+                                'op': 'add',
+                                'path': 'l',
+                                'previous_value': None,
+                                'value': 'lambda',
+                            },
+                            {
+                                'op': 'replace',
+                                'path': 'b',
+                                'previous_value': 'beta',
+                                'value': 'LATIN SMALL LETTER B',
+                            },
+                        ]
+                    }
                 ]
             },
             {
                 'information_source': 'Original imported data',
+                'timestamp': '2015-03-07T05:35:15.297559',
+                'version_id': '42648e36ff699179',
                 'data': {
+                    'id': '24680',
                     'a': 'alpha',
                     'b': 'beta',
                     'l': None,
                 },
-                'diff': [
+                'diffs': [
                     {
-                        'op': 'add',
-                        'path': 'a',
-                        'value': 'alpha',
-                    },
-                    {
-                        'op': 'add',
-                        'path': 'b',
-                        'value': 'beta',
-                    },
-                ]
+                        'parent_version_id': None,
+                        'parent_diff': [
+                            {
+                                'op': 'add',
+                                'path': 'a',
+                                'value': 'alpha',
+                            },
+                            {
+                                'op': 'add',
+                                'path': 'b',
+                                'value': 'beta',
+                            },
+                            {
+                                'op': 'add',
+                                'path': 'id',
+                                'value': '24680',
+                            },
+                        ]
+                    }
+                ],
             },
         ]
 
@@ -136,7 +176,10 @@ class TestVersionDiffs(UK2015ExamplesMixin, TestCase):
         versions = [
             {
                 'information_source': 'After clicking "Standing again"',
+                'timestamp': '2015-05-08T01:52:27.061038',
+                'version_id': '3aa8d7da968e10fa',
                 'data': {
+                    'id': '24680',
                     'standing_in': {
                         '2010': {
                             'name': 'South Cambridgeshire',
@@ -153,7 +196,10 @@ class TestVersionDiffs(UK2015ExamplesMixin, TestCase):
             },
             {
                 'information_source': 'Original imported data',
+                'timestamp': '2015-03-10T05:35:15.297559',
+                'version_id': 'fd105d1cf3b5ed0f',
                 'data': {
+                    'id': '24680',
                     'standing_in': {
                         '2010': {
                             'name': 'South Cambridgeshire',
@@ -168,7 +214,10 @@ class TestVersionDiffs(UK2015ExamplesMixin, TestCase):
         expected_result = [
             {
                 'information_source': 'After clicking "Standing again"',
+                'timestamp': '2015-05-08T01:52:27.061038',
+                'version_id': '3aa8d7da968e10fa',
                 'data': {
+                    'id': '24680',
                     'standing_in': {
                         '2010': {
                             'name': 'South Cambridgeshire',
@@ -180,17 +229,25 @@ class TestVersionDiffs(UK2015ExamplesMixin, TestCase):
                         },
                     }
                 },
-                'diff': [
+                'diffs': [
                     {
-                        'op': 'add',
-                        'path': 'standing_in/2015',
-                        'value': 'is known to be standing in Edinburgh North and Leith in the 2015 General Election',
+                        'parent_version_id': 'fd105d1cf3b5ed0f',
+                        'parent_diff': [
+                            {
+                                'op': 'add',
+                                'path': 'standing_in/2015',
+                                'value': 'is known to be standing in Edinburgh North and Leith in the 2015 General Election',
+                            }
+                        ]
                     }
                 ]
             },
             {
                 'information_source': 'Original imported data',
+                'timestamp': '2015-03-10T05:35:15.297559',
+                'version_id': 'fd105d1cf3b5ed0f',
                 'data': {
+                    'id': '24680',
                     'standing_in': {
                         '2010': {
                             'name': 'South Cambridgeshire',
@@ -198,11 +255,22 @@ class TestVersionDiffs(UK2015ExamplesMixin, TestCase):
                         },
                     }
                 },
-                'diff':[
+                'diffs': [
                     {
-                        'op': 'add',
-                        'path': 'standing_in',
-                        'value': 'was known to be standing in South Cambridgeshire in the 2010 General Election',
+                        'parent_version_id': None,
+                        'parent_diff': [
+                            {
+                                'op': 'add',
+                                'path': 'id',
+                                'value': '24680',
+
+                            },
+                            {
+                                'op': 'add',
+                                'path': 'standing_in',
+                                'value': 'was known to be standing in South Cambridgeshire in the 2010 General Election',
+                            },
+                        ]
                     }
                 ]
             },
@@ -217,7 +285,10 @@ class TestVersionDiffs(UK2015ExamplesMixin, TestCase):
         versions = [
             {
                 'information_source': 'After clicking "Not standing again"',
+                'timestamp': '2015-05-08T01:52:27.061038',
+                'version_id': '698ae05960970b60',
                 'data': {
+                    'id': '24680',
                     'standing_in': {
                         '2010': {
                             'name': 'South Cambridgeshire',
@@ -230,7 +301,10 @@ class TestVersionDiffs(UK2015ExamplesMixin, TestCase):
             },
             {
                 'information_source': 'Original imported data',
+                'timestamp': '2015-03-10T05:35:15.297559',
+                'version_id': 'd1fd9c3830d8d722',
                 'data': {
+                    'id': '24680',
                     'standing_in': {
                         '2010': {
                             'name': 'South Cambridgeshire',
@@ -245,7 +319,10 @@ class TestVersionDiffs(UK2015ExamplesMixin, TestCase):
         expected_result = [
             {
                 'information_source': 'After clicking "Not standing again"',
+                'timestamp': '2015-05-08T01:52:27.061038',
+                'version_id': '698ae05960970b60',
                 'data': {
+                    'id': '24680',
                     'standing_in': {
                         '2010': {
                             'name': 'South Cambridgeshire',
@@ -254,17 +331,25 @@ class TestVersionDiffs(UK2015ExamplesMixin, TestCase):
                         '2015': None,
                     }
                 },
-                'diff': [
+                'diffs': [
                     {
-                        'op': 'add',
-                        'path': 'standing_in/2015',
-                        'value': 'is known not to be standing in the 2015 General Election',
+                        'parent_version_id': 'd1fd9c3830d8d722',
+                        'parent_diff': [
+                            {
+                                'op': 'add',
+                                'path': 'standing_in/2015',
+                                'value': 'is known not to be standing in the 2015 General Election',
+                            }
+                        ]
                     }
-                ]
+                ],
             },
             {
                 'information_source': 'Original imported data',
+                'timestamp': '2015-03-10T05:35:15.297559',
+                'version_id': 'd1fd9c3830d8d722',
                 'data': {
+                    'id': '24680',
                     'standing_in': {
                         '2010': {
                             'name': 'South Cambridgeshire',
@@ -272,11 +357,21 @@ class TestVersionDiffs(UK2015ExamplesMixin, TestCase):
                         },
                     }
                 },
-                'diff':[
+                'diffs': [
                     {
-                        'op': 'add',
-                        'path': 'standing_in',
-                        'value': 'was known to be standing in South Cambridgeshire in the 2010 General Election',
+                        'parent_version_id': None,
+                        'parent_diff': [
+                            {
+                                'op': 'add',
+                                'path': 'id',
+                                'value': '24680',
+                            },
+                            {
+                                'op': 'add',
+                                'path': 'standing_in',
+                                'value': 'was known to be standing in South Cambridgeshire in the 2010 General Election',
+                            }
+                        ]
                     }
                 ]
             },
@@ -291,7 +386,10 @@ class TestVersionDiffs(UK2015ExamplesMixin, TestCase):
         versions = [
             {
                 'information_source': 'After clicking "Not standing again"',
+                'timestamp': '2015-05-08T01:52:27.061038',
+                'version_id': '95ac9c97c1d72ebb',
                 'data': {
+                    'id': '24680',
                     'party_memberships': {
                         '2010': {
                             'id': 'party:58',
@@ -306,7 +404,10 @@ class TestVersionDiffs(UK2015ExamplesMixin, TestCase):
             },
             {
                 'information_source': 'Original imported data',
+                'timestamp': '2015-03-10T05:35:15.297559',
+                'version_id': '10fcaee60b9f5203',
                 'data': {
+                    'id': '24680',
                     'party_memberships': {
                         '2010': {
                             'id': 'party:58',
@@ -324,7 +425,10 @@ class TestVersionDiffs(UK2015ExamplesMixin, TestCase):
         expected_result = [
             {
                 'information_source': 'After clicking "Not standing again"',
+                'timestamp': '2015-05-08T01:52:27.061038',
+                'version_id': '95ac9c97c1d72ebb',
                 'data': {
+                    'id': '24680',
                     'party_memberships': {
                         '2010': {
                             'id': 'party:58',
@@ -336,24 +440,32 @@ class TestVersionDiffs(UK2015ExamplesMixin, TestCase):
                         }
                     },
                 },
-                'diff': [
+                'diffs': [
                     {
-                        'op': 'replace',
-                        'path': 'party_memberships/2015/id',
-                        'previous_value': 'is known to be standing for the party with ID party:58 in the 2015 General Election',
-                        'value': 'is known to be standing for the party with ID ynmp-party:2 in the 2015 General Election',
-                    },
-                    {
-                        'op': 'replace',
-                        'path': 'party_memberships/2015/name',
-                        'previous_value': 'is known to be standing for the party \'Mebyon Kernow - The Party for Cornwall\' in the 2015 General Election',
-                        'value': 'is known to be standing for the party \'Independent\' in the 2015 General Election',
-                    },
+                        'parent_version_id': '10fcaee60b9f5203',
+                        'parent_diff':  [
+                            {
+                                'op': 'replace',
+                                'path': 'party_memberships/2015/id',
+                                'previous_value': 'is known to be standing for the party with ID party:58 in the 2015 General Election',
+                                'value': 'is known to be standing for the party with ID ynmp-party:2 in the 2015 General Election',
+                            },
+                            {
+                                'op': 'replace',
+                                'path': 'party_memberships/2015/name',
+                                'previous_value': 'is known to be standing for the party \'Mebyon Kernow - The Party for Cornwall\' in the 2015 General Election',
+                                'value': 'is known to be standing for the party \'Independent\' in the 2015 General Election',
+                            },
+                        ],
+                    }
                 ]
             },
             {
                 'information_source': 'Original imported data',
+                'timestamp': '2015-03-10T05:35:15.297559',
+                'version_id': '10fcaee60b9f5203',
                 'data': {
+                    'id': '24680',
                     'party_memberships': {
                         '2010': {
                             'id': 'party:58',
@@ -365,11 +477,21 @@ class TestVersionDiffs(UK2015ExamplesMixin, TestCase):
                         }
                     },
                 },
-                'diff':[
+                'diffs': [
                     {
-                        'op': 'add',
-                        'path': 'party_memberships',
-                        'value': 'is known to be standing for the party "Mebyon Kernow - The Party for Cornwall" in the 2015 General Election and was known to be standing for the party "Mebyon Kernow - The Party for Cornwall" in the 2010 General Election',
+                        'parent_version_id': None,
+                        'parent_diff': [
+                            {
+                                'op': 'add',
+                                'path': 'id',
+                                'value': '24680',
+                            },
+                            {
+                                'op': 'add',
+                                'path': 'party_memberships',
+                                'value': 'is known to be standing for the party "Mebyon Kernow - The Party for Cornwall" in the 2015 General Election and was known to be standing for the party "Mebyon Kernow - The Party for Cornwall" in the 2010 General Election',
+                            },
+                        ]
                     }
                 ]
             },
@@ -384,7 +506,10 @@ class TestVersionDiffs(UK2015ExamplesMixin, TestCase):
         versions = [
             {
                 'information_source': 'After clicking "Not standing again"',
+                'timestamp': '2015-05-08T01:52:27.061038',
+                'version_id': '65c16b93a0f41b00',
                 'data': {
+                    'id': '24680',
                     'standing_in': {
                         '2015': {'mapit_url': 'http://mapit.mysociety.org/area/65659',
                                  'name': 'Truro and Falmouth',
@@ -394,7 +519,10 @@ class TestVersionDiffs(UK2015ExamplesMixin, TestCase):
             },
             {
                 'information_source': 'Original imported data',
+                'timestamp': '2015-03-10T05:35:15.297559',
+                'version_id': '1a5144605b4c1498',
                 'data': {
+                    'id': '24680',
                     "standing_in": {
                         "2015": {
                             "post_id": "65808",
@@ -409,30 +537,41 @@ class TestVersionDiffs(UK2015ExamplesMixin, TestCase):
         expected_result = [
             {
                 'information_source': 'After clicking "Not standing again"',
+                'timestamp': '2015-05-08T01:52:27.061038',
+                'version_id': '65c16b93a0f41b00',
                 'data': {
+                    'id': '24680',
                     'standing_in': {
                         '2015': {'name': 'Truro and Falmouth',
                                  'post_id': '65659'}
                     },
                 },
-                'diff': [
+                'diffs': [
                     {
-                        'op': 'replace',
-                        'path': 'standing_in/2015/name',
-                        'previous_value': 'is known to be standing in Dulwich and West Norwood in the 2015 General Election',
-                        'value': 'is known to be standing in Truro and Falmouth in the 2015 General Election',
-                    },
-                    {
-                        'op': 'replace',
-                        'path': 'standing_in/2015/post_id',
-                        'previous_value': 'is known to be standing for the post with ID 65808 in the 2015 General Election',
-                        'value': 'is known to be standing for the post with ID 65659 in the 2015 General Election',
-                    },
+                        'parent_version_id': '1a5144605b4c1498',
+                        'parent_diff': [
+                            {
+                                'op': 'replace',
+                                'path': 'standing_in/2015/name',
+                                'previous_value': 'is known to be standing in Dulwich and West Norwood in the 2015 General Election',
+                                'value': 'is known to be standing in Truro and Falmouth in the 2015 General Election',
+                            },
+                            {
+                                'op': 'replace',
+                                'path': 'standing_in/2015/post_id',
+                                'previous_value': 'is known to be standing for the post with ID 65808 in the 2015 General Election',
+                                'value': 'is known to be standing for the post with ID 65659 in the 2015 General Election',
+                            },
+                        ]
+                    }
                 ]
             },
             {
                 'information_source': 'Original imported data',
+                'timestamp': '2015-03-10T05:35:15.297559',
+                'version_id': '1a5144605b4c1498',
                 'data': {
+                    'id': '24680',
                     "standing_in": {
                         "2015": {
                             "post_id": "65808",
@@ -440,11 +579,21 @@ class TestVersionDiffs(UK2015ExamplesMixin, TestCase):
                         },
                     },
                 },
-                'diff':[
+                'diffs': [
                     {
-                        'op': 'add',
-                        'path': 'standing_in',
-                        'value': 'is known to be standing in Dulwich and West Norwood in the 2015 General Election',
+                        'parent_version_id': None,
+                        'parent_diff': [
+                            {
+                                'op': 'add',
+                                'path': 'id',
+                                'value': '24680',
+                            },
+                            {
+                                'op': 'add',
+                                'path': 'standing_in',
+                                'value': 'is known to be standing in Dulwich and West Norwood in the 2015 General Election',
+                            },
+                        ]
                     }
                 ]
             },
@@ -460,7 +609,10 @@ class TestVersionDiffs(UK2015ExamplesMixin, TestCase):
             {
                 'user': 'john',
                 'information_source': 'Manual correction by a user',
+                'timestamp': '2015-04-12T05:35:15.297559',
+                'version_id': 'e6dcd55bb903499e',
                 'data': {
+                    'id': '24680',
                     'identifiers': [
                         {
                             'scheme': 'yournextmp-candidate',
@@ -481,7 +633,10 @@ class TestVersionDiffs(UK2015ExamplesMixin, TestCase):
             },
             {
                 'information_source': 'Updated by a script',
+                'timestamp': '2015-03-10T05:35:15.297559',
+                'version_id': '788a3291f1103de5',
                 'data': {
+                    'id': '24680',
                     'identifiers': [
                         {
                             'scheme': 'yournextmp-candidate',
@@ -506,7 +661,10 @@ class TestVersionDiffs(UK2015ExamplesMixin, TestCase):
             {
                 'user': 'john',
                 'information_source': 'Manual correction by a user',
+                'timestamp': '2015-04-12T05:35:15.297559',
+                'version_id': 'e6dcd55bb903499e',
                 'data': {
+                    'id': '24680',
                     'identifiers': [
                         {
                             'scheme': 'yournextmp-candidate',
@@ -522,18 +680,26 @@ class TestVersionDiffs(UK2015ExamplesMixin, TestCase):
                         }
                     ],
                 },
-                'diff': [
+                'diffs': [
                     {
-                        'path': 'other_names/0/name',
-                        'previous_value': 'Tessa J Jowell',
-                        'value': 'Tessa Jane Jowell',
-                        'op': 'replace'
+                        'parent_version_id': '788a3291f1103de5',
+                        'parent_diff': [
+                            {
+                                'path': 'other_names/0/name',
+                                'previous_value': 'Tessa J Jowell',
+                                'value': 'Tessa Jane Jowell',
+                                'op': 'replace'
+                            }
+                        ]
                     }
                 ],
             },
             {
                 'information_source': 'Updated by a script',
+                'timestamp': '2015-03-10T05:35:15.297559',
+                'version_id': '788a3291f1103de5',
                 'data': {
+                    'id': '24680',
                     'identifiers': [
                         {
                             'scheme': 'yournextmp-candidate',
@@ -549,28 +715,38 @@ class TestVersionDiffs(UK2015ExamplesMixin, TestCase):
                         }
                     ]
                 },
-                'diff': [
+                'diffs': [
                     {
-                        "op": "add",
-                        "path": "identifiers",
-                        "value": [
+                        'parent_version_id': None,
+                        'parent_diff': [
                             {
-                                "identifier": "2009",
-                                "scheme": "yournextmp-candidate"
-                            }
-                        ]
-                    },
-                    {
-                        "op": "add",
-                        "path": "other_names",
-                        "value": [
+                                'op': 'add',
+                                'path': 'id',
+                                'value': '24680',
+                            },
                             {
-                                "end_date": None,
-                                "name": "Tessa J Jowell",
-                                "note": "Full name",
-                                "start_date": None
+                                "op": "add",
+                                "path": "identifiers",
+                                "value": [
+                                    {
+                                        "identifier": "2009",
+                                        "scheme": "yournextmp-candidate"
+                                    }
+                                ]
+                            },
+                            {
+                                "op": "add",
+                                "path": "other_names",
+                                "value": [
+                                    {
+                                        "end_date": None,
+                                        "name": "Tessa J Jowell",
+                                        "note": "Full name",
+                                        "start_date": None
+                                    }
+                                ]
                             }
-                        ]
+                        ],
                     }
                 ],
             },
@@ -586,7 +762,10 @@ class TestVersionDiffs(UK2015ExamplesMixin, TestCase):
             {
                 'user': 'john',
                 'information_source': 'Manual correction by a user',
+                'timestamp': '2015-04-12T05:35:15.297559',
+                'version_id': 'a2fd462d7b9ea219',
                 'data': {
+                    'id': '24680',
                     'identifiers': [
                         {
                             'scheme': 'yournextmp-candidate',
@@ -618,7 +797,10 @@ class TestVersionDiffs(UK2015ExamplesMixin, TestCase):
             },
             {
                 'information_source': 'Updated by a script',
+                'timestamp': '2015-03-10T05:35:15.297559',
+                'version_id': '66b78855c5f19197',
                 'data': {
+                    'id': '24680',
                     'identifiers': [
                         {
                             'scheme': 'yournextmp-candidate',
@@ -653,29 +835,37 @@ class TestVersionDiffs(UK2015ExamplesMixin, TestCase):
         expected_result = [
             {
                 'information_source': 'Manual correction by a user',
-                'diff': [
+                'timestamp': '2015-04-12T05:35:15.297559',
+                'version_id': 'a2fd462d7b9ea219',
+                'diffs': [
                     {
-                        'path': 'other_names/0',
-                        'value': {
-                            'note': '',
-                            'name': 'Joey',
-                            'end_date': '',
-                            'start_date': ''
-                        },
-                        'op': 'add'
-                    },
-                    {
-                        'path': 'other_names/3',
-                        'previous_value': {
-                            'note': '',
-                            'name': 'Joey',
-                            'end_date': '',
-                            'start_date': ''
-                        },
-                        'op': 'remove'
+                        'parent_version_id': '66b78855c5f19197',
+                        'parent_diff': [
+                            {
+                                'path': 'other_names/0',
+                                'value': {
+                                    'note': '',
+                                    'name': 'Joey',
+                                    'end_date': '',
+                                    'start_date': ''
+                                },
+                                'op': 'add'
+                            },
+                            {
+                                'path': 'other_names/3',
+                                'previous_value': {
+                                    'note': '',
+                                    'name': 'Joey',
+                                    'end_date': '',
+                                    'start_date': ''
+                                },
+                                'op': 'remove'
+                            }
+                        ]
                     }
                 ],
                 'data': {
+                    'id': '24680',
                     'identifiers': [
                         {
                             'scheme': 'yournextmp-candidate',
@@ -706,43 +896,51 @@ class TestVersionDiffs(UK2015ExamplesMixin, TestCase):
             },
             {
                 'information_source': 'Updated by a script',
-                'diff': [
+                'timestamp': '2015-03-10T05:35:15.297559',
+                'version_id': '66b78855c5f19197',
+                'diffs': [
                     {
-                        'path': 'identifiers',
-                        'value': [
+                        'parent_version_id': None,
+                        'parent_diff': [
                             {
-                                'scheme': 'yournextmp-candidate',
-                                'identifier': '2009'
-                            }
-                        ],
-                        'op': 'add'
-                    },
-                    {
-                        'path': 'other_names',
-                        'value': [
-                            {
-                                'note': '',
-                                'name': 'Joseph Tribbiani',
-                                'end_date': '',
-                                'start_date': ''
+                                'path': 'identifiers',
+                                'value': [
+                                    {
+                                        'scheme': 'yournextmp-candidate',
+                                        'identifier': '2009'
+                                    }
+                                ],
+                                'op': 'add'
                             },
                             {
-                                'note': 'Ballot paper',
-                                'name': 'Jonathan Francis Tribbiani',
-                                'end_date': '',
-                                'start_date': ''
-                            },
-                            {
-                                'note': '',
-                                'name': 'Joey',
-                                'end_date': '',
-                                'start_date': ''
+                                'path': 'other_names',
+                                'value': [
+                                    {
+                                        'note': '',
+                                        'name': 'Joseph Tribbiani',
+                                        'end_date': '',
+                                        'start_date': ''
+                                    },
+                                    {
+                                        'note': 'Ballot paper',
+                                        'name': 'Jonathan Francis Tribbiani',
+                                        'end_date': '',
+                                        'start_date': ''
+                                    },
+                                    {
+                                        'note': '',
+                                        'name': 'Joey',
+                                        'end_date': '',
+                                        'start_date': ''
+                                    }
+                                ],
+                                'op': 'add'
                             }
                         ],
-                        'op': 'add'
                     }
                 ],
                 'data': {
+                    'id': '24680',
                     'identifiers': [
                         {
                             'scheme': 'yournextmp-candidate',
@@ -784,7 +982,10 @@ class TestVersionDiffs(UK2015ExamplesMixin, TestCase):
             {
                 'user': 'john',
                 'information_source': 'Manual correction by a user',
+                'timestamp': '2015-05-08T01:52:27.061038',
+                'version_id': '1d33caabf421c656',
                 'data': {
+                    'id': '24680',
                     'identifiers': [
                         {
                             'scheme': 'yournextmp-candidate',
@@ -816,7 +1017,10 @@ class TestVersionDiffs(UK2015ExamplesMixin, TestCase):
             },
             {
                 'information_source': 'Updated by a script',
+                'timestamp': '2015-03-10T05:35:15.297559',
+                'version_id': 'f7cc564751d31a2b',
                 'data': {
+                    'id': '24680',
                     'identifiers': [
                         {
                             'scheme': 'yournextmp-candidate',
@@ -851,29 +1055,37 @@ class TestVersionDiffs(UK2015ExamplesMixin, TestCase):
         expected_result = [
             {
                 'information_source': 'Manual correction by a user',
-                'diff': [
+                'timestamp': '2015-05-08T01:52:27.061038',
+                'version_id': '1d33caabf421c656',
+                'diffs': [
                     {
-                        'path': 'other_names/0',
-                        'value': {
-                            'note': '',
-                            'name': 'Joey',
-                            'end_date': '',
-                            'start_date': ''
-                        },
-                        'op': 'add'
-                    },
-                    {
-                        'path': 'other_names/3',
-                        'previous_value': {
-                            'note': '',
-                            'name': 'Joey',
-                            'end_date': '',
-                            'start_date': ''
-                        },
-                        'op': 'remove'
+                        'parent_version_id': 'f7cc564751d31a2b',
+                        'parent_diff': [
+                            {
+                                'path': 'other_names/0',
+                                'value': {
+                                    'note': '',
+                                    'name': 'Joey',
+                                    'end_date': '',
+                                    'start_date': ''
+                                },
+                                'op': 'add'
+                            },
+                            {
+                                'path': 'other_names/3',
+                                'previous_value': {
+                                    'note': '',
+                                    'name': 'Joey',
+                                    'end_date': '',
+                                    'start_date': ''
+                                },
+                                'op': 'remove'
+                            }
+                        ]
                     }
                 ],
                 'data': {
+                    'id': '24680',
                     'identifiers': [
                         {
                             'scheme': 'yournextmp-candidate',
@@ -904,43 +1116,56 @@ class TestVersionDiffs(UK2015ExamplesMixin, TestCase):
             },
             {
                 'information_source': 'Updated by a script',
-                'diff': [
+                'timestamp': '2015-03-10T05:35:15.297559',
+                'version_id': 'f7cc564751d31a2b',
+                'diffs': [
                     {
-                        'path': 'identifiers',
-                        'value': [
+                        'parent_version_id': None,
+                        'parent_diff': [
                             {
-                                'scheme': 'yournextmp-candidate',
-                                'identifier': '2009'
-                            }
-                        ],
-                        'op': 'add'
-                    },
-                    {
-                        'path': 'other_names',
-                        'value': [
-                            {
-                                'note': '',
-                                'name': 'Joseph Tribbiani',
-                                'end_date': '',
-                                'start_date': ''
+                                'op': 'add',
+                                'path': 'id',
+                                'value': '24680',
                             },
                             {
-                                'note': 'Ballot paper',
-                                'name': 'Jonathan Francis Tribbiani',
-                                'end_date': '',
-                                'start_date': ''
+                                'path': 'identifiers',
+                                'value': [
+                                    {
+                                        'scheme': 'yournextmp-candidate',
+                                        'identifier': '2009'
+                                    }
+                                ],
+                                'op': 'add'
                             },
                             {
-                                'note': '',
-                                'name': 'Joey',
-                                'end_date': '',
-                                'start_date': ''
+                                'path': 'other_names',
+                                'value': [
+                                    {
+                                        'note': '',
+                                        'name': 'Joseph Tribbiani',
+                                        'end_date': '',
+                                        'start_date': ''
+                                    },
+                                    {
+                                        'note': 'Ballot paper',
+                                        'name': 'Jonathan Francis Tribbiani',
+                                        'end_date': '',
+                                        'start_date': ''
+                                    },
+                                    {
+                                        'note': '',
+                                        'name': 'Joey',
+                                        'end_date': '',
+                                        'start_date': ''
+                                    }
+                                ],
+                                'op': 'add'
                             }
                         ],
-                        'op': 'add'
                     }
                 ],
                 'data': {
+                    'id': '24680',
                     'identifiers': [
                         {
                             'scheme': 'yournextmp-candidate',
@@ -1040,12 +1265,17 @@ class TestVersionDiffs(UK2015ExamplesMixin, TestCase):
             'username': 'test',
             'timestamp': '2015-05-08T01:52:27.061038',
             'version_id': '3fc494d54f61a157',
-            'diff': [{
-                'path': 'other_names/0/note',
-                'previous_value': None,
-                'value': 'Maiden name',
-                'op': 'add'
-            }],
+            'diffs': [
+                {
+                    'parent_version_id': '2f07734529a83242',
+                    'parent_diff': [{
+                        'path': 'other_names/0/note',
+                        'previous_value': None,
+                        'value': 'Maiden name',
+                        'op': 'add'
+                    }],
+                }
+            ],
             'data': {
                 'honorific_suffix': '',
                 'party_ppc_page_url': '',
@@ -1071,36 +1301,41 @@ class TestVersionDiffs(UK2015ExamplesMixin, TestCase):
             'username': 'test',
             'timestamp': '2015-03-10T05:35:15.297559',
             'version_id': '2f07734529a83242',
-            'diff': [
+            'diffs': [
                 {
-                    'path': 'honorific_prefix',
-                    'value': 'Mrs',
-                    'op': 'add'
-                },
-                {
-                    'path': 'id',
-                    'value': '6704',
-                    'op': 'add'
-                },
-                {
-                    'path': 'identifiers',
-                    'value': [{
-                        'scheme': 'yournextmp-candidate',
-                        'identifier': '13445'
-                    }],
-                    'op': 'add'
-                },
-                {
-                    'path': 'name',
-                    'value': 'Sarah Jones',
-                    'op': 'add'
-                },
-                {
-                    'path': 'other_names',
-                    'value': [{
-                        'name': 'Sarah Smith'
-                    }],
-                    'op': 'add'
+                    'parent_version_id': None,
+                    'parent_diff': [
+                        {
+                            'path': 'honorific_prefix',
+                            'value': 'Mrs',
+                            'op': 'add'
+                        },
+                        {
+                            'path': 'id',
+                            'value': '6704',
+                            'op': 'add'
+                        },
+                        {
+                            'path': 'identifiers',
+                            'value': [{
+                                'scheme': 'yournextmp-candidate',
+                                'identifier': '13445'
+                            }],
+                            'op': 'add'
+                        },
+                        {
+                            'path': 'name',
+                            'value': 'Sarah Jones',
+                            'op': 'add'
+                        },
+                        {
+                        'path': 'other_names',
+                            'value': [{
+                                'name': 'Sarah Smith'
+                            }],
+                            'op': 'add'
+                        }
+                    ],
                 }
             ],
             'data': {

--- a/candidates/tests/test_version_tree.py
+++ b/candidates/tests/test_version_tree.py
@@ -1,0 +1,325 @@
+from django.test import TestCase
+
+from candidates.models.versions import get_versions_parent_map
+
+
+class TestVersionTree(TestCase):
+
+    def test_simple_linear_single_id(self):
+        versions = [
+            {
+                "data": {
+                    "id": "2009",
+                },
+                "information_source": "Found her Wikipedia page through Google",
+                "timestamp": "2014-11-25T10:02:40.184563",
+                "username": "user",
+                "version_id": "407db6845dbb0007"
+            },
+            {
+                "data": {
+                    "id": "2009",
+                },
+                "information_source": "It says she's standing down here: http://www.bbc.co.uk/news/uk-politics-25045746",
+                "timestamp": "2014-11-23T18:09:11.604997",
+                "username": "mark",
+                "version_id": "36198267ad42acb1"
+            },
+            {
+                "data": {
+                    "id": "2009",
+                },
+                "information_source": "Imported from YourNextMP data from 2010",
+                "timestamp": "2014-11-21T18:16:48.116236",
+                "version_id": "53e1260ec3946bbf"
+            }
+        ]
+        self.assertEqual(
+            get_versions_parent_map(versions),
+            {
+                '407db6845dbb0007': ['36198267ad42acb1'],
+                '36198267ad42acb1': ['53e1260ec3946bbf'],
+                '53e1260ec3946bbf': [],
+            }
+        )
+
+    def test_single_merge(self):
+        versions = [
+            {
+                "data": {
+                    "id": "4",
+                },
+                "information_source": "Approved a photo upload from a script who provided the message: \"Auto imported from Twitter\"",
+                "timestamp": "2016-05-01T19:35:44.838011",
+                "username": "j0e_m",
+                "version_id": "086bab0dbcbff4d1"
+            },
+            {
+                "data": {
+                    "id": "4",
+                },
+                "information_source": "Updated by the automated Twitter account checker (candidates_update_twitter_usernames)",
+                "timestamp": "2016-04-28T08:46:05.352089",
+                "version_id": "016b59341d65b9dc"
+            },
+            {
+                "data": {
+                    "id": "4",
+                },
+                "information_source": "more up to date email address from merged candidate page",
+                "timestamp": "2016-04-23T14:30:30.328947",
+                "username": "JeniT",
+                "version_id": "7c4e8a767f45a0ab"
+            },
+            {
+                "data": {
+                    "id": "4",
+                },
+                "information_source": "After merging person 6628",
+                "timestamp": "2016-04-23T14:28:53.499803",
+                "username": "JeniT",
+                "version_id": "4df120ba2cb9042c"
+            },
+            {
+                "data": {
+                    "id": "4",
+                },
+                "information_source": "There's a Labour candidate already listed for Rushcliffe on this site, plus you also show Andrew Clayworth standing as the TUSC candidate in Nottingham South.",
+                "timestamp": "2015-03-21T00:16:33.324290",
+                "username": "greenm2",
+                "version_id": "6eaf38ba8f30f68c"
+            },
+            {
+                "data": {
+                    "id": "4",
+                },
+                "information_source": "Imported from YourNextMP data from 2010",
+                "timestamp": "2014-11-21T18:07:15.616170",
+                "version_id": "5a30bda120ae89b1"
+            },
+            {
+                "data": {
+                    "id": "6628",
+                },
+                "information_source": "http://tusc2015.com/andrew-clayworth-for-nottingham-south/",
+                "timestamp": "2016-04-23T14:26:34.673240",
+                "username": "JeniT",
+                "version_id": "4ce77239a3ce82f4"
+            },
+            {
+                "data": {
+                    "id": "6628",
+                },
+                "information_source": "[Quick update from the constituency page]",
+                "timestamp": "2015-05-08T05:25:31.230573",
+                "username": "symroe",
+                "version_id": "1dd9756a410cdc3c"
+            },
+            {
+                "data": {
+                    "id": "6628",
+                },
+                "information_source": "Approved a photo upload from TUSCNottmSouth who provided the message: \"\"",
+                "timestamp": "2015-04-17T09:19:15.053401",
+                "username": "mark",
+                "version_id": "3d75507f7f81411d"
+            },
+            {
+                "data": {
+                    "id": "6628",
+                },
+                "information_source": "The candidate",
+                "timestamp": "2015-04-16T23:32:31.301827",
+                "username": "TUSCNottmSouth",
+                "version_id": "23a5014297200590"
+            },
+            {
+                "data": {
+                    "id": "6628",
+                },
+                "information_source": "http://www.tusc.org.uk/txt/324.pdf",
+                "timestamp": "2015-03-05T14:45:03.058131",
+                "username": "bwdeacon",
+                "version_id": "5abf454b55e734a5"
+            }
+        ]
+        self.assertEqual(
+            get_versions_parent_map(versions),
+            {
+                # The versions with ID 6628:
+                '5abf454b55e734a5': [],
+                '23a5014297200590': ['5abf454b55e734a5'],
+                '3d75507f7f81411d': ['23a5014297200590'],
+                '1dd9756a410cdc3c': ['3d75507f7f81411d'],
+                '4ce77239a3ce82f4': ['1dd9756a410cdc3c'],
+                # Now the versions with ID 4:
+                '5a30bda120ae89b1': [],
+                '6eaf38ba8f30f68c': ['5a30bda120ae89b1'],
+                # This was the version representing the merge:
+                '4df120ba2cb9042c': ['6eaf38ba8f30f68c', '4ce77239a3ce82f4'],
+                '7c4e8a767f45a0ab': ['4df120ba2cb9042c'],
+                '016b59341d65b9dc': ['7c4e8a767f45a0ab'],
+                '086bab0dbcbff4d1': ['016b59341d65b9dc'],
+            }
+        )
+
+    def test_bogus_merge_unknown_other(self):
+        versions = [
+            {
+                "data": {
+                    "id": "2009",
+                },
+                "information_source": "After merging person 123456789",
+                "timestamp": "2014-11-25T10:02:40.184563",
+                "username": "user",
+                "version_id": "407db6845dbb0007"
+            },
+            {
+                "data": {
+                    "id": "2009",
+                },
+                "information_source": "It says she's standing down here: http://www.bbc.co.uk/news/uk-politics-25045746",
+                "timestamp": "2014-11-23T18:09:11.604997",
+                "username": "mark",
+                "version_id": "36198267ad42acb1"
+            },
+            {
+                "data": {
+                    "id": "2009",
+                },
+                "information_source": "Imported from YourNextMP data from 2010",
+                "timestamp": "2014-11-21T18:16:48.116236",
+                "version_id": "53e1260ec3946bbf"
+            }
+        ]
+        with self.assertRaisesRegexp(
+                Exception,
+                r'Found a bogus merge version for person with ID: 2009 - no '
+                r'merged history of person with ID 123456789 found'
+        ):
+            get_versions_parent_map(versions)
+
+    def test_other_person_earlier(self):
+        versions = [
+            {
+                "data": {
+                    "id": "2009",
+                },
+                "information_source": "Some random update",
+                "timestamp": "2014-11-25T10:02:40.184563",
+                "username": "user",
+                "version_id": "407db6845dbb0007"
+            },
+            {
+                "data": {
+                    "id": "2009",
+                },
+                "information_source": "After merging person 567",
+                "timestamp": "2014-11-24T10:02:40.184563",
+                "username": "user",
+                "version_id": "43eb6cd97a180e4a"
+
+            },
+            {
+                "data": {
+                    "id": "2009",
+                },
+                "information_source": "It says she's standing down here: http://www.bbc.co.uk/news/uk-politics-25045746",
+                "timestamp": "2014-11-23T18:09:11.604997",
+                "username": "mark",
+                "version_id": "36198267ad42acb1"
+            },
+            {
+                "data": {
+                    "id": "2009",
+                },
+                "information_source": "Imported from YourNextMP data from 2010",
+                "timestamp": "2014-11-21T18:16:48.116236",
+                "version_id": "53e1260ec3946bbf"
+            },
+            {
+                "data": {
+                    "id": "567",
+                },
+                "information_source": "Spotted on the interwebs!",
+                "timestamp": "2014-10-02T19:03:10.236114",
+                "version_id": "3787faf978dee092"
+            },            
+        ]
+        self.assertEqual(
+            get_versions_parent_map(versions),
+            {
+                # The versions with ID 2009:
+                '407db6845dbb0007': ['43eb6cd97a180e4a'],
+                # The merge:
+                '43eb6cd97a180e4a': ['36198267ad42acb1', '3787faf978dee092'],
+                '36198267ad42acb1': ['53e1260ec3946bbf'],
+                '53e1260ec3946bbf': [],
+                # The older, but secondary version with ID 567:
+                '3787faf978dee092': [],
+            }
+        )
+
+    def test_bogus_merge_extraneous(self):
+        versions = [
+            {
+                "data": {
+                    "id": "2009",
+                },
+                "information_source": "After merging person 567",
+                "timestamp": "2014-11-26T10:02:40.184563",
+                "username": "user",
+                "version_id": "1164b8bcedb1a1e6"
+            },
+            {
+                "data": {
+                    "id": "2009",
+                },
+                "information_source": "Some random update",
+                "timestamp": "2014-11-25T10:02:40.184563",
+                "username": "user",
+                "version_id": "407db6845dbb0007"
+            },
+            {
+                "data": {
+                    "id": "2009",
+                },
+                "information_source": "After merging person 567",
+                "timestamp": "2014-11-24T10:02:40.184563",
+                "username": "user",
+                "version_id": "43eb6cd97a180e4a"
+
+            },
+            {
+                "data": {
+                    "id": "2009",
+                },
+                "information_source": "It says she's standing down here: http://www.bbc.co.uk/news/uk-politics-25045746",
+                "timestamp": "2014-11-23T18:09:11.604997",
+                "username": "mark",
+                "version_id": "36198267ad42acb1"
+            },
+            {
+                "data": {
+                    "id": "2009",
+                },
+                "information_source": "Imported from YourNextMP data from 2010",
+                "timestamp": "2014-11-21T18:16:48.116236",
+                "version_id": "53e1260ec3946bbf"
+            },
+            {
+                "data": {
+                    "id": "567",
+                },
+                "information_source": "Spotted on the interwebs!",
+                "timestamp": "2014-10-02T19:03:10.236114",
+                "version_id": "3787faf978dee092"
+            },
+            
+        ]
+        with self.assertRaisesRegexp(
+                Exception,
+                r'It looks like there was a bogus merge version for person ' \
+                r'with ID 567; there were 2 merge versions and 2 person IDs.'
+        ):
+            get_versions_parent_map(versions)


### PR DESCRIPTION
The history of changes to a candidate's data previously showed the changes introduced by each version relative to whatever happened to be before it in the `versions` list. However, this being a linear data structure is artificial, since when a duplicate candidate is found and merged that history becomes a tree - the two version lists are joined at the merge.

This pull request does the following things:
* Adds code to infer the correct tree structure of the version history from the existing versions lists.
* Changes the rendering of diffs, so you see the difference from that version to its (0 to 2) parents
* Adds the IDs and parents as HTML attributes to make it easier to add in Javascript-based visualization of the tree in the future.

For example, here is how two versions of https://candidates.democracyclub.org.uk/person/7899 as they were before:

![before-diffs](https://cloud.githubusercontent.com/assets/7907/25567106/77daaf22-2dde-11e7-9f9a-a77b77024dc0.png)

And here those changes are after this pull request:

![after-diffs](https://cloud.githubusercontent.com/assets/7907/25567107/80a5af94-2dde-11e7-9566-113c6090ab27.png)

