### PR TITLE
UK results to postelection

### DIFF
--- a/candidates/templatetags/standing.py
+++ b/candidates/templatetags/standing.py
@@ -44,8 +44,9 @@ def get_known_candidacy_prefix_and_suffix(candidacy):
     prefix = ''
     suffix = ''
     if 'uk_results' in settings.INSTALLED_APPS:
-        candidate_results = list(candidacy.result.all())
-        if candidate_results:
+        candidate_results = candidacy.result.all().order_by(
+            'membership').distinct('membership')
+        if candidate_results.exists():
             for candidate_result in candidate_results:
                 if candidate_result.result_set.post_election_result.confirmed:
                     # Then we're OK to display this result:

--- a/candidates/templatetags/standing.py
+++ b/candidates/templatetags/standing.py
@@ -24,7 +24,7 @@ def get_candidacy(person, election):
                     'result',
                     CandidateResult.objects.select_related(
                         'result_set',
-                        'result_set__post_result',
+                        'result_set__post_election_result',
                     )
                 )
             )
@@ -47,7 +47,7 @@ def get_known_candidacy_prefix_and_suffix(candidacy):
         candidate_results = list(candidacy.result.all())
         if candidate_results:
             for candidate_result in candidate_results:
-                if candidate_result.result_set.post_result.confirmed:
+                if candidate_result.result_set.post_election_result.confirmed:
                     # Then we're OK to display this result:
                     suffix += '<br>'
                     if candidate_result.is_winner:

--- a/candidates/urls.py
+++ b/candidates/urls.py
@@ -10,8 +10,8 @@ from rest_framework import routers
 
 import candidates.views as views
 from uk_results.views import (
-    CouncilElectionViewSet, CandidateResultViewSet, PostResultViewSet,
-    ResultSetViewSet,
+    CouncilElectionViewSet, CandidateResultViewSet,
+    PostElectionResultViewSet, ResultSetViewSet,
 )
 
 from .feeds import RecentChangesFeed
@@ -35,7 +35,7 @@ api_router.register(r'complex_fields', views.ComplexPopoloFieldViewSet)
 
 api_router.register(r'council_elections', CouncilElectionViewSet)
 api_router.register(r'candidate_results', CandidateResultViewSet)
-api_router.register(r'post_results', PostResultViewSet)
+api_router.register(r'post_results', PostElectionResultViewSet)
 api_router.register(r'result_sets', ResultSetViewSet)
 
 api_router.register(

--- a/candidates/views/constituencies.py
+++ b/candidates/views/constituencies.py
@@ -67,13 +67,19 @@ class ConstituencyDetailView(ElectionMixin, TemplateView):
         from ..election_specific import shorten_post_label
         context = super(ConstituencyDetailView, self).get_context_data(**kwargs)
 
-        context['post_id'] = post_id = kwargs['post_id']
-        mp_post = get_object_or_404(
-            Post.objects.select_related('extra'),
-            extra__slug=post_id,
-            extra__elections__slug=self.election,
+        context['post_election'] = get_object_or_404(
+            PostExtraElection.objects.all().select_related(
+                'postextra__base',
+                'election',
+                ),
+            postextra__slug=context['post_id'],
+            election__slug=kwargs['election']
         )
+
+        context['post_id'] = post_id = kwargs['post_id']
+        mp_post = context['post_election'].postextra.base
         context['post_obj'] = mp_post
+
 
         documents_by_type = {}
         # Make sure that every available document type has a key in

--- a/elections/uk/templates/uk/constituency.html
+++ b/elections/uk/templates/uk/constituency.html
@@ -14,28 +14,23 @@
         {% include 'candidates/_candidates_for_post.html' %}
 
 
-        {# TODO This is not a great way to do this! #}
-        {# Basically, we can only support FPTP voting systems #}
-        {# {% if 'local' in election %} #}
-        {#   {% if show_results_feature %} #}
-        {#      {% if post_obj.postresult_set.confirmed %} #}
-        {#       {% if post_obj.postresult_set.all.0 %} #}
-        {#       <section> #}
-        {#         <h3>Results</h3> #}
-        {#         {% with post_obj.postresult_set.all.0.result_sets.all.confirmed.latest as result %} #}
-        {#           {% include "uk_results/includes/vote_result_item.html" with result=result results=result.candidate_results.all %} #}
-        {#         {% endwith %} #}
-        {#       </section> #}
-        {#       {% endif %} #}
-        {#  #}
-        {#       {% if not post_obj.postresult_set.all.0 %} #}
-        {#       <a href="{% url "report-post-votes-view" post_data.id %}" class="button"> #}
-        {#         Report results for {{post_data.label}} #}
-        {#       </a> #}
-        {#       {% endif %} #}
-        {#   {% endif %} #}
-        {#   {% endif %} #}
-        {# {% endif %} #}
+        {# TODO Remove elections that aren't FPTP #}
+        {% if show_results_feature %}
+          {% if post_election.postelectionresult_set.confirmed %}
+            <section>
+            <h3>Results</h3>
+            {% with post_election.postelectionresult_set.confirmed.confirmed_resultset as confirmed_results %}
+            {% include "uk_results/includes/vote_result_item.html" with result=confirmed_results results=confirmed_results.confirmed_resultset.candidate_results.all %}
+            {% endwith %}
+            </section>
+          {% endif %}
+
+          {% if not post_election.postelectionresult_set.confirmed %}
+            <a href="{% url "report-post-votes-view" post_election.id %}" class="button">
+            Report results for {{post_data.label}}
+            </a>
+          {% endif %}
+        {% endif %}
 
         {% if not candidates_locked %}
             {% if some_official_documents %}

--- a/elections/uk/tests/test_custom_merge.py
+++ b/elections/uk/tests/test_custom_merge.py
@@ -5,8 +5,9 @@ from popolo.models import Person
 from candidates.tests import factories
 from candidates.tests.auth import TestUserMixin
 from candidates.tests.uk_examples import UK2015ExamplesMixin
+from candidates.models import PostExtraElection
 
-from uk_results.models import CandidateResult, PostResult, ResultSet
+from uk_results.models import CandidateResult, PostElectionResult, ResultSet
 
 
 @attr(country='uk')
@@ -60,8 +61,12 @@ class TestUKResultsPreserved(TestUserMixin, UK2015ExamplesMixin, WebTest):
         )
 
         # Now attach a vote count to the secondary person's candidacy:
-        post_result = PostResult.objects.create(
-            post=secondary_membership_extra.base.post,
+        pee = PostExtraElection.objects.get(
+            postextra=secondary_membership_extra.base.post.extra,
+            election=secondary_membership_extra.election
+        )
+        post_election_result = PostElectionResult.objects.create(
+            post_election=pee,
             confirmed=False,
         )
         result_set = ResultSet.objects.create(

--- a/elections/uk/tests/test_custom_merge.py
+++ b/elections/uk/tests/test_custom_merge.py
@@ -70,7 +70,7 @@ class TestUKResultsPreserved(TestUserMixin, UK2015ExamplesMixin, WebTest):
             confirmed=False,
         )
         result_set = ResultSet.objects.create(
-            post_result=post_result,
+            post_election_result=post_election_result,
             num_turnout_reported=51561,
             num_spoilt_ballots=42,
             ip_address='127.0.0.1',
@@ -120,12 +120,16 @@ class TestUKResultsPreserved(TestUserMixin, UK2015ExamplesMixin, WebTest):
         )
 
         # Now attach a vote count to the primary person's candidacy:
-        post_result = PostResult.objects.create(
-            post=primary_membership_extra.base.post,
+        pee = PostExtraElection.objects.get(
+            postextra=primary_membership_extra.base.post.extra,
+            election=primary_membership_extra.election
+        )
+        post_election_result = PostElectionResult.objects.create(
+            post_election=pee,
             confirmed=False,
         )
         result_set = ResultSet.objects.create(
-            post_result=post_result,
+            post_election_result=post_election_result,
             num_turnout_reported=46659,
             num_spoilt_ballots=42,
             ip_address='127.0.0.1',

--- a/elections/uk/views/frontpage.py
+++ b/elections/uk/views/frontpage.py
@@ -126,10 +126,10 @@ class ConstituencyPostcodeFinderView(ContributorsMixin, FormView):
             context['council_election_percent'] = 0
 
         from candidates.models import PostExtra
-        from uk_results.models import PostResult
+        from uk_results.models import PostElectionResult
         context['votes_total'] = PostExtra.objects.filter(
             postextraelection__election__slug__contains="local").count()
-        context['votes_confirmed'] = PostResult.objects.filter(
+        context['votes_confirmed'] = PostElectionResult.objects.filter(
             confirmed=True).count()
 
         if float(context['votes_confirmed']):

--- a/uk_results/constants.py
+++ b/uk_results/constants.py
@@ -19,6 +19,7 @@ CONFIRMED_STATUS = 'confirmed'
 REJECTED_STATUS = 'rejected'
 
 REPORTED_RESULT_STATUSES = (
+    (None, 'Unreviewed'),
     (UNCONFIRMED_STATUS, 'Unconfirmed'),
     (CONFIRMED_STATUS, 'Confirmed'),
     (REJECTED_STATUS, 'Rejected'),

--- a/uk_results/forms.py
+++ b/uk_results/forms.py
@@ -93,14 +93,14 @@ class ReviewVotesForm(forms.ModelForm):
 
     def __init__(self, request, review_result, *args, **kwargs):
         self.request = request
-        self.post = review_result.post_result.post
+        self.post_election = review_result.post_election_result
 
         super(ReviewVotesForm, self).__init__(*args, **kwargs)
 
     def mark_candidates_as_winner(self, request, instance):
         for candidate_result in instance.candidate_results.all():
             membership = candidate_result.membership
-            post = instance.post_result.post
+            post_election = instance.post_election_result.post_election
             election = membership.extra.election
 
             source = instance.review_source
@@ -121,8 +121,8 @@ class ReviewVotesForm(forms.ModelForm):
                     election=election,
                     winner=membership.person,
                     winner_person_name=membership.person.name,
-                    post_id=post.extra.slug,
-                    post_name=post.label,
+                    post_id=post_election.postextra.slug,
+                    post_name=post_election.postextra.base.label,
                     winner_party_id=membership.on_behalf_of.extra.slug,
                     source=source,
                     user=instance.reviewed_by,

--- a/uk_results/forms.py
+++ b/uk_results/forms.py
@@ -88,7 +88,8 @@ class ReviewVotesForm(forms.ModelForm):
             'reviewed_by': forms.HiddenInput(),
             'review_source': forms.Textarea(
                 attrs={'rows': 1, 'columns': 72}
-            )
+            ),
+            'review_status': forms.widgets.RadioSelect,
         }
 
     def __init__(self, request, review_result, *args, **kwargs):

--- a/uk_results/forms.py
+++ b/uk_results/forms.py
@@ -165,9 +165,9 @@ class ResultSetForm(forms.ModelForm):
             'source',
         )
 
-    def __init__(self, post_result, *args, **kwargs):
-        self.post = post_result.post
-        self.post_result = post_result
+    def __init__(self, post_election_result, *args, **kwargs):
+        self.post_election = post_election_result.post_election
+        self.post_election_result = post_election_result
         self.memberships = []
 
         initial_values = {}
@@ -187,7 +187,8 @@ class ResultSetForm(forms.ModelForm):
         existing_fields = self.fields
         fields = OrderedDict()
 
-        memberships = self.post.memberships.all()
+        memberships = self.post_election.postextra.base.memberships.filter(
+            extra__election=self.post_election.election)
         memberships = sorted(
             memberships,
             key=lambda member: member.person.name.split(' ')[-1]
@@ -261,18 +262,14 @@ class ResultSetForm(forms.ModelForm):
 
     def save(self, request):
         instance = super(ResultSetForm, self).save(commit=False)
-        instance.post_result = self.post_result
+        instance.post_election_result = self.post_election_result
         instance.user = request.user if \
             request.user.is_authenticated() else None
         instance.ip_address = get_client_ip(request)
         instance.save(request)
 
-        election = self.memberships[0][0].extra.election
-        postextra = self.post.extra
-        pee = PostExtraElection.objects.get(
-            postextra=postextra, election=election)
-
-        winner_count = pee.winner_count
+        post_election = self.post_election_result.post_election
+        winner_count = post_election.winner_count
 
         winners = dict(sorted(
             [("{}-{}".format(self[y].value(), x.person.id), x)

--- a/uk_results/migrations/0029_add_postresult_post_election.py
+++ b/uk_results/migrations/0029_add_postresult_post_election.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('candidates', '0032_migrate_org_slugs'),
+        ('uk_results', '0028_auto_20170503_1633'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='postresult',
+            name='post_election',
+            field=models.ForeignKey(
+                null=True, to='candidates.PostExtraElection'),
+            preserve_default=False,
+        ),
+    ]
+

--- a/uk_results/migrations/0030_populate_postresult_post_election.py
+++ b/uk_results/migrations/0030_populate_postresult_post_election.py
@@ -1,0 +1,88 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+from collections import defaultdict
+
+from django.db import migrations, models
+
+
+def set_post_election_from_post(apps, schema_editor):
+    """
+    This is far from idea. Try to guess the PostExtraElection
+    that this PostResult relates to. This will have to be done by looking
+    and the related memberships and assuming they're correct (sometimes they
+    won't be, and that will have to be fixed manually later).
+    """
+    PostResult = apps.get_model('uk_results', 'PostResult')
+    PostExtraElection = apps.get_model('candidates', 'PostExtraElection')
+
+    print(PostResult.objects.all().count())
+    qs = PostResult.objects.all().select_related('post__extra')
+    for post_result in qs:
+        pee = None
+        elections = post_result.post.extra.elections.all()
+        if elections.count() == 1:
+            # This is an easy case – this post only has one known election
+            pee = PostExtraElection.objects.get(
+                election=elections.first(),
+                postextra=post_result.post.extra
+            )
+            post_result.post_election = pee
+            post_result.save()
+
+        else:
+            if not post_result.result_sets.exists():
+                # There are no results sets for this post_result
+                # so we cna just delete it
+                post_result.delete()
+                continue
+
+            result_sets_by_election = defaultdict(list)
+            # Work out how many elections we have results for.
+            # If it's only 1, then use that one
+            for result_set in post_result.result_sets.all():
+                for candidate_result in result_set.candidate_results.all():
+                    this_election = candidate_result.membership.extra.election
+                    result_sets_by_election[this_election].append(result_set)
+
+            if len(set(result_sets_by_election.keys())) == 1:
+                election = result_sets_by_election.keys()[0]
+                pee = PostExtraElection.objects.get(
+                    election=election,
+                    postextra=post_result.post.extra
+                )
+                post_result.post_election = pee
+                post_result.save()
+
+            else:
+                # We have results for more than one election, but only
+                # a single PostResult object.
+                # Split the result_sets up in to a new PostResult per election
+                for election, result_sets in result_sets_by_election.items():
+                    result_sets = set(result_sets)
+                    pee = PostExtraElection.objects.get(
+                        election=election,
+                        postextra=post_result.post.extra
+                    )
+                    pr = PostResult.objects.create(
+                        post_election=pee,
+                        post=post_result.post,
+                        confirmed=post_result.confirmed,
+                        confirmed_resultset=post_result.confirmed_resultset
+                    )
+                    for result_set in result_sets:
+                        result_set.post_result = pr
+                        result_set.save()
+                post_result.delete()
+
+
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('uk_results', '0029_add_postresult_post_election'),
+    ]
+
+    operations = [
+        migrations.RunPython(set_post_election_from_post),
+    ]

--- a/uk_results/migrations/0030_populate_postresult_post_election.py
+++ b/uk_results/migrations/0030_populate_postresult_post_election.py
@@ -7,7 +7,7 @@ from django.db import migrations, models
 
 def set_post_election_from_post(apps, schema_editor):
     """
-    This is far from idea. Try to guess the PostExtraElection
+    This is far from ideal. Try to guess the PostExtraElection
     that this PostResult relates to. This will have to be done by looking
     and the related memberships and assuming they're correct (sometimes they
     won't be, and that will have to be fixed manually later).
@@ -20,6 +20,8 @@ def set_post_election_from_post(apps, schema_editor):
     for post_result in qs:
         pee = None
         elections = post_result.post.extra.elections.all()
+        if not elections.exists():
+            raise ValueError("Post with no elections found.")
         if elections.count() == 1:
             # This is an easy case – this post only has one known election
             pee = PostExtraElection.objects.get(
@@ -32,7 +34,7 @@ def set_post_election_from_post(apps, schema_editor):
         else:
             if not post_result.result_sets.exists():
                 # There are no results sets for this post_result
-                # so we cna just delete it
+                # so we can just delete it
                 post_result.delete()
                 continue
 

--- a/uk_results/migrations/0031_remove_postresult_post.py
+++ b/uk_results/migrations/0031_remove_postresult_post.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('uk_results', '0030_populate_postresult_post_election'),
+    ]
+
+    operations = [
+        migrations.RemoveField(
+            model_name='postresult',
+            name='post',
+        ),
+        migrations.AlterField(
+            model_name='postresult',
+            name='post_election',
+            field=models.ForeignKey(
+                to='candidates.PostExtraElection', null=False),
+        ),
+
+    ]

--- a/uk_results/migrations/0032_rename_postresult_to_postelectionresult.py
+++ b/uk_results/migrations/0032_rename_postresult_to_postelectionresult.py
@@ -1,0 +1,17 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('uk_results', '0031_remove_postresult_post'),
+    ]
+
+    operations = [
+        migrations.RenameModel(
+            'PostResult',
+            'PostElectionResult'),
+    ]

--- a/uk_results/migrations/0033_auto_20170506_2042.py
+++ b/uk_results/migrations/0033_auto_20170506_2042.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('uk_results', '0032_rename_postresult_to_postelectionresult'),
+    ]
+
+    operations = [
+        migrations.RenameField(
+            model_name='resultset',
+            old_name='post_result',
+            new_name='post_election_result',
+        ),
+    ]

--- a/uk_results/models/votes_models.py
+++ b/uk_results/models/votes_models.py
@@ -54,11 +54,11 @@ class ResultSet(BaseResultModel, ResultStatusMixin):
     def save(self, *args, **kwargs):
         super(ResultSet, self).save(*args, **kwargs)
         if self.review_status == "confirmed":
-            self.post_result.confirmed = True
-            self.post_result.confirmed_resultset = self
+            self.post_election_result.confirmed = True
+            self.post_election_result.confirmed_resultset = self
             if not self.review_source:
                 self.review_source = self.source
-            self.post_result.save()
+            self.post_election_result.save()
 
 
 

--- a/uk_results/models/votes_models.py
+++ b/uk_results/models/votes_models.py
@@ -12,7 +12,7 @@ class PostResultManager(models.Manager):
 
 
 class PostResult(models.Model):
-    post = models.ForeignKey('popolo.Post')
+    post_election = models.ForeignKey('candidates.PostExtraElection')
     confirmed = models.BooleanField(default=False)
     confirmed_resultset = models.OneToOneField(
         'ResultSet', null=True)

--- a/uk_results/models/votes_models.py
+++ b/uk_results/models/votes_models.py
@@ -8,7 +8,12 @@ from .base import BaseResultModel, ResultStatusMixin
 
 class PostElectionResultManager(models.Manager):
     def confirmed(self):
-        return self.filter(confirmed=True)
+        qs = self.filter(confirmed=True)
+        if qs.exists():
+            return qs.latest()
+        else:
+            return False
+
 
 
 class PostElectionResult(models.Model):
@@ -19,6 +24,9 @@ class PostElectionResult(models.Model):
         'ResultSet', null=True)
 
     objects = PostElectionResultManager()
+
+    class Meta:
+        get_latest_by = 'confirmed_resultset__created'
 
     @models.permalink
     def get_absolute_url(self):
@@ -48,7 +56,7 @@ class ResultSet(BaseResultModel, ResultStatusMixin):
         return u"pk=%d user=%r post=%r" % (
             self.pk,
             self.user,
-            self.post_result,
+            self.post_election_result,
         )
 
     def save(self, *args, **kwargs):

--- a/uk_results/models/votes_models.py
+++ b/uk_results/models/votes_models.py
@@ -6,27 +6,29 @@ from django.db import transaction
 from .base import BaseResultModel, ResultStatusMixin
 
 
-class PostResultManager(models.Manager):
+class PostElectionResultManager(models.Manager):
     def confirmed(self):
         return self.filter(confirmed=True)
 
 
-class PostResult(models.Model):
+class PostElectionResult(models.Model):
+    # post = models.ForeignKey('popolo.Post')
     post_election = models.ForeignKey('candidates.PostExtraElection')
     confirmed = models.BooleanField(default=False)
     confirmed_resultset = models.OneToOneField(
         'ResultSet', null=True)
 
-    objects = PostResultManager()
+    objects = PostElectionResultManager()
 
     @models.permalink
     def get_absolute_url(self):
-        return ('post-results-view', (), {'post_id': self.post.extra.slug})
+        return ('post-results-view', (), {
+            'post_election_id': self.post_election.pk})
 
 
 class ResultSet(BaseResultModel, ResultStatusMixin):
-    post_result = models.ForeignKey(
-        PostResult,
+    post_election_result = models.ForeignKey(
+        PostElectionResult,
         related_name='result_sets',
     )
 

--- a/uk_results/serializers.py
+++ b/uk_results/serializers.py
@@ -2,11 +2,12 @@ from __future__ import unicode_literals
 
 from rest_framework import serializers
 
-from .models import PostResult, ResultSet, CandidateResult
+from .models import PostElectionResult, ResultSet, CandidateResult
 
 from candidates.serializers import (
-    MembershipSerializer, MinimalPostExtraSerializer
+    MembershipSerializer, EmbeddedPostElectionSerializer
 )
+
 
 class CandidateResultSerializer(serializers.HyperlinkedModelSerializer):
     class Meta:
@@ -39,14 +40,14 @@ class ResultSetSerializer(serializers.HyperlinkedModelSerializer):
     candidate_results = CandidateResultSerializer(many=True, read_only=True)
 
 
-class PostResultSerializer(serializers.HyperlinkedModelSerializer):
+class PostElectionResultSerializer(serializers.HyperlinkedModelSerializer):
     class Meta:
-        model = PostResult
+        model = PostElectionResult
         fields = (
             'id', 'url',
             'confirmed',
-            'post',
+            'post_election',
             'result_sets',
         )
-    post = MinimalPostExtraSerializer(source='post.extra')
+    post_election = EmbeddedPostElectionSerializer()
     result_sets = ResultSetSerializer(many=True)

--- a/uk_results/templates/uk_results/councilelection_detail.html
+++ b/uk_results/templates/uk_results/councilelection_detail.html
@@ -43,8 +43,8 @@
       {#   {% else %} #}
       {#   <a class="button tiny" href="{% url 'report-post-votes-view' post.slug %}">Report votes</a> #}
       {#   {% endif %} #}
-      {% if post.base.postresult_set.all.0.confirmed_resultset %}
-      {% include "uk_results/includes/vote_result_item.html" with result=post.base.postresult_set.all.0.confirmed_resultset results=result.candidate_results.all show_heading=True show_post_name=True %}
+      {% if post_election.postelectionresult_set.confirmed %}
+      {% include "uk_results/includes/vote_result_item.html" with result=post_election.postelectionresult_set.confirmed.confirmed_resultset show_heading=True show_post_name=True %}
       {% else %}
         <div>
           <h3>{{ post_election.postextra.base.label }}</h3>

--- a/uk_results/templates/uk_results/councilelection_detail.html
+++ b/uk_results/templates/uk_results/councilelection_detail.html
@@ -35,7 +35,7 @@
 <h3>Wards</h3>
 <div class="row">
   <div class="columns large-6">
-    {% for post in posts %}
+    {% for post_election in post_elections %}
       {# <li class="area_{{ post.base.area.identifier }}"> #}
       {#   {{ post }} #}
       {#   {% if post.confirmed %} #}
@@ -47,8 +47,8 @@
       {% include "uk_results/includes/vote_result_item.html" with result=post.base.postresult_set.all.0.confirmed_resultset results=result.candidate_results.all show_heading=True show_post_name=True %}
       {% else %}
         <div>
-          <h3>{{ post }}</h3>
-          <a class="button tiny" href="{% url 'report-post-votes-view' post.slug %}">Report votes</a>
+          <h3>{{ post_election.postextra.base.label }}</h3>
+          <a class="button tiny" href="{% url 'report-post-votes-view' post_election.pk %}">Report votes</a>
         </div>
       {% endif %}
     {% endfor %}

--- a/uk_results/templates/uk_results/includes/vote_result_item.html
+++ b/uk_results/templates/uk_results/includes/vote_result_item.html
@@ -1,13 +1,14 @@
 <div class="vote_result">
   {% if show_heading %}
+
   <h4>
     {% if result.review_status == 'confirmed' %}
-    Result{% if show_post_name %}: {{ result.post_result.post.area.name }}{% endif %}
+    Result{% if show_post_name %}: {{ result.post_election_result.post_election.postextra.base.label }}{% endif %}
     {% else %}
-    Reported result{% if show_post_name %}: {{ result.post_result.post.area.name }}{% endif %}
+    Reported result{% if show_post_name %}: {{ result.post_election_result.post_election.postextra.base.label }}{% endif %}
     {% endif %}
   </h4>
-  <h5>{{result.post_result.post.extra.postextraelection_set.all.0.election}}</h5>
+  <h5>{{result.post_election_result.post_election.election}}</h5>
   {% endif %}
 
   {% if result.review_status == 'confirmed' %}

--- a/uk_results/templates/uk_results/includes/vote_result_item.html
+++ b/uk_results/templates/uk_results/includes/vote_result_item.html
@@ -15,7 +15,7 @@
   {% else %}
   <p><strong>This result is not been confirmed</strong></p>
     {% if user_can_confirm_control %}
-    <a href="{% url 'review-votes-view' pk=result.pk %}" class="button tiny">
+    <a href="{% url 'review-votes-view' result_set_id=result.pk %}" class="button tiny">
       Review
     </a>
     {% endif %}

--- a/uk_results/templates/uk_results/posts/post_view.html
+++ b/uk_results/templates/uk_results/posts/post_view.html
@@ -16,7 +16,7 @@
 
 
 <p>
-  <a href="{% url 'report-post-votes-view' post_id=object.post.extra.slug %}" class="button">
+  <a href="{% url 'report-post-votes-view' post_election_id=object.post_election_id %}" class="button">
     Report votes
   </a>
 </p>

--- a/uk_results/templates/uk_results/posts/review_reported_votes.html
+++ b/uk_results/templates/uk_results/posts/review_reported_votes.html
@@ -24,7 +24,7 @@
 </form>
 
 {% if user_can_confirm_control %}
-<a href="{% url 'report-post-votes-view' object.post_result.post.role %}?{{ edit_querystring }}" class="button warning">Edit these results</a>
+<a href="{% url 'report-post-votes-view' object.post_election_result.post_election_id %}?{{ edit_querystring }}" class="button warning">Edit these results</a>
 {% endif %}
 
 {% endblock results_content %}

--- a/uk_results/templates/uk_results/uk_results_base.html
+++ b/uk_results/templates/uk_results/uk_results_base.html
@@ -7,8 +7,8 @@
     <ul class="left">
       <li><a href="{% url 'results-home' %}">Results Home</a></li>
       <li><a href="{% url 'councils-with-elections' %}">Councils</a></li>
-      {# <li><a href="{% url 'latest-control-view' %}">Control results</a></li> #}
-      {# <li><a href="{% url 'latest-votes-view' %}">Vote results</a></li> #}
+      <li><a href="{% url 'latest-control-view' %}">Control results</a></li>
+      <li><a href="{% url 'latest-votes-view' %}">Vote results</a></li>
     </ul>
   </section>
 </nav>

--- a/uk_results/urls.py
+++ b/uk_results/urls.py
@@ -55,7 +55,7 @@ urlpatterns = [
         name='report-post-votes-view'
     ),
     url(
-        r'^posts/(?P<post_election_id>[\d]+)/review$',
+        r'^posts/(?P<result_set_id>[\d]+)/review$',
         views.ReviewPostReportView.as_view(),
         name='review-votes-view'
     ),

--- a/uk_results/urls.py
+++ b/uk_results/urls.py
@@ -65,6 +65,12 @@ urlpatterns = [
         name='latest-votes-view'
     ),
 
+    url(
+        r'^posts/(?P<post_slug>[^/]+)/$',
+        views.PostResultsRedirectView.as_view(),
+        name='post-result-redirect-view'
+    ),
+
 
 
     # Map Views

--- a/uk_results/urls.py
+++ b/uk_results/urls.py
@@ -44,18 +44,18 @@ urlpatterns = [
 
     # Votes
     url(
-        r'^posts/(?P<post_id>[^/]+)/$',
+        r'^posts/(?P<post_election_id>[\d]+)/$',
         views.PostResultsView.as_view(),
         name='post-results-view'
     ),
 
     url(
-        r'^posts/(?P<post_id>[^/]+)/report$',
+        r'^posts/(?P<post_election_id>[\d]+)/report$',
         views.PostReportVotesView.as_view(),
         name='report-post-votes-view'
     ),
     url(
-        r'^posts/(?P<pk>[^/]+)/review$',
+        r'^posts/(?P<post_election_id>[\d]+)/review$',
         views.ReviewPostReportView.as_view(),
         name='review-votes-view'
     ),

--- a/uk_results/views/api.py
+++ b/uk_results/views/api.py
@@ -9,11 +9,11 @@ from candidates.serializers import OrganizationExtraSerializer
 from candidates.views import ResultsSetPagination
 
 from ..serializers import (
-    CandidateResultSerializer, PostResultSerializer, ResultSetSerializer
+    CandidateResultSerializer, PostElectionResultSerializer, ResultSetSerializer
 )
 from ..models import (
     CandidateResult, CouncilElection, CouncilElectionResultSet,
-    PostResult, ResultSet,
+    PostElectionResult, ResultSet,
 )
 
 
@@ -114,8 +114,8 @@ class ResultSetViewSet(viewsets.ModelViewSet):
 
 
 
-class PostResultViewSet(viewsets.ModelViewSet):
-    queryset = PostResult.objects \
+class PostElectionResultViewSet(viewsets.ModelViewSet):
+    queryset = PostElectionResult.objects \
         .select_related('post__extra') \
         .prefetch_related(
             Prefetch(
@@ -139,6 +139,6 @@ class PostResultViewSet(viewsets.ModelViewSet):
             ),
         ) \
         .order_by('id')
-    serializer_class = PostResultSerializer
+    serializer_class = PostElectionResultSerializer
     pagination_class = ResultsSetPagination
     filter_fields = ('confirmed',)

--- a/uk_results/views/base.py
+++ b/uk_results/views/base.py
@@ -1,8 +1,11 @@
 from django.conf import settings
+from django.shortcuts import get_object_or_404
 
 from braces.views import UserPassesTestMixin
-
 from auth_helpers.views import user_in_group
+
+from candidates.models import PostExtraElection
+from ..models import PostElectionResult
 
 
 class BaseResultsViewMixin(UserPassesTestMixin):
@@ -13,9 +16,12 @@ class BaseResultsViewMixin(UserPassesTestMixin):
         results_feature_active = getattr(
             settings, 'RESULTS_FEATURE_ACTIVE', False)
 
-        return any(
-                (in_group, results_feature_active)
-            )
+        return any((in_group, results_feature_active))
 
-
-
+    def get_object(self):
+        post_election_id = self.kwargs.get('post_election_id')
+        pee = get_object_or_404(
+            PostExtraElection,
+            pk=post_election_id,
+        )
+        return PostElectionResult.objects.get_or_create(post_election=pee)[0]

--- a/uk_results/views/base.py
+++ b/uk_results/views/base.py
@@ -8,7 +8,7 @@ from candidates.models import PostExtraElection
 from ..models import PostElectionResult
 
 
-class BaseResultsViewMixin(UserPassesTestMixin):
+class ResultsViewPermissionsMixin(UserPassesTestMixin):
     raise_exception = True
     def test_func(self, user):
         in_group = user_in_group(self.request.user,
@@ -17,6 +17,9 @@ class BaseResultsViewMixin(UserPassesTestMixin):
             settings, 'RESULTS_FEATURE_ACTIVE', False)
 
         return any((in_group, results_feature_active))
+
+
+class BaseResultsViewMixin(ResultsViewPermissionsMixin):
 
     def get_object(self):
         post_election_id = self.kwargs.get('post_election_id')

--- a/uk_results/views/base_views.py
+++ b/uk_results/views/base_views.py
@@ -36,15 +36,16 @@ class ResultsHomeView(BaseResultsViewMixin, TemplateView):
 
 
         from candidates.models import PostExtraElection
-        from uk_results.models import PostResult
+        from uk_results.models import PostElectionResult
         context['votes_total'] = PostExtraElection.objects.filter(
             election__slug__contains="local",
             election__election_date=RESULTS_DATE,
 
         ).count()
-        context['votes_confirmed'] = PostResult.objects.filter(
+
+        context['votes_confirmed'] = PostElectionResult.objects.filter(
             confirmed=True,
-            post__extra__elections__election_date=RESULTS_DATE
+            post_election__election__election_date=RESULTS_DATE
         ).count()
 
         if float(context['votes_confirmed']):

--- a/uk_results/views/control_views.py
+++ b/uk_results/views/control_views.py
@@ -120,7 +120,10 @@ class LatestControlResults(BaseResultsViewMixin, ListView):
 
     def get_queryset(self):
         queryset = self.queryset
-        queryset.filter(council_election__election__election_date=RESULTS_DATE)
+        queryset = queryset.filter(
+            council_election__election__election_date=RESULTS_DATE)
+        queryset = queryset.select_related(
+            'controller', 'council_election__council')
 
         status = self.request.GET.get('status')
         if status:

--- a/uk_results/views/control_views.py
+++ b/uk_results/views/control_views.py
@@ -10,7 +10,7 @@ from ..constants import CONFIRMED_STATUS, RESULTS_DATE
 from ..models import CouncilElection, CouncilElectionResultSet
 from ..forms import (ReportCouncilElectionControlForm,
                      ReviewControlForm)
-from .base import BaseResultsViewMixin
+from .base import BaseResultsViewMixin, ResultsViewPermissionsMixin
 
 
 class CouncilsWithElections(BaseResultsViewMixin, TemplateView):
@@ -136,7 +136,7 @@ class LatestControlResults(BaseResultsViewMixin, ListView):
         return queryset
 
 
-class ConfirmControl(BaseResultsViewMixin, UpdateView):
+class ConfirmControl(ResultsViewPermissionsMixin, UpdateView):
     template_name = "uk_results/review_reported_control.html"
     queryset = CouncilElectionResultSet.objects.all()
 

--- a/uk_results/views/control_views.py
+++ b/uk_results/views/control_views.py
@@ -54,10 +54,10 @@ class CouncilElectionView(BaseResultsViewMixin, DetailView):
 
     def get_context_data(self, **kwargs):
         context = super(CouncilElectionView, self).get_context_data(**kwargs)
-        context['posts'] = self.object.election.posts.select_related(
-            'base',
-            'base__area',
-        ).order_by('base__label')
+        context['post_elections'] = \
+            self.object.election.postextraelection_set.all().select_related(
+                'postextra__base', 'election'
+            )
         return context
 
 

--- a/uk_results/views/control_views.py
+++ b/uk_results/views/control_views.py
@@ -23,6 +23,9 @@ class CouncilsWithElections(BaseResultsViewMixin, TemplateView):
         councils = councils.select_related(
             'council',
             'election',
+            'controller_resultset',
+            'controller_resultset__controller',
+            'controller_resultset__controller__partywithcolour',
             # 'reported_results',
         )
         councils = councils.prefetch_related(
@@ -31,6 +34,7 @@ class CouncilsWithElections(BaseResultsViewMixin, TemplateView):
                 CouncilElectionResultSet.objects.select_related(
                     'council_election',
                     'council_election__election',
+                    'council_election__council',
                     'council_election__council',
                 )
             )

--- a/uk_results/views/votes_views.py
+++ b/uk_results/views/votes_views.py
@@ -79,7 +79,13 @@ class PostReportVotesView(BaseResultsViewMixin, FormView):
 
 class ReviewPostReportView(ResultsViewPermissionsMixin, UpdateView):
     template_name = "uk_results/posts/review_reported_votes.html"
-    queryset = ResultSet.objects.all()
+    queryset = ResultSet.objects.all().select_related(
+        'post_election_result',
+    ).prefetch_related(
+        'candidate_results__membership',
+        'candidate_results__membership__on_behalf_of__partywithcolour',
+        'candidate_results__membership__person',
+    )
     pk_url_kwarg = 'result_set_id'
 
     def get_form(self, form_class=None):

--- a/uk_results/views/votes_views.py
+++ b/uk_results/views/votes_views.py
@@ -56,7 +56,7 @@ class PostReportVotesView(BaseResultsViewMixin, FormView):
                 action_type='record-council-result',
                 ip_address=get_client_ip(self.request),
                 source=form['source'].value(),
-                post=form.post,
+                post=form.post_election.postextra.base,
             )
 
         if 'report_and_confirm' in self.request.POST:
@@ -69,7 +69,7 @@ class PostReportVotesView(BaseResultsViewMixin, FormView):
                     action_type='confirm-council-result',
                     ip_address=get_client_ip(self.request),
                     source="Confirmed when reporting",
-                    post=form.post,
+                    post=form.post_election.postextra.base,
                 )
 
         return super(PostReportVotesView, self).form_valid(form)

--- a/uk_results/views/votes_views.py
+++ b/uk_results/views/votes_views.py
@@ -6,10 +6,8 @@ from django.views.generic import (DetailView, FormView, UpdateView, ListView)
 from candidates.views.version_data import get_client_ip
 from candidates.models import LoggedAction
 
-from popolo.models import Post
-
 from ..constants import CONFIRMED_STATUS, RESULTS_DATE
-from ..models import PostResult, ResultSet
+from ..models import PostElectionResult, ResultSet
 from ..forms import ResultSetForm, ReviewVotesForm
 from .base import BaseResultsViewMixin
 
@@ -17,20 +15,10 @@ from .base import BaseResultsViewMixin
 class PostResultsView(BaseResultsViewMixin, DetailView):
     template_name = "uk_results/posts/post_view.html"
 
-    def get_object(self):
-        slug = self.kwargs.get('post_id')
-        post = get_object_or_404(Post, extra__slug=slug)
-        return PostResult.objects.get_or_create(post=post)[0]
-
 
 class PostReportVotesView(BaseResultsViewMixin, FormView):
-    model = PostResult
+    model = PostElectionResult
     template_name = "uk_results/report_council_election_control.html"
-
-    def get_object(self):
-        slug = self.kwargs.get('post_id')
-        post = get_object_or_404(Post, extra__slug=slug)
-        return PostResult.objects.get_or_create(post=post)[0]
 
     def get_context_data(self, **kwargs):
         context = super(PostReportVotesView, self).get_context_data(**kwargs)
@@ -51,7 +39,7 @@ class PostReportVotesView(BaseResultsViewMixin, FormView):
         self.object = self.get_object()
 
         return ResultSetForm(
-            post_result=self.object,
+            post_election_result=self.object,
             **self.get_form_kwargs()
         )
 


### PR DESCRIPTION
Migration 0030 is the tricky one – we have to assign the existing
data PostExtraElection objects. There are 3 main cases:

1. Where we have 1 existing election for this Post. This means we just
   get a PostExtraElection for the (election, post) combo.

2. Where we have more than one election, but only result for one of them.
   Here we can just assign a PostExtraElection for the
   (election, post) combo.

3. Where we have results for each (election, post). Here we need to make a
   new PostResult object per (election, post) combo.

This has been tested on the live data as of 2017-05-06. Note that this
commit on it's own will break various other things. More commits will
follow.