### PR TITLE
uk_results: return a 404 if the post slug is unknown

### DIFF
--- a/uk_results/views/votes_views.py
+++ b/uk_results/views/votes_views.py
@@ -1,3 +1,4 @@
+from django.shortcuts import get_object_or_404
 from django.utils.six.moves.urllib_parse import urlencode
 
 from django.views.generic import (DetailView, FormView, UpdateView, ListView)
@@ -18,7 +19,7 @@ class PostResultsView(BaseResultsViewMixin, DetailView):
 
     def get_object(self):
         slug = self.kwargs.get('post_id')
-        post = Post.objects.get(extra__slug=slug)
+        post = get_object_or_404(Post, extra__slug=slug)
         return PostResult.objects.get_or_create(post=post)[0]
 
 
@@ -28,7 +29,7 @@ class PostReportVotesView(BaseResultsViewMixin, FormView):
 
     def get_object(self):
         slug = self.kwargs.get('post_id')
-        post = Post.objects.get(extra__slug=slug)
+        post = get_object_or_404(Post, extra__slug=slug)
         return PostResult.objects.get_or_create(post=post)[0]
 
     def get_context_data(self, **kwargs):


### PR DESCRIPTION
We've been getting a lot of error emails caused by web crawlers
returning to posts that (I assume) had their slugs changed at some
point. It's reasonable to return a 404 in this case, which also
will avoid the error emails.

Fixes #135