### PR TITLE
Remove screen name if twitter user ID is invalid

### DIFF
--- a/candidates/management/commands/candidates_update_twitter_usernames.py
+++ b/candidates/management/commands/candidates_update_twitter_usernames.py
@@ -85,6 +85,8 @@ class Command(BaseCommand):
                     person_url=person.extra.get_absolute_url(),
                 ))
                 self.remove_twitter_user_id(person, user_id)
+                if screen_name:
+                    self.remove_twitter_screen_name(person, screen_name)
                 return
             correct_screen_name = self.twitter_data.user_id_to_screen_name[user_id]
             if (screen_name is None) or (screen_name != correct_screen_name):

--- a/candidates/tests/test_twitter_update_usernames_command.py
+++ b/candidates/tests/test_twitter_update_usernames_command.py
@@ -294,15 +294,10 @@ class TestUpdateTwitterUsernamesCommand(TestUserMixin, TestCase):
                             'screen_name': 'notreallyatwitteraccount',
                             'profile_image_url_https': 'https://example.com/a.jpg',
                         },
-                        {
-                            'id': 765,
-                            'screen_name': 'notatwitteraccounteither',
-                            'profile_image_url_https': 'https://example.com/b.jpg',
-                        },
                     ]
                     return mock_result
             if 'user_id' in data:
-                if data['user_id'] == '987':
+                if data['user_id'] == '765,987':
                     mock_result.json.return_value = {
                         "errors": [
                             {
@@ -327,6 +322,13 @@ class TestUpdateTwitterUsernamesCommand(TestUserMixin, TestCase):
             0)
 
         self.assertEqual(
+            self.screen_name_and_user_id.contact_details.filter(contact_type='twitter').count(),
+            0)
+        self.assertEqual(
+            self.screen_name_and_user_id.identifiers.filter(scheme='twitter').count(),
+            0)
+
+        self.assertEqual(
             split_output(out),
             [
                 'Adding the user ID 321',
@@ -334,5 +336,9 @@ class TestUpdateTwitterUsernamesCommand(TestUserMixin, TestCase):
                 'as it is not a valid Twitter user ID. '
                 '/person/{0}/person-with-just-a-twitter-user-id'.format(
                     self.just_userid.id),
+                'Removing user ID 765 for Someone with a Twitter screen name ' \
+                'and user ID as it is not a valid Twitter user ID. ' \
+                '/person/{0}/someone-with-a-twitter-screen-name-and-user-id'.format(
+                    self.screen_name_and_user_id.id),
             ]
         )


### PR DESCRIPTION
Currently if a twitter user ID is invalid, it’s removed.
The screen name is not removed until the next run,
though. This does both in the same run.

There might be a preferable way of writing this, e.g.
that makes both changes in a single log entry.