### PR TITLE
483 - Mark recent changes as reviewed - PART I

### DIFF
--- a/candidates/forms.py
+++ b/candidates/forms.py
@@ -591,3 +591,14 @@ class OtherNameForm(forms.ModelForm):
         ),
         max_length=512,
     )
+
+
+class ChangeReviewedForm(forms.Form):
+    person_id = StrippedCharField(
+        widget=forms.HiddenInput(),
+        required=True
+    )
+    logged_action_id = StrippedCharField(
+        widget=forms.HiddenInput(),
+        required=True
+    )

--- a/candidates/migrations/0033_changereviewed.py
+++ b/candidates/migrations/0033_changereviewed.py
@@ -1,0 +1,27 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+from django.conf import settings
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('popolo', '0002_update_models_from_upstream'),
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+        ('candidates', '0032_migrate_org_slugs'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='ChangeReviewed',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('created', models.DateTimeField(auto_now_add=True)),
+                ('logged_action', models.ForeignKey(to='candidates.LoggedAction')),
+                ('person', models.ForeignKey(to='popolo.Person')),
+                ('reviewer', models.ForeignKey(to=settings.AUTH_USER_MODEL)),
+            ],
+        ),
+    ]

--- a/candidates/migrations/0034_add_trusted_to_review_changes_group.py
+++ b/candidates/migrations/0034_add_trusted_to_review_changes_group.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations
+
+from auth_helpers.migrations import (
+    get_migration_group_create,
+    get_migration_group_delete,
+)
+from candidates.models import TRUSTED_TO_REVIEW_CHANGES_GROUP_NAME
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('candidates', '0033_changereviewed'),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            get_migration_group_create(TRUSTED_TO_REVIEW_CHANGES_GROUP_NAME, []),
+            get_migration_group_delete(TRUSTED_TO_REVIEW_CHANGES_GROUP_NAME),
+        )
+    ]

--- a/candidates/models/__init__.py
+++ b/candidates/models/__init__.py
@@ -29,6 +29,7 @@ from .fields import ComplexPopoloField
 from .db import LoggedAction
 from .db import PersonRedirect
 from .db import UserTermsAgreement
+from .db import ChangeReviewed
 
 from .auth import TRUSTED_TO_MERGE_GROUP_NAME
 from .auth import TRUSTED_TO_LOCK_GROUP_NAME

--- a/candidates/models/__init__.py
+++ b/candidates/models/__init__.py
@@ -34,4 +34,5 @@ from .db import ChangeReviewed
 from .auth import TRUSTED_TO_MERGE_GROUP_NAME
 from .auth import TRUSTED_TO_LOCK_GROUP_NAME
 from .auth import TRUSTED_TO_RENAME_GROUP_NAME
+from .auth import TRUSTED_TO_REVIEW_CHANGES_GROUP_NAME
 from .auth import RESULT_RECORDERS_GROUP_NAME

--- a/candidates/models/auth.py
+++ b/candidates/models/auth.py
@@ -8,6 +8,7 @@ from auth_helpers.views import user_in_group
 TRUSTED_TO_MERGE_GROUP_NAME = 'Trusted To Merge'
 TRUSTED_TO_LOCK_GROUP_NAME = 'Trusted To Lock'
 TRUSTED_TO_RENAME_GROUP_NAME = 'Trusted To Rename'
+TRUSTED_TO_REVIEW_CHANGES_GROUP_NAME = 'Trusted To Review Changes'
 RESULT_RECORDERS_GROUP_NAME = 'Result Recorders'
 
 class NameChangeDisallowedException(Exception):

--- a/candidates/models/db.py
+++ b/candidates/models/db.py
@@ -42,6 +42,13 @@ class UserTermsAgreement(models.Model):
     assigned_to_dc = models.BooleanField(default=False)
 
 
+class ChangeReviewed(models.Model):
+    person = models.ForeignKey(Person)
+    logged_action = models.ForeignKey(LoggedAction)
+    reviewer = models.ForeignKey(User)
+    created = models.DateTimeField(auto_now_add=True)
+
+
 def create_user_terms_agreement(sender, instance, created, **kwargs):
     if created:
         UserTermsAgreement.objects.create(user=instance)

--- a/candidates/templates/candidates/recent-changes.html
+++ b/candidates/templates/candidates/recent-changes.html
@@ -12,26 +12,30 @@
 {% block content %}
 
 <table>
-  <tr>
-    <th>{% trans "User" %}</th>
-    <th>{% trans "Date and time" %}</th>
-    <th>{% trans "Action" %}</th>
-    <th>{% trans "Candidate edited" %}</th>
-    <th>{% trans "Information source" %}</th>
-  </tr>
-  {% for action in actions %}
-    <tr>
-      <td>{{ action.user.username }}</td>
-      <td>{{ action.created }}</td>
-      <td>{{ action.action_type }}</td>
-      {% if action.person %}
-        <td><a href="{% url 'person-view' person_id=action.person.id %}">{{ action.person.name }}</a></td>
-      {% else %}
-        <td></td>
-      {% endif %}
-      <td>{{ action.source }}</td>
-    </tr>
-  {% endfor %}
+    <thead>
+        <tr>
+            <th>{% trans "User" %}</th>
+            <th>{% trans "Date and time" %}</th>
+            <th>{% trans "Action" %}</th>
+            <th>{% trans "Candidate edited" %}</th>
+            <th>{% trans "Information source" %}</th>
+        </tr>
+    </thead>
+    <tbody>
+      {% for action in actions %}
+        <tr>
+            <td>{{ action.user.username }}</td>
+            <td>{{ action.created }}</td>
+            <td>{{ action.action_type }}</td>
+            {% if action.person %}
+            <td><a href="{% url 'person-view' person_id=action.person.id %}">{{ action.person.name }}</a></td>
+            {% else %}
+            <td></td>
+            {% endif %}
+            <td>{{ action.source }}</td>
+        </tr>
+      {% endfor %}
+    </tbody>
 </table>
 
 <div class="pagination">

--- a/candidates/templates/candidates/recent-changes.html
+++ b/candidates/templates/candidates/recent-changes.html
@@ -19,6 +19,7 @@
             <th>{% trans "Action" %}</th>
             <th>{% trans "Candidate edited" %}</th>
             <th>{% trans "Information source" %}</th>
+            <th>{% trans "Review" %}</th>
         </tr>
     </thead>
     <tbody>
@@ -33,6 +34,14 @@
             <td></td>
             {% endif %}
             <td>{{ action.source }}</td>
+            <td>
+                <form method="post" action="{% url 'mark-change-as-reviewed' %}">
+                    {% csrf_token %}
+                    <input type="hidden" name="person_id" value="{{ action.person.id }}"/>
+                    <input type="hidden" name="logged_action_id" value="{{ action.id }}"/>
+                    <input type="submit" value="Mark as reviewed">
+                </form>
+            </td>
         </tr>
       {% endfor %}
     </tbody>

--- a/candidates/tests/auth.py
+++ b/candidates/tests/auth.py
@@ -6,6 +6,7 @@ from candidates.models import (
     TRUSTED_TO_MERGE_GROUP_NAME,
     TRUSTED_TO_LOCK_GROUP_NAME,
     TRUSTED_TO_RENAME_GROUP_NAME,
+    TRUSTED_TO_REVIEW_CHANGES_GROUP_NAME,
     RESULT_RECORDERS_GROUP_NAME,
 )
 from official_documents.models import DOCUMENT_UPLOADERS_GROUP_NAME
@@ -22,6 +23,7 @@ class TestUserMixin(object):
                 ('charles', 'user_who_can_lock', [TRUSTED_TO_LOCK_GROUP_NAME]),
                 ('delilah', 'user_who_can_upload_documents', [DOCUMENT_UPLOADERS_GROUP_NAME]),
                 ('ermintrude', 'user_who_can_rename', [TRUSTED_TO_RENAME_GROUP_NAME]),
+                ('ursula', 'user_who_can_review_changes', [TRUSTED_TO_REVIEW_CHANGES_GROUP_NAME]),
                 ('frankie', 'user_who_can_record_results', [RESULT_RECORDERS_GROUP_NAME]),
         ):
             u = User.objects.create_user(

--- a/candidates/tests/test_change_reviewed.py
+++ b/candidates/tests/test_change_reviewed.py
@@ -1,0 +1,29 @@
+from django.test import TestCase
+
+from candidates.models import ChangeReviewed
+
+
+class TestChangeReviewed(TestCase):
+    def test_requires_a_popolo_person(self):
+        with self.assertRaises(ValueError):
+            ChangeReviewed.objects.create(
+                person=None,
+                logged_action=1,
+                reviewer=1
+            )
+
+    def test_requires_a_logged_action(self):
+        with self.assertRaises(ValueError):
+            ChangeReviewed.objects.create(
+                person=1,
+                logged_action=None,
+                reviewer=1
+            )
+
+    def test_requires_a_reviewer(self):
+        with self.assertRaises(ValueError):
+            ChangeReviewed.objects.create(
+                person=1,
+                logged_action=1,
+                reviewer=None
+            )

--- a/candidates/tests/test_leaderboard.py
+++ b/candidates/tests/test_leaderboard.py
@@ -8,6 +8,7 @@ from .auth import TestUserMixin
 from .factories import PersonExtraFactory
 from ..models import LoggedAction
 
+
 class TestLeaderboardView(TestUserMixin, WebTest):
 
     def setUp(self):
@@ -81,4 +82,5 @@ class TestLeaderboardView(TestUserMixin, WebTest):
             '5,ermintrude,0\r\n'
             '6,frankie,0\r\n'
             '7,johnrefused,0\r\n'
+            '8,ursula,0\r\n'
         )

--- a/candidates/tests/test_mark_change_as_reviewed_view.py
+++ b/candidates/tests/test_mark_change_as_reviewed_view.py
@@ -1,0 +1,105 @@
+from __future__ import unicode_literals
+
+from django.core.exceptions import ValidationError
+from django_webtest import WebTest
+
+from .auth import TestUserMixin
+from ..models import ChangeReviewed, LoggedAction
+from candidates.tests import factories
+
+from popolo.models import Person
+
+
+class TestMarkChangeAsReviewedView(TestUserMixin, WebTest):
+    def setUp(self):
+        test_person_1 = factories.PersonExtraFactory.create(
+            base__id=9876,
+            base__name='Test Candidate for Recent Changes',
+        )
+        self.action1 = LoggedAction.objects.create(
+            user=self.user,
+            action_type='person-create',
+            ip_address='127.0.0.1',
+            person=test_person_1.base,
+            popit_person_new_version='1234567890abcdef',
+            source='Just for tests...',
+        )
+        self.app.get('/recent-changes', user=self.user)
+
+    def test_redirects_to_recent_changes_page(self):
+        response = self.post_to_change_reviewed(
+            Person.objects.last().id,
+            LoggedAction.objects.last().id,
+        )
+        self.assertEqual(response.status_code, 302)
+
+    def test_marks_a_change_as_reviewed(self):
+        count_before = len(ChangeReviewed.objects.all())
+        self.post_to_change_reviewed(
+            Person.objects.last().id,
+            LoggedAction.objects.last().id,
+        )
+        count_after = len(ChangeReviewed.objects.all())
+        self.assertEqual(count_after - count_before, 1)
+
+    def test_404s_if_person_not_in_database(self):
+        response = self.post_to_change_reviewed(
+            0,
+            LoggedAction.objects.last().id,
+        )
+        self.assertEqual(response.status_code, 404)
+
+    def test_404s_if_logged_action_not_in_database(self):
+        response = self.post_to_change_reviewed(
+            Person.objects.last().id,
+            0,
+        )
+        self.assertEqual(response.status_code, 404)
+
+    def test_errors_if_person_field_present_but_empty(self):
+        with self.assertRaises(ValidationError):
+            self.post_to_change_reviewed(
+                '',
+                LoggedAction.objects.last().id,
+            )
+
+    def test_errors_if_logged_action_field_present_but_empty(self):
+        with self.assertRaises(ValidationError):
+            self.post_to_change_reviewed(
+                Person.objects.last().id,
+                '',
+            )
+
+    def test_errors_if_person_field_not_present(self):
+        with self.assertRaises(ValidationError):
+            self.app.post(
+                '/mark-change-as-reviewed',
+                {
+                    'csrfmiddlewaretoken': self.app.cookies['csrftoken'],
+                    'logged_action_id': LoggedAction.objects.last().id,
+                },
+                user=self.user,
+            )
+
+    def test_errors_if_logged_action_field_not_present(self):
+        with self.assertRaises(ValidationError):
+            self.app.post(
+                '/mark-change-as-reviewed',
+                {
+                    'csrfmiddlewaretoken': self.app.cookies['csrftoken'],
+                    'person_id': Person.objects.last().id,
+                },
+                user=self.user,
+            )
+
+    def post_to_change_reviewed(self, person_id, logged_action_id):
+        return self.app.post(
+            '/mark-change-as-reviewed',
+            {
+                'csrfmiddlewaretoken': self.app.cookies['csrftoken'],
+                'person_id': person_id,
+                'logged_action_id': logged_action_id,
+            },
+            user=self.user,
+            expect_errors=True,
+        )

--- a/candidates/tests/test_recent_changes_view.py
+++ b/candidates/tests/test_recent_changes_view.py
@@ -35,7 +35,7 @@ class TestRecentChangesView(TestUserMixin, WebTest):
             popit_person_new_version='987654321',
             source='Also just for testing',
         )
-        self.response = self.app.get('/recent-changes', user=self.user)
+        self.response = self.app.get('/recent-changes', user=self.user_who_can_review_changes)
 
     def tearDown(self):
         self.action2.delete()
@@ -58,3 +58,7 @@ class TestRecentChangesView(TestUserMixin, WebTest):
         action_input = self.response.html.find_all('input', attrs={'name': 'logged_action_id'})[0]
         value = str(LoggedAction.objects.last().id)
         self.assertEqual(action_input.get('value'), value)
+
+    def test_page_is_forbidden_if_user_has_no_review_permissions(self):
+        response = self.app.get('/recent-changes', user=self.user, expect_errors=True)
+        self.assertEqual(response.status_code, 403)

--- a/candidates/tests/test_recent_changes_view.py
+++ b/candidates/tests/test_recent_changes_view.py
@@ -39,8 +39,7 @@ class TestRecentChangesView(TestUserMixin, WebTest):
         self.action2.delete()
         self.action1.delete()
 
-    def test_recent_changes_page(self):
-        # Just a smoke test to check that the page loads:
+    def test_loads_all_recent_changes(self):
         response = self.app.get('/recent-changes')
-        table = response.html.find('table')
-        self.assertEqual(3, len(table.find_all('tr')))
+        tbody = response.html.find('tbody')
+        self.assertEqual(len(tbody.find_all('tr')), 2)

--- a/candidates/urls.py
+++ b/candidates/urls.py
@@ -207,6 +207,11 @@ patterns_to_format = [
         'name': 'recent-changes'
     },
     {
+        'pattern': r'^mark-change-as-reviewed$',
+        'view': views.MarkChangeAsReviewedView.as_view(),
+        'name': 'mark-change-as-reviewed'
+    },
+    {
         'pattern': r'^leaderboard$',
         'view': views.LeaderboardView.as_view(),
         'name': 'leaderboard'

--- a/candidates/views/users.py
+++ b/candidates/views/users.py
@@ -12,15 +12,17 @@ from django.shortcuts import get_object_or_404
 from django.utils.translation import ugettext_lazy as _
 from django.views.generic import TemplateView, View
 
+from auth_helpers.views import GroupRequiredMixin
 from ..forms import ChangeReviewedForm
 from .mixins import ContributorsMixin
-from ..models import ChangeReviewed, LoggedAction
+from ..models import ChangeReviewed, LoggedAction, TRUSTED_TO_REVIEW_CHANGES_GROUP_NAME
 
 from popolo.models import Person
 
 
-class RecentChangesView(ContributorsMixin, TemplateView):
+class RecentChangesView(GroupRequiredMixin, ContributorsMixin, TemplateView):
     template_name = 'candidates/recent-changes.html'
+    required_group_name = TRUSTED_TO_REVIEW_CHANGES_GROUP_NAME
 
     def get_context_data(self, **kwargs):
         context = super(RecentChangesView, self).get_context_data(**kwargs)
@@ -36,7 +38,9 @@ class RecentChangesView(ContributorsMixin, TemplateView):
         return context
 
 
-class MarkChangeAsReviewedView(View):
+class MarkChangeAsReviewedView(GroupRequiredMixin, View):
+    required_group_name = TRUSTED_TO_REVIEW_CHANGES_GROUP_NAME
+
     def post(self, request, *args, **kwargs):
         form = ChangeReviewedForm(data=self.request.POST)
 

--- a/candidates/views/users.py
+++ b/candidates/views/users.py
@@ -3,12 +3,21 @@ from __future__ import unicode_literals
 import csv
 
 from django.contrib.auth.models import User
+from django.core.exceptions import ValidationError
 from django.core.paginator import Paginator, EmptyPage, PageNotAnInteger
+from django.core.urlresolvers import reverse
 from django.db.models import Count
-from django.http import HttpResponse
+from django.http import HttpResponse, HttpResponseRedirect
+from django.shortcuts import get_object_or_404
+from django.utils.translation import ugettext_lazy as _
 from django.views.generic import TemplateView, View
 
+from ..forms import ChangeReviewedForm
 from .mixins import ContributorsMixin
+from ..models import ChangeReviewed, LoggedAction
+
+from popolo.models import Person
+
 
 class RecentChangesView(ContributorsMixin, TemplateView):
     template_name = 'candidates/recent-changes.html'
@@ -26,6 +35,29 @@ class RecentChangesView(ContributorsMixin, TemplateView):
             context['actions'] = paginator.page(paginator.num_pages)
         return context
 
+
+class MarkChangeAsReviewedView(View):
+    def post(self, request, *args, **kwargs):
+        form = ChangeReviewedForm(data=self.request.POST)
+
+        if form.is_valid():
+            person_id = form.cleaned_data['person_id']
+            logged_action_id = form.cleaned_data['logged_action_id']
+            reviewer_id = request.user.id
+
+            ChangeReviewed.objects.create(
+                person=get_object_or_404(Person, pk=person_id),
+                logged_action=get_object_or_404(LoggedAction, pk=logged_action_id),
+                reviewer=get_object_or_404(User, pk=reviewer_id),
+            )
+            return HttpResponseRedirect(
+                reverse('recent-changes')
+            )
+        else:
+            message = _('Invalid data POSTed to MarkChangeAsReviewedView')
+            raise ValidationError(message)
+
+
 class LeaderboardView(ContributorsMixin, TemplateView):
     template_name = 'candidates/leaderboard.html'
 
@@ -33,6 +65,7 @@ class LeaderboardView(ContributorsMixin, TemplateView):
         context = super(LeaderboardView, self).get_context_data(**kwargs)
         context['leaderboards'] = self.get_leaderboards()
         return context
+
 
 class UserContributions(View):
 


### PR DESCRIPTION
Regarding the "`outcome`" field, if it is a text field, we should probably have either a default text, or make it mandatory that the reviewer introduces something in that text field. Or we could also have an extra boolean field "_reviewed_" which reads the checkbox. After a discussion with Mark, we decided to leave it out. In Mark's words:

> _...thinking about it more, let's leave it out in the first version, and just say that a row in that table means "I've looked at it, and it's either fine or i fixed it"_

Regarding the recent changes template, I believe Zarino is working on a better structured way of presenting the information shown on this page, so for the time being this PR only adds a simple form with two hidden inputs for two of the three required foreign keys of the `ChangeReviewed` table, the third one being the user sent with the request.

## Related issues

Part of #483