### PR TITLE
Add an Atom feed of changes that might need to be reviewed

### DIFF
--- a/candidates/feeds.py
+++ b/candidates/feeds.py
@@ -7,7 +7,6 @@ from django.contrib.syndication.views import Feed
 from django.core.urlresolvers import reverse
 from django.utils.feedgenerator import Atom1Feed
 from django.utils.html import escape
-from django.utils.text import slugify
 from django.utils.translation import ugettext_lazy as _
 
 from .models import LoggedAction

--- a/candidates/feeds.py
+++ b/candidates/feeds.py
@@ -6,12 +6,14 @@ from django.contrib.sites.models import Site
 from django.contrib.syndication.views import Feed
 from django.core.urlresolvers import reverse
 from django.utils.feedgenerator import Atom1Feed
+from django.utils.html import escape
 from django.utils.text import slugify
 from django.utils.translation import ugettext_lazy as _
 
 from .models import LoggedAction
 
 lock_re = re.compile(r'^(?:Unl|L)ocked\s*constituency (.*) \((\d+)\)$')
+
 
 class RecentChangesFeed(Feed):
     site_name = Site.objects.get_current().name
@@ -42,3 +44,53 @@ class RecentChangesFeed(Feed):
             return reverse('person-view', args=[item.person_id])
         else:
             return '/'
+
+
+class NeedsReviewFeed(Feed):
+    site_name = Site.objects.get_current().name
+    title = _('{site_name} changes for review').format(site_name=site_name)
+    link = '/feeds/needs-review.xml'
+    feed_type = Atom1Feed
+
+    def items(self):
+        # Consider changes in the last 5 days:
+        return sorted(
+            LoggedAction.objects.in_recent_days(5).needs_review().items(),
+            key=lambda t: t[0].created,
+            reverse=True)
+
+    def item_title(self, item):
+        if item[0].person:
+            return "{0} ({1}) - {2}".format(
+                item[0].person.name,
+                item[0].person_id,
+                item[0].action_type,
+            )
+        elif item[0].post:
+            return "{0} ({1}) - {2}".format(
+                item[0].post.label,
+                item[0].post.extra.slug,
+                item[0].action_type,
+            )
+        else:
+            return item[0].action_type
+
+    def item_description(self, item):
+        la = item[0]
+        unescaped = '''
+<p>{action_type} of {subject} by {user} with source: &ldquo;{source}&rdquo;</p>
+<ul>
+{reasons_review_needed}
+</ul>
+<p>Updated at {timestamp}</p>'''.strip().format(
+            action_type=la.action_type,
+            subject=la.subject_html,
+            user=la.user.username,
+            source=la.source,
+            reasons_review_needed='\n'.join(
+                '<li>{0}</li>'.format(i) for i in item[1]),
+            timestamp=la.updated)
+        return escape(unescaped)
+
+    def item_link(self, item):
+        return item[0].subject_url

--- a/candidates/models/__init__.py
+++ b/candidates/models/__init__.py
@@ -30,6 +30,8 @@ from .db import LoggedAction
 from .db import PersonRedirect
 from .db import UserTermsAgreement
 
+from .needs_review import needs_review_fns
+
 from .auth import TRUSTED_TO_MERGE_GROUP_NAME
 from .auth import TRUSTED_TO_LOCK_GROUP_NAME
 from .auth import TRUSTED_TO_RENAME_GROUP_NAME

--- a/candidates/models/db.py
+++ b/candidates/models/db.py
@@ -27,6 +27,10 @@ class LoggedAction(models.Model):
     source = models.TextField()
     post = models.ForeignKey(Post, blank=True, null=True)
 
+    def __repr__(self):
+        fmt = str("<LoggedAction username='{username}' action_type='{action_type}'>")
+        return fmt.format(username=self.user.username, action_type=self.action_type)
+
 
 class PersonRedirect(models.Model):
     '''This represents a redirection from one person ID to another

--- a/candidates/models/db.py
+++ b/candidates/models/db.py
@@ -1,8 +1,11 @@
 from __future__ import unicode_literals
 
-from django.db import models
 from django.contrib.auth.models import User
+from django.core.urlresolvers import reverse
+from django.db import models
 from django.db.models.signals import post_save
+
+from slugify import slugify
 
 from popolo.models import Person, Post
 
@@ -30,6 +33,37 @@ class LoggedAction(models.Model):
     def __repr__(self):
         fmt = str("<LoggedAction username='{username}' action_type='{action_type}'>")
         return fmt.format(username=self.user.username, action_type=self.action_type)
+
+    @property
+    def subject_url(self):
+        if self.post:
+            # FIXME: Note that this won't always be correct because
+            # LoggedAction objects only reference Post at the moment,
+            # rather than a Post and an Election (or a PostExtraElection).
+            election = self.post.extra.elections.get(current=True)
+            return reverse('constituency', kwargs={
+                'election': election.slug,
+                'post_id': self.post.extra.slug,
+                'ignored_slug': slugify(self.post.extra.short_label),
+            })
+        elif self.person:
+            return reverse('person-view', kwargs={'person_id': self.person.id})
+        return None
+
+    @property
+    def subject_html(self):
+        if self.post:
+            return '<a href="{url}">{text} ({post_slug})</a>'.format(
+                url=self.subject_url,
+                text=self.post.extra.short_label,
+                post_slug=self.post.extra.slug,
+            )
+        elif self.person:
+            return '<a href="{url}">{text} ({person_id})</a>'.format(
+                url=self.subject_url,
+                text=self.person.name,
+                person_id=self.person.id)
+        return ''
 
 
 class PersonRedirect(models.Model):

--- a/candidates/models/db.py
+++ b/candidates/models/db.py
@@ -1,5 +1,8 @@
 from __future__ import unicode_literals
 
+from datetime import datetime, timedelta
+from functools import reduce
+
 from django.contrib.auth.models import User
 from django.core.urlresolvers import reverse
 from django.db import models
@@ -8,6 +11,30 @@ from django.db.models.signals import post_save
 from slugify import slugify
 
 from popolo.models import Person, Post
+
+from .needs_review import needs_review_fns
+
+
+def merge_dicts_with_list_values(dict_a, dict_b):
+    return {
+        k: dict_a.get(k, []) + dict_b.get(k, [])
+        for k in set(dict_a.keys()) | set(dict_b.keys())
+    }
+
+
+class LoggedActionQuerySet(models.QuerySet):
+
+    def in_recent_days(self, days=5):
+        return self.filter(
+            created__gte=(datetime.now() - timedelta(days=days)))
+
+    def needs_review(self):
+        '''Return a dict of LoggedAction -> list of reasons should be reviewed'''
+        return reduce(
+            merge_dicts_with_list_values,
+            [f(self) for f in needs_review_fns],
+            {}
+        )
 
 
 class LoggedAction(models.Model):
@@ -29,6 +56,8 @@ class LoggedAction(models.Model):
     ip_address = models.CharField(max_length=50, blank=True, null=True)
     source = models.TextField()
     post = models.ForeignKey(Post, blank=True, null=True)
+
+    objects = LoggedActionQuerySet.as_manager()
 
     def __repr__(self):
         fmt = str("<LoggedAction username='{username}' action_type='{action_type}'>")

--- a/candidates/models/needs_review.py
+++ b/candidates/models/needs_review.py
@@ -1,0 +1,70 @@
+from django.conf import settings
+from django.contrib.auth.models import User
+from django.core.cache import cache
+from django.utils.translation import ugettext as _
+
+from popolo.models import Person
+
+# This is the number of the first edits of a user that are considered
+# to need review.
+NEEDS_REVIEW_FIRST_EDITS = 3
+
+
+# These functions are a bit annoying to write, because
+# logged_action_qs is typically the result of a slice, and you're not
+# allowed to do chain filter() or various other methods after slicing
+# a queryset.
+
+def needs_review_due_to_first_edits(logged_action_qs):
+    from candidates.models import LoggedAction
+    user_ids = set(logged_action_qs.values_list('user', flat=True))
+    # Find the first three edits of each of these users. I can't see a
+    # simple way of making this efficient query-wise, so let's cache
+    # them.
+    user_id_to_user = {
+        u.id: u for u in User.objects.filter(pk__in=user_ids)}
+    needs_review_la_ids = set()
+    for user_id in user_ids:
+        cache_key = 'earliest_edits_for_user_id:{0}'.format(user_id)
+        earliest_edits = cache.get(cache_key)
+        if earliest_edits is None or len(earliest_edits) < NEEDS_REVIEW_FIRST_EDITS:
+            earliest_edits = LoggedAction.objects \
+                .filter(user_id=user_id) \
+                .order_by('created')[:NEEDS_REVIEW_FIRST_EDITS] \
+                .values_list('pk', flat=True)
+            cache.set(cache_key, earliest_edits)
+        for la_id in earliest_edits:
+            needs_review_la_ids.add(la_id)
+    return {
+        la: [_("One of the first {n} edits of user {username}").format(
+            n=NEEDS_REVIEW_FIRST_EDITS, username=user_id_to_user[la.user_id].username)]
+        for la in logged_action_qs if la.id in needs_review_la_ids
+    }
+
+
+def needs_review_due_to_subject_having_died(logged_action_qs):
+    person_ids = logged_action_qs.values_list('person', flat=True)
+    person_ids = set(p for p in person_ids if p is not None)
+    dead_people_ids = set(
+        Person.objects \
+        .filter(pk__in=person_ids) \
+        .exclude(death_date='') \
+        .values_list('pk', flat=True))
+    return {
+        la: [_("Edit of a candidate who has died")]
+        for la in logged_action_qs if la.person_id in dead_people_ids}
+
+
+def needs_review_due_to_candidate_specifically(logged_action_qs):
+    person_ids = set(logged_action_qs.values_list('person', flat=True))
+    needs_review_person_ids = person_ids & settings.PEOPLE_LIABLE_TO_VANDALISM
+    return {
+        la: [_("Edit of a candidate whose record may be particularly liable to vandalism")]
+        for la in logged_action_qs if la.person_id in needs_review_person_ids}
+
+
+needs_review_fns = [
+    needs_review_due_to_first_edits,
+    needs_review_due_to_subject_having_died,
+    needs_review_due_to_candidate_specifically,
+]

--- a/candidates/tests/test_changes_for_review.py
+++ b/candidates/tests/test_changes_for_review.py
@@ -1,0 +1,261 @@
+from __future__ import unicode_literals
+
+import codecs
+from io import BytesIO
+import os
+import re
+
+from datetime import datetime, timedelta
+
+from django_webtest import WebTest
+from django.test import TestCase
+from django.test.utils import override_settings
+from django.utils import six
+
+from lxml import etree
+
+from candidates.models import LoggedAction
+
+from .auth import TestUserMixin
+from . import factories
+
+
+def random_person_id():
+    return codecs.encode(os.urandom(8), 'hex').decode()
+
+
+def change_updated_and_created(la, timestamp):
+    # auto_add_now and auto_now are used for the LoggedAction created
+    # and updated fields, which are awkward to override. You can do
+    # this, however, by use the update() method of QuerySet, which is
+    # converted directly to an SQL UPDATE and doesn't trigger
+    # save-related signals.
+    LoggedAction.objects.filter(pk=la.pk).update(
+        created=timestamp, updated=timestamp)
+
+
+def canonicalize_xml(xml_bytes):
+    parsed = etree.fromstring(xml_bytes)
+    out = BytesIO()
+    parsed.getroottree().write_c14n(out)
+    return out.getvalue()
+
+
+@override_settings(PEOPLE_LIABLE_TO_VANDALISM={2811})
+class TestNeedsReview(TestUserMixin, WebTest):
+
+    maxDiff = None
+
+    def setUp(self):
+        super(TestNeedsReview, self).setUp()
+        current_datetime = datetime(2017, 5, 2, 18, 10, 5, 0)
+        # Reuse existing users created in TestUserMixin:
+        for username, u in (
+                ('lapsed_experienced', self.user),
+                ('new_suddenly_lots', self.user_who_can_merge),
+                ('new_only_one', self.user_who_can_upload_documents),
+                ('morbid_vandal', self.user_who_can_lock)):
+            u.username = username
+            u.save()
+            setattr(self, username, u)
+
+        example_person = factories.PersonExtraFactory.create(
+            base__id='2009',
+            base__name='Tessa Jowell',
+        ).base
+
+        # Create old edits for the experienced user:
+        date_ages_ago = current_datetime - timedelta(days=365)
+        for i in range(20):
+            la = LoggedAction.objects.create(
+                user=self.lapsed_experienced,
+                action_type='person-update',
+                person=example_person,
+                popit_person_new_version=random_person_id(),
+                source='Just for tests...',
+            )
+            dt = date_ages_ago - timedelta(minutes=i*10)
+            change_updated_and_created(la, dt)
+        # ... and a couple of new edits for the experienced user:
+        for i in range(2):
+            la = LoggedAction.objects.create(
+                user=self.lapsed_experienced,
+                action_type='person-update',
+                person=example_person,
+                popit_person_new_version=random_person_id(),
+                source='Just for tests...',
+            )
+            dt = current_datetime - timedelta(minutes=i*5)
+            change_updated_and_created(la, dt)
+
+        # Create lots of very recent edits for a new user:
+        for i in range(10):
+            la = LoggedAction.objects.create(
+                user=self.new_suddenly_lots,
+                action_type='person-update',
+                person=example_person,
+                popit_person_new_version=random_person_id(),
+                source='Just for tests',
+            )
+            dt = current_datetime - timedelta(minutes=i*7)
+            change_updated_and_created(la, dt)
+
+        # Create a single recent edit for a new user:
+        la = LoggedAction.objects.create(
+            user=self.new_only_one,
+            action_type='person-update',
+            person=example_person,
+            popit_person_new_version=random_person_id(),
+            source='Just for tests',
+        )
+        dt = current_datetime - timedelta(minutes=2)
+        change_updated_and_created(la, dt)
+
+        # Create a candidate with a death date, and edit of that
+        # candidate:
+        dead_person = factories.PersonExtraFactory.create(
+            base__id='7448',
+            base__name='The Eurovisionary Ronnie Carroll',
+            base__birth_date='1934-08-18',
+            base__death_date='2015-04-13'
+        ).base
+        la = LoggedAction.objects.create(
+            user=self.morbid_vandal,
+            action_type='person-update',
+            person=dead_person,
+            popit_person_new_version=random_person_id(),
+            source='Just for tests',
+            updated=dt,
+            created=dt,
+        )
+        dt = current_datetime - timedelta(minutes=4)
+        change_updated_and_created(la, dt)
+
+        prime_minister = factories.PersonExtraFactory.create(
+            base__id='2811',
+            base__name='Theresa May',
+        ).base
+        # Create a candidate on the "liable to vandalism" list.
+        la = LoggedAction.objects.create(
+            user=self.lapsed_experienced,
+            action_type='person-update',
+            person=prime_minister,
+            popit_person_new_version=random_person_id(),
+            source='Just for tests...',
+        )
+        dt = current_datetime - timedelta(minutes=33)
+        change_updated_and_created(la, dt)
+
+    def test_needs_review_as_expected(self):
+        needs_review_dict = LoggedAction.objects.in_recent_days(5).needs_review()
+        # Here we're expecting the following LoggedActions to be picked out:
+        #    1 edit of a dead candidate (by 'morbid_vandal'
+        #    3 edits from 'new_suddenly_lots' (we just consider the first
+        #      three edits from a new user needs_review)
+        #    1 first edit from 'new_only_one'
+        #    1 edit from a user who was mostly active in the past to the
+        #      prime minister's record
+        self.assertEqual(len(needs_review_dict), 1 + 3 + 1 + 1)
+        results = [
+            (la.user.username, la.action_type, reasons)
+            for la, reasons in
+            sorted(needs_review_dict.items(), key=lambda t: t[0].created)
+        ]
+        self.assertEqual(
+            results,
+            [('new_suddenly_lots',
+              'person-update',
+              ['One of the first 3 edits of user new_suddenly_lots']),
+             ('new_suddenly_lots',
+              'person-update',
+              ['One of the first 3 edits of user new_suddenly_lots']),
+             ('new_suddenly_lots',
+              'person-update',
+              ['One of the first 3 edits of user new_suddenly_lots']),
+             ('lapsed_experienced',
+              'person-update',
+              ['Edit of a candidate whose record may be particularly liable to vandalism']),
+             ('morbid_vandal',
+              'person-update',
+              ['One of the first 3 edits of user morbid_vandal',
+               'Edit of a candidate who has died']),
+             ('new_only_one',
+              'person-update',
+              ['One of the first 3 edits of user new_only_one'])])
+
+    def test_xml_feed(self):
+        response = self.app.get('/feeds/needs-review.xml')
+        removed_updated = re.sub(
+            r'<updated>.*</updated>',
+            '<updated></updated>',
+            response.content.decode())
+        got = canonicalize_xml(removed_updated.encode())
+        expected = b'<feed xmlns="http://www.w3.org/2005/Atom" xml:lang="en-gb">' \
+                   b'<title>example.com changes for review</title>' \
+                   b'<link href="http://example.com/feeds/needs-review.xml" rel="alternate"></link>' \
+                   b'<link href="http://example.com/feeds/needs-review.xml" rel="self"></link>' \
+                   b'<id>http://example.com/feeds/needs-review.xml</id>' \
+                   b'<updated></updated>' \
+                   b'<entry>' \
+                   b'<title>Tessa Jowell (2009) - person-update</title>' \
+                   b'<link href="http://example.com/person/2009" rel="alternate"></link>' \
+                   b'<id>http://example.com/person/2009</id>' \
+                   b'''<summary type="html">&amp;lt;p&amp;gt;person-update of &amp;lt;a href=&amp;quot;/person/2009&amp;quot;&amp;gt;Tessa Jowell (2009)&amp;lt;/a&amp;gt; by new_only_one with source: &amp;amp;ldquo;Just for tests&amp;amp;rdquo;&amp;lt;/p&amp;gt;
+&amp;lt;ul&amp;gt;
+&amp;lt;li&amp;gt;One of the first 3 edits of user new_only_one&amp;lt;/li&amp;gt;
+&amp;lt;/ul&amp;gt;
+&amp;lt;p&amp;gt;Updated at 2017-05-02 17:08:05+00:00&amp;lt;/p&amp;gt;</summary>''' \
+                   b'</entry>' \
+                   b'<entry>' \
+                   b'<title>The Eurovisionary Ronnie Carroll (7448) - person-update</title>' \
+                   b'<link href="http://example.com/person/7448" rel="alternate"></link>' \
+                   b'<id>http://example.com/person/7448</id>' \
+                   b'''<summary type="html">&amp;lt;p&amp;gt;person-update of &amp;lt;a href=&amp;quot;/person/7448&amp;quot;&amp;gt;The Eurovisionary Ronnie Carroll (7448)&amp;lt;/a&amp;gt; by morbid_vandal with source: &amp;amp;ldquo;Just for tests&amp;amp;rdquo;&amp;lt;/p&amp;gt;
+&amp;lt;ul&amp;gt;
+&amp;lt;li&amp;gt;One of the first 3 edits of user morbid_vandal&amp;lt;/li&amp;gt;
+&amp;lt;li&amp;gt;Edit of a candidate who has died&amp;lt;/li&amp;gt;
+&amp;lt;/ul&amp;gt;
+&amp;lt;p&amp;gt;Updated at 2017-05-02 17:06:05+00:00&amp;lt;/p&amp;gt;</summary>''' \
+                   b'</entry>' \
+                   b'<entry>' \
+                   b'<title>Theresa May (2811) - person-update</title>' \
+                   b'<link href="http://example.com/person/2811" rel="alternate"></link>' \
+                   b'<id>http://example.com/person/2811</id>' \
+                   b'''<summary type="html">&amp;lt;p&amp;gt;person-update of &amp;lt;a href=&amp;quot;/person/2811&amp;quot;&amp;gt;Theresa May (2811)&amp;lt;/a&amp;gt; by lapsed_experienced with source: &amp;amp;ldquo;Just for tests...&amp;amp;rdquo;&amp;lt;/p&amp;gt;
+&amp;lt;ul&amp;gt;
+&amp;lt;li&amp;gt;Edit of a candidate whose record may be particularly liable to vandalism&amp;lt;/li&amp;gt;
+&amp;lt;/ul&amp;gt;
+&amp;lt;p&amp;gt;Updated at 2017-05-02 16:37:05+00:00&amp;lt;/p&amp;gt;</summary>''' \
+                   b'</entry>' \
+                   b'<entry>' \
+                   b'<title>Tessa Jowell (2009) - person-update</title>' \
+                   b'<link href="http://example.com/person/2009" rel="alternate"></link>' \
+                   b'<id>http://example.com/person/2009</id>' \
+                   b'''<summary type="html">&amp;lt;p&amp;gt;person-update of &amp;lt;a href=&amp;quot;/person/2009&amp;quot;&amp;gt;Tessa Jowell (2009)&amp;lt;/a&amp;gt; by new_suddenly_lots with source: &amp;amp;ldquo;Just for tests&amp;amp;rdquo;&amp;lt;/p&amp;gt;
+&amp;lt;ul&amp;gt;
+&amp;lt;li&amp;gt;One of the first 3 edits of user new_suddenly_lots&amp;lt;/li&amp;gt;
+&amp;lt;/ul&amp;gt;
+&amp;lt;p&amp;gt;Updated at 2017-05-02 16:21:05+00:00&amp;lt;/p&amp;gt;</summary>''' \
+                   b'</entry>' \
+                   b'<entry>' \
+                   b'<title>Tessa Jowell (2009) - person-update</title>' \
+                   b'<link href="http://example.com/person/2009" rel="alternate"></link>' \
+                   b'<id>http://example.com/person/2009</id>' \
+                   b'''<summary type="html">&amp;lt;p&amp;gt;person-update of &amp;lt;a href=&amp;quot;/person/2009&amp;quot;&amp;gt;Tessa Jowell (2009)&amp;lt;/a&amp;gt; by new_suddenly_lots with source: &amp;amp;ldquo;Just for tests&amp;amp;rdquo;&amp;lt;/p&amp;gt;
+&amp;lt;ul&amp;gt;
+&amp;lt;li&amp;gt;One of the first 3 edits of user new_suddenly_lots&amp;lt;/li&amp;gt;
+&amp;lt;/ul&amp;gt;
+&amp;lt;p&amp;gt;Updated at 2017-05-02 16:14:05+00:00&amp;lt;/p&amp;gt;</summary>''' \
+                   b'</entry>' \
+                   b'<entry>' \
+                   b'<title>Tessa Jowell (2009) - person-update</title>' \
+                   b'<link href="http://example.com/person/2009" rel="alternate"></link>' \
+                   b'<id>http://example.com/person/2009</id>' \
+                   b'''<summary type="html">&amp;lt;p&amp;gt;person-update of &amp;lt;a href=&amp;quot;/person/2009&amp;quot;&amp;gt;Tessa Jowell (2009)&amp;lt;/a&amp;gt; by new_suddenly_lots with source: &amp;amp;ldquo;Just for tests&amp;amp;rdquo;&amp;lt;/p&amp;gt;
+&amp;lt;ul&amp;gt;
+&amp;lt;li&amp;gt;One of the first 3 edits of user new_suddenly_lots&amp;lt;/li&amp;gt;
+&amp;lt;/ul&amp;gt;
+&amp;lt;p&amp;gt;Updated at 2017-05-02 16:07:05+00:00&amp;lt;/p&amp;gt;</summary>''' \
+                   b'</entry>' \
+                   b'</feed>'
+        self.assertEqual(got, expected)

--- a/candidates/tests/test_logged_action.py
+++ b/candidates/tests/test_logged_action.py
@@ -1,0 +1,26 @@
+from django.test import TestCase
+
+from candidates.models import LoggedAction
+
+from .auth import TestUserMixin
+from . import factories
+
+class TestLoggedAction(TestUserMixin, TestCase):
+
+    def test_logged_action_repr(self):
+        person = factories.PersonExtraFactory.create(
+            base__id='9876',
+            base__name='Test Candidate',
+        ).base
+        action = LoggedAction.objects.create(
+            user=self.user,
+            action_type='person-create',
+            ip_address='127.0.0.1',
+            person=person,
+            popit_person_new_version='1234567890abcdef',
+            source='Just for tests...',
+        )
+        self.assertEqual(
+            repr(action),
+            str("<LoggedAction username='john' action_type='person-create'>"),
+        )

--- a/candidates/tests/test_logged_action.py
+++ b/candidates/tests/test_logged_action.py
@@ -3,9 +3,10 @@ from django.test import TestCase
 from candidates.models import LoggedAction
 
 from .auth import TestUserMixin
+from .uk_examples import UK2015ExamplesMixin
 from . import factories
 
-class TestLoggedAction(TestUserMixin, TestCase):
+class TestLoggedAction(TestUserMixin, UK2015ExamplesMixin, TestCase):
 
     def test_logged_action_repr(self):
         person = factories.PersonExtraFactory.create(
@@ -23,4 +24,36 @@ class TestLoggedAction(TestUserMixin, TestCase):
         self.assertEqual(
             repr(action),
             str("<LoggedAction username='john' action_type='person-create'>"),
+        )
+
+    def test_subject_person(self):
+        person = factories.PersonExtraFactory.create(
+            base__id='9876',
+            base__name='Test Candidate',
+        ).base
+        action = LoggedAction.objects.create(
+            user=self.user,
+            action_type='person-create',
+            ip_address='127.0.0.1',
+            person=person,
+            popit_person_new_version='1234567890abcdef',
+            source='Just for tests...',
+        )
+        self.assertEqual(
+            action.subject_html,
+            '<a href="/person/9876">Test Candidate (9876)</a>',
+        )
+
+    def test_subject_post(self):
+        action = LoggedAction.objects.create(
+            user=self.user,
+            action_type='constituency-lock',
+            ip_address='127.0.0.1',
+            post=self.camberwell_post_extra.base,
+            popit_person_new_version='1234567890abcdef',
+            source='Just for tests...',
+        )
+        self.assertEqual(
+            action.subject_html,
+            '<a href="/election/2015/post/65913/camberwell-and-peckham">Camberwell and Peckham (65913)</a>',
         )

--- a/candidates/tests/test_twitter_queue_images_command.py
+++ b/candidates/tests/test_twitter_queue_images_command.py
@@ -2,6 +2,7 @@ from __future__ import print_function, unicode_literals
 
 from mock import Mock, call, patch
 from os.path import dirname, join
+import re
 
 from django.core.management import call_command
 from django.test import TestCase
@@ -248,7 +249,12 @@ class TestTwitterImageQueueCommand(TestUserMixin, TestCase):
 
         mock_requests.get.side_effect = fake_get
 
-        call_command('candidates_add_twitter_images_to_queue')
+        with capture_output() as (out, err):
+            call_command('candidates_add_twitter_images_to_queue')
+
+        output_lines = split_output(out)
+        self.assertEqual(len(output_lines), 1)
+        self.assertTrue(re.search(r'^Ignoring a non-image file \S+$', output_lines[0]))
 
         new_queued_images = QueuedImage.objects.exclude(
             id__in=self.existing_queued_image_ids)

--- a/candidates/urls.py
+++ b/candidates/urls.py
@@ -14,7 +14,7 @@ from uk_results.views import (
     ResultSetViewSet,
 )
 
-from .feeds import RecentChangesFeed
+from .feeds import RecentChangesFeed, NeedsReviewFeed
 from .constants import ELECTION_ID_REGEX, POST_ID_REGEX
 
 api_router = routers.DefaultRouter()
@@ -220,6 +220,11 @@ patterns_to_format = [
         'pattern': r'^feeds/changes.xml$',
         'view': RecentChangesFeed(),
         'name': 'changes_feed'
+    },
+    {
+        'pattern': r'^feeds/needs-review.xml$',
+        'view': NeedsReviewFeed(),
+        'name': 'needs-review_feed'
     },
     {
         'pattern': r'^help/api$',

--- a/elections/uk/settings.py
+++ b/elections/uk/settings.py
@@ -14,3 +14,65 @@ INSTALLED_APPS = [
 TEMPLATE_CONTEXT_PROCESSORS = (
     "uk_results.context_processors.show_results_feature",
 )
+
+PEOPLE_LIABLE_TO_VANDALISM = {
+    2811, # Theresa May
+    1120, # Jeremy Corbyn
+    4546, # Boris Johnson
+    6035, # Paul Nuttall
+    8372, # Nicola Sturgeon
+    737, # Ruth Davidson
+
+    # Below we include the person ID of anyone who is currently a minister.
+    # This list was generated from:
+    #
+    #   https://github.com/mysociety/parlparse/blob/master/members/ministers-2010.json
+    #
+    # ... with this snippet of Python:
+    #
+    # import datetime, json
+    # with open(ministers-2010.json') as f:
+    #     ministers = json.load(f)
+    # for m in ministers['memberships']:
+    #     if not re.search(r'^(Minister|The Secretary of State|Deputy Prime Minister|The Prime Minister)', m.get('role', '')):
+    #         continue
+    #     today = str(date.today())
+    #     if not (today >= m['start_date'] and today <= m.get('end_date', '9999-12-31')):
+    #         continue
+    #     i = Identifier.objects.filter(identifier=m['person_id']).first()
+    #     if i is None:
+    #         continue
+    #     person = i.content_object
+    #     print '    {0}, # {1} ({2})'.format(person.id, person.name, m['role'])
+
+    2885, # David Davis (The Secretary of State for Exiting the European Union)
+    212, # Alan Duncan (Minister of State)
+    2832, # Michael Fallon (The Secretary of State for Defence)
+    451, # Liam Fox (The Secretary of State for International Trade and President of the Board of Trade)
+    918, # Nick Gibb (Minister of State (Department for Education))
+    3486, # Damian Green (The Secretary of State for Work and Pensions)
+    3445, # John Hayes (Minister of State (Department for Transport))
+    2811, # Theresa May (The Prime Minister)
+    3284, # Chris Grayling (The Secretary of State for Transport)
+    3151, # David Jones (Minister of State (Department for Exiting the European Union))
+    2534, # James Brokenshire (The Secretary of State for Northern Ireland)
+    3238, # Ben Wallace (Minister of State (Home Office) (Security))
+    4021, # Justine Greening (Minister for Women and Equalities)
+    4021, # Justine Greening (The Secretary of State for Education)
+    3155, # Jeremy Hunt (The Secretary of State for Health)
+    1918, # Greg Clark (The Secretary of State for Business, Energy and Industrial Strategy )
+    1592, # David Mundell (The Secretary of State for Scotland)
+    1104, # Edward Timpson (Minister of State (Department for Education))
+    1303, # Karen Bradley (The Secretary of State for Culture, Media and Sport)
+    1923, # Alun Cairns (The Secretary of State for Wales)
+    3737, # Matthew Hancock (Minister of State (Department for Culture, Media and Sport) (Digital Policy))
+    1326, # Priti Patel (The Secretary of State for International Development)
+    3741, # Robert Halfon (Minister of State (Department of Education) (Apprenticeships and Skills))
+    519, # Amber Rudd (The Secretary of State for the Home Department)
+    2875, # Andrea Leadsom (The Secretary of State for Environment, Food and Rural Affairs)
+    349, # Sajid Javid (The Secretary of State for Communities and Local Government)
+    4881, # Gavin Barwell (Minister of State (Department for Communities and Local Government) (Housing, Planning and London))
+    3533, # Brandon Lewis (Minister of State (Home Office) (Policing and the Fire Service))
+    2204, # Jo Johnson (Minister of State (Department for Education) (Universities and Science) (Joint with the Department for Business, Energy and Industrial Strategy))
+    2204, # Jo Johnson (Minister of State (Department for Business, Energy and Industrial Strategy) (Universities and Science) (Joint with the Department for Education))
+}

--- a/mysite/settings/conf.py
+++ b/mysite/settings/conf.py
@@ -54,6 +54,11 @@ def add_election_specific_settings(settings, full_election_app):
         getattr(elections_module, 'TEMPLATE_CONTEXT_PROCESSORS', ())
     settings['TEMPLATE_CONTEXT_PROCESSORS'] += extra_context_processors
 
+    # Get any election-specific people whose pages might be
+    # particularly subject to vandalism (e.g. party leaders):
+    settings['PEOPLE_LIABLE_TO_VANDALISM'] = \
+        getattr(elections_module, 'PEOPLE_LIABLE_TO_VANDALISM', set())
+
     # Add any election-specific INSTALLED_APPS:
     settings['INSTALLED_APPS'].extend(
         getattr(elections_module, 'INSTALLED_APPS', []))


### PR DESCRIPTION
This commit introduces an Atom feed at /feeds/needs-review.xml that
lists changes within the last 5 days that might need to be checked by an
admin or trusted user. This initial version includes three criteria that
will cause a change to be included in this feed, which are:

 - If a change is one of the first three changes that a new user has
   made.

 - If the change is to a candidate who is deceased.

 - If the change is to a candidate in the settings.PEOPLE_LIABLE_TO_VANDALISM
   set. (This commit adds a few notable politicians to that set for the
   uk instance of the site, including all current government ministers.)
