### PR TITLE
Reduce queries used by /api/v0.9/candidates_for_postcode

### DIFF
--- a/candidates/serializers.py
+++ b/candidates/serializers.py
@@ -88,7 +88,7 @@ class ObjectWithImageField(serializers.RelatedField):
         kwargs = {'version': 'v0.9'}
         request = self.context['request']
         if isinstance(value, candidates_models.PersonExtra):
-            kwargs.update({'pk': value.base.id})
+            kwargs.update({'pk': value.base_id})
             return reverse('person-detail', kwargs=kwargs, request=request)
         elif isinstance(value, candidates_models.OrganizationExtra):
             kwargs.update({'slug': value.slug})

--- a/candidates/views/api.py
+++ b/candidates/views/api.py
@@ -37,7 +37,7 @@ def fetch_posts_for_area(**kwargs):
     posts = Post.objects.filter(
         area__identifier__in=area_ids,
     ).select_related(
-        'area', 'area__extra__type', 'organization'
+        'area', 'area__extra__type', 'organization', 'extra',
     ).prefetch_related(
         'extra__elections'
     )
@@ -137,8 +137,7 @@ class CandidatesAndElectionsForPostcodeViewSet(ViewSet):
                 election_kwargs['election_date__gte'] = request.GET['date_gte']
 
         results = []
-        qs = posts.all().select_related('extra')
-        for post in qs:
+        for post in posts:
             for election in post.extra.elections.filter(**election_kwargs):
                 candidates = []
                 for membership in post.memberships.filter(

--- a/candidates/views/api.py
+++ b/candidates/views/api.py
@@ -4,7 +4,7 @@ import json
 from os.path import dirname
 import subprocess
 import sys
-from datetime import date, timedelta
+from datetime import date, datetime, timedelta
 from dateutil import parser
 
 import django
@@ -44,6 +44,26 @@ def fetch_posts_for_area(**kwargs):
     return posts
 
 
+def parse_date(date_text):
+    if date_text == 'today':
+        return date.today()
+    try:
+        return datetime.strptime(date_text, '%Y-%m-%d').date()
+    except ValueError:
+        return None
+
+
+def handle_election(election, request, only_upcoming=False):
+    if only_upcoming:
+        only_after = date.today()
+    else:
+        only_after = parse_date(request.GET.get('date_gte', ''))
+    if (only_after is not None) and (election.election_date < only_after):
+        return False
+    if election.current or request.GET.get('all_elections'):
+        return True
+    return False
+
 
 class UpcomingElectionsView(View):
 
@@ -73,15 +93,10 @@ class UpcomingElectionsView(View):
             )
 
         results = []
-        for post in posts.all():
-            try:
-                election = post.extra.elections.get(
-                    current=True,
-                    election_date__gte=date.today()
-                )
-            except:
-                continue
-            if election:
+        for post in posts:
+            for election in post.extra.elections.all():
+                if not handle_election(election, request, only_upcoming=True):
+                    continue
                 results.append({
                     'post_name': post.label,
                     'post_slug': post.extra.slug,
@@ -124,21 +139,11 @@ class CandidatesAndElectionsForPostcodeViewSet(ViewSet):
         except Exception as e:
             return self._error(e.message)
 
-
-        election_kwargs = {
-            'current': True,
-        }
-        if 'all_elections' in request.GET:
-            del election_kwargs['current']
-        if 'date_gte' in request.GET:
-            if request.GET['date_gte'] == "today":
-                election_kwargs['election_date__gte'] = date.today()
-            else:
-                election_kwargs['election_date__gte'] = request.GET['date_gte']
-
         results = []
         for post in posts:
-            for election in post.extra.elections.filter(**election_kwargs):
+            for election in post.extra.elections.all():
+                if not handle_election(election, request):
+                    continue
                 candidates = []
                 for membership in post.memberships.filter(
                         extra__election=election,


### PR DESCRIPTION
The queries these commits avoid are typically very fast, so these changes
make only a modest difference, but still help: e.g. for one postcode I tried, it
reduced the number of queries from 56 to 36 and time for those queries
from about 250ms to 150ms.
