### PR TITLE
Make a test of multiple header values insensitve to their order

### DIFF
--- a/candidates/tests/test_caching.py
+++ b/candidates/tests/test_caching.py
@@ -36,8 +36,10 @@ class TestCaching(TestUserMixin, UK2015ExamplesMixin, WebTest):
         for header, value in headers:
             if header == 'Cache-Control':
                 seen_cache = True
-                self.assertTrue(
-                    value == 'no-cache, no-store, must-revalidate, max-age=0'
+                values = set(value.split(', '))
+                self.assertEqual(
+                    values,
+                    {'no-cache', 'no-store', 'must-revalidate', 'max-age=0'}
                 )
 
         self.assertTrue(seen_cache)


### PR DESCRIPTION
This test sometimes failed on Python 3 because the values in the header
were ordered differently - splitting them and comparing as a set should
fix that.