### PR TITLE
Add a URL to the twitter image import

### DIFF
--- a/candidates/management/commands/candidates_add_twitter_images_to_queue.py
+++ b/candidates/management/commands/candidates_add_twitter_images_to_queue.py
@@ -28,7 +28,7 @@ class Command(BaseCommand):
 
     help = "Add Twitter avatars for candidates without images to the moderation queue"
 
-    def add_twitter_image_to_queue(self, person, image_url):
+    def add_twitter_image_to_queue(self, person, image_url, user_id):
         if person.queuedimage_set.exists():
             # Don't add an image to the queue if there is one already
             # in the queue. It doesn't matter if that queued image has
@@ -58,10 +58,13 @@ class Command(BaseCommand):
             verbose(msg.format(url=image_url))
             return
 
+        justification_for_use = "Auto imported from Twitter: " \
+            "https://twitter.com/intent/user?user_id={user_id}".format(
+                user_id=user_id)
         qi = QueuedImage(
             decision=QueuedImage.UNDECIDED,
             why_allowed=CopyrightOptions.PROFILE_PHOTO,
-            justification_for_use="Auto imported from Twitter",
+            justification_for_use=justification_for_use,
             person=person
         )
         qi.save()
@@ -79,7 +82,8 @@ class Command(BaseCommand):
                   "user ID: {user_id}"
             verbose(_(msg).format(person=person, user_id=user_id))
             self.add_twitter_image_to_queue(
-                person, self.twitter_data.user_id_to_photo_url[user_id])
+                person, self.twitter_data.user_id_to_photo_url[user_id],
+                user_id)
 
     def handle(self, *args, **options):
         global VERBOSE

--- a/candidates/tests/test_twitter_queue_images_command.py
+++ b/candidates/tests/test_twitter_queue_images_command.py
@@ -138,8 +138,14 @@ class TestTwitterImageQueueCommand(TestUserMixin, TestCase):
         )
 
         self.assertEqual(new_queued_images.count(), 2)
-        new_queued_images.get(person=self.p_no_images)
-        new_queued_images.get(person=self.p_existing_image_but_none_in_queue)
+        newly_enqueued_a = new_queued_images.get(person=self.p_no_images)
+        self.assertEqual(
+            newly_enqueued_a.justification_for_use,
+            'Auto imported from Twitter: https://twitter.com/intent/user?user_id=1001')
+        newly_enqueued_b = new_queued_images.get(person=self.p_existing_image_but_none_in_queue)
+        self.assertEqual(
+            newly_enqueued_b.justification_for_use,
+            'Auto imported from Twitter: https://twitter.com/intent/user?user_id=1006')
 
     def test_multiple_twitter_identifiers(self, mock_twitter_data, mock_requests):
         self.p_no_images.identifiers.create(
@@ -193,7 +199,12 @@ class TestTwitterImageQueueCommand(TestUserMixin, TestCase):
         )
 
         self.assertEqual(new_queued_images.count(), 1)
-        new_queued_images.get(person=self.p_existing_image_but_none_in_queue)
+        newly_enqueued = new_queued_images.get()
+        self.assertEqual(newly_enqueued.person, self.p_existing_image_but_none_in_queue)
+        self.assertEqual(
+            newly_enqueued.justification_for_use,
+            'Auto imported from Twitter: https://twitter.com/intent/user?user_id=1006')
+
 
     def test_only_enqueue_from_200_status_code(self, mock_twitter_data, mock_requests):
 
@@ -230,6 +241,11 @@ class TestTwitterImageQueueCommand(TestUserMixin, TestCase):
         # had a 200 status code:
         self.assertEqual(new_queued_images.count(), 1)
         new_queued_images.get(person=self.p_existing_image_but_none_in_queue)
+        newly_enqueued = new_queued_images.get()
+        self.assertEqual(newly_enqueued.person, self.p_existing_image_but_none_in_queue)
+        self.assertEqual(
+            newly_enqueued.justification_for_use,
+            'Auto imported from Twitter: https://twitter.com/intent/user?user_id=1006')
 
     def test_only_enqueue_files_that_seem_to_be_images(self, mock_twitter_data, mock_requests):
 
@@ -270,4 +286,8 @@ class TestTwitterImageQueueCommand(TestUserMixin, TestCase):
         # Out of the two URLs of images that were downloaded, only one
         # had a 200 status code:
         self.assertEqual(new_queued_images.count(), 1)
-        new_queued_images.get(person=self.p_existing_image_but_none_in_queue)
+        newly_enqueued = new_queued_images.get()
+        self.assertEqual(newly_enqueued.person, self.p_existing_image_but_none_in_queue)
+        self.assertEqual(
+            newly_enqueued.justification_for_use,
+            'Auto imported from Twitter: https://twitter.com/intent/user?user_id=1006')


### PR DESCRIPTION
The ‘justification for use’ explicitly requests a source URL, so I’ve
added that.

I’ve used the twitter ID URL rather than twitter.com/screenname, since
it’s persistent.