### PR TITLE
Fix API requests that are missing a trailing slash

### DIFF
--- a/candidates/middleware.py
+++ b/candidates/middleware.py
@@ -94,7 +94,7 @@ class DisableCachingForAuthenticatedUsers(object):
     )
 
     def process_response(self, request, response):
-        if request.user.is_authenticated():
+        if hasattr(request, 'user') and request.user.is_authenticated():
             if all(path_re.search(request.path) is None
                     for path_re in self.EXCLUDED_PATHS):
                 add_never_cache_headers(response)

--- a/candidates/tests/test_caching.py
+++ b/candidates/tests/test_caching.py
@@ -41,3 +41,21 @@ class TestCaching(TestUserMixin, UK2015ExamplesMixin, WebTest):
                 )
 
         self.assertTrue(seen_cache)
+
+    def test_api_post_endpoint(self):
+        # This is a regression test for the error:
+        # Internal Server Error: /api/v0.9/posts/WMC:E14001021
+        # Traceback (most recent call last):
+        #   File "/var/www/ynr/env/local/lib/python2.7/site-packages/django/core/handlers/base.py", line 223, in get_response
+        #     response = middleware_method(request, response)
+        #   File "/var/www/ynr/code/candidates/middleware.py", line 97, in process_response
+        #     if request.user.is_authenticated():
+        # AttributeError: 'WSGIRequest' object has no attribute 'user'
+        without_slash = '/api/v0.9/posts/{0}'.format(
+            self.edinburgh_east_post_extra.slug)
+        with_slash = without_slash + '/'
+        response = self.app.get(without_slash)
+        self.assertEqual(response.status_code, 301)
+        self.assertEqual(response.location, 'http://localhost:80' + with_slash)
+        response = self.app.get(with_slash)
+        self.assertEqual(response.status_code, 200)


### PR DESCRIPTION
Since the change introduced in 15050c8c45c508da2e24c2c8bebcf868fb3b6781
we have been getting the following error:

  Internal Server Error: /api/v0.9/posts/WMC:E14001021
  Traceback (most recent call last):
    File "/var/www/ynr/env/local/lib/python2.7/site-packages/django/core/handlers/base.py", line 223, in get_response
      response = middleware_method(request, response)
    File "/var/www/ynr/code/candidates/middleware.py", line 97, in process_response
      if request.user.is_authenticated():
  AttributeError: 'WSGIRequest' object has no attribute 'user'

... for API requests that are missing the trailing slash. In these cases
a redirect is being generated, but user is not being set on the request
object before it's processed by the DisableCachingForAuthenticatedUsers
middleware.  This fix seems to fix that problem.