### PR TITLE
Fix the error detail key from EveryElection's postcode lookup

### DIFF
--- a/elections/uk/mapit.py
+++ b/elections/uk/mapit.py
@@ -69,7 +69,7 @@ def get_areas(url, cache_key, exception):
         return result
     elif r.status_code == 400:
         ee_result = r.json()
-        raise exception(ee_result['error'])
+        raise exception(ee_result['detail'])
     elif r.status_code == 404:
         raise exception(
             _('The url "{}" couldn’t be found').format(url)


### PR DESCRIPTION
It appears that EveryElection returns the error message from a 400
response to a bad postcode under the 'detail' key, not 'error'.
This meant that users putting an invalid postcode into
candidates.democracyclub.org.uk would get an internal server error
instead of being sent back to the home page with a more helpful
error in-page. This commit fixes that.