### PR TITLE
Fix for not being able to add people through bulk_adding

### DIFF
--- a/bulk_adding/tests.py
+++ b/bulk_adding/tests.py
@@ -1,4 +1,9 @@
+import json
+
+from django.core.management import call_command
 from django_webtest import WebTest
+from popolo.models import Person
+
 from candidates.tests.auth import TestUserMixin
 
 from official_documents.models import OfficialDocument
@@ -12,6 +17,7 @@ class TestBulkAdding(TestUserMixin, UK2015ExamplesMixin, WebTest):
 
     def setUp(self):
         super(TestBulkAdding, self).setUp()
+        call_command('rebuild_index', verbosity=0, interactive=False)
 
     def testNoFormIfNoSopn(self):
         response = self.app.get(
@@ -54,3 +60,54 @@ class TestBulkAdding(TestUserMixin, UK2015ExamplesMixin, WebTest):
             response,
             "Review"
         )
+
+    def test_submitting_form(self):
+        post = self.dulwich_post_extra.base
+
+        OfficialDocument.objects.create(
+            election=self.election,
+            post=post,
+            source_url='http://example.com',
+            document_type=OfficialDocument.NOMINATION_PAPER,
+            uploaded_file="sopn.pdf"
+        )
+
+        response = self.app.get(
+            '/bulk_adding/2015/65808/',
+            user=self.user
+        )
+
+        form = response.forms['bulk_add_form']
+        form['form-0-name'] = 'Homer Simpson'
+        form['form-0-party'] = self.green_party_extra.base.id
+
+        response = form.submit()
+        self.assertEqual(response.status_code, 302)
+
+        # This takes us to a page with a radio button for adding them
+        # as a new person or alternative radio buttons if any
+        # candidates with similar names were found.
+        response = response.follow()
+        form = response.forms[1]
+        form['form-0-select_person'].select('_new')
+        response = form.submit()
+
+        self.assertEqual(Person.objects.count(), 1)
+        homer = Person.objects.get()
+        self.assertEqual(homer.name, 'Homer Simpson')
+        homer_versions = json.loads(homer.extra.versions)
+        self.assertEqual(len(homer_versions), 2)
+        self.assertEqual(
+            homer_versions[0]['information_source'],
+            'http://example.com')
+        self.assertEqual(
+            homer_versions[1]['information_source'],
+            'http://example.com')
+
+        self.assertEqual(homer.memberships.count(), 1)
+        membership = homer.memberships.get()
+        self.assertEqual(membership.role, 'Candidate')
+        self.assertEqual(membership.on_behalf_of.name, 'Green Party')
+        self.assertEqual(
+            membership.post.label,
+            'Member of Parliament for Dulwich and West Norwood')

--- a/bulk_adding/views.py
+++ b/bulk_adding/views.py
@@ -68,7 +68,7 @@ class BulkAddView(BaseBulkAddView):
 
         if 'official_document' in context and \
                 context['official_document'] is not None:
-            form_kwargs['source'] = context['official_document'].source_url,
+            form_kwargs['source'] = context['official_document'].source_url
 
         if self.request.POST:
             context['formset'] = forms.BulkAddFormSet(


### PR DESCRIPTION
A stray comma meant that a tuple was being assigned to source_url
instead of the URL of the document, and validation of the page where you
enter everyone's name was failing. This commit fixes that and adds a
functional test for the simplest possible workflow where you actually
create a person from the bulk_adding interface.