### PR TITLE
Turn off caching for logged in users

### DIFF
--- a/candidates/tests/test_caching.py
+++ b/candidates/tests/test_caching.py
@@ -1,0 +1,43 @@
+from __future__ import unicode_literals
+
+from django_webtest import WebTest
+
+from .auth import TestUserMixin
+from .uk_examples import UK2015ExamplesMixin
+
+
+class TestCaching(TestUserMixin, UK2015ExamplesMixin, WebTest):
+
+    def setUp(self):
+        super(TestCaching, self).setUp()
+
+    def test_unauth_user_cache_headers(self):
+        response = self.app.get(
+            '/election/2015/post/65808/dulwich-and-west-norwood',
+        )
+
+        headers = response.headerlist
+        seen_cache = False
+        for header, value in headers:
+            if header == 'Cache-Control':
+                seen_cache = True
+                self.assertTrue(value == 'max-age=1200')
+
+        self.assertTrue(seen_cache)
+
+    def test_auth_user_cache_headers(self):
+        response = self.app.get(
+            '/election/2015/post/65808/dulwich-and-west-norwood',
+            user=self.user
+        )
+
+        headers = response.headerlist
+        seen_cache = False
+        for header, value in headers:
+            if header == 'Cache-Control':
+                seen_cache = True
+                self.assertTrue(
+                    value == 'no-cache, no-store, must-revalidate, max-age=0'
+                )
+
+        self.assertTrue(seen_cache)

--- a/mysite/settings/conf.py
+++ b/mysite/settings/conf.py
@@ -270,6 +270,7 @@ def get_settings(conf_file_leafname, election_app=None, tests=False):
             'candidates.middleware.DisallowedUpdateMiddleware',
             'django.contrib.messages.middleware.MessageMiddleware',
             'django.middleware.clickjacking.XFrameOptionsMiddleware',
+            'candidates.middleware.DisableCachingForAuthenticatedUsers',
         ),
 
         # django-allauth settings:


### PR DESCRIPTION
This avoids the problem of a logged in users having to hard refresh
pages to see changes they have made when editing candidate pages.

Fixes #841