### PR TITLE
Require a source_url for each OfficialDocument

### DIFF
--- a/official_documents/migrations/0018_make_source_url_required.py
+++ b/official_documents/migrations/0018_make_source_url_required.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('official_documents', '0017_update_django_extensions_datetime_fields'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='officialdocument',
+            name='source_url',
+            field=models.URLField(help_text='The page that links to this document', max_length=1000),
+        ),
+    ]

--- a/official_documents/models.py
+++ b/official_documents/models.py
@@ -39,7 +39,7 @@ class OfficialDocument(TimeStampedModel):
     uploaded_file = models.FileField(
         upload_to=document_file_name, max_length=800)
     post = models.ForeignKey(Post, blank=True, null=True)
-    source_url = models.URLField(blank=True,
+    source_url = models.URLField(
         help_text=_("The page that links to this document"),
         max_length=1000,
     )


### PR DESCRIPTION
The bulk_adding application has some surprising behaviour if you ever
try to add candidates from a document without a source_url, and in
practice there should always be a source_url for every document. (We've
made sure this is the case in the UK database now.)

This commit removes the blank=True from the source_url field definition
so creating an OfficialDocument with a blank source_url should be
disallowed in the upload form and the admin.