### PR TITLE
Fix performance issues with the admin for QueuedImage

### DIFF
--- a/moderation_queue/admin.py
+++ b/moderation_queue/admin.py
@@ -9,4 +9,8 @@ class QueuedImageAdmin(admin.ModelAdmin):
     list_filter = ('decision',)
     ordering = ('-created',)
 
+    def get_queryset(self, request):
+        qs = super(QueuedImageAdmin, self).get_queryset(request)
+        return qs.select_related('person', 'user')
+
 admin.site.register(QueuedImage, QueuedImageAdmin)

--- a/moderation_queue/admin.py
+++ b/moderation_queue/admin.py
@@ -6,6 +6,7 @@ from .models import QueuedImage
 class QueuedImageAdmin(admin.ModelAdmin):
     list_display = ('user', 'person', 'created', 'decision')
     search_fields = ('user__username', 'person__id')
+    exclude = ('person',)
     list_filter = ('decision',)
     ordering = ('-created',)
 


### PR DESCRIPTION
The list page was slow, but individual QueuedImage admin pages
were site-destroyingly slow. This pull request includes a select_related
use on the list page to speed it up, and removes the person field from
the detailed page, which should address both of those problems.