### PR TITLE
Inline adding of alternative names on bulk editing page

### DIFF
--- a/bulk_adding/static/bulk_adding/css/bulk.scss
+++ b/bulk_adding/static/bulk_adding/css/bulk.scss
@@ -1,0 +1,12 @@
+.bulk-add__known-people {
+    li {
+        & > :first-child {
+            display: block;
+            margin-bottom: 0.2em;
+        }
+
+        .button {
+            margin-right: 0.5em;
+        }
+    }
+}

--- a/bulk_adding/static/bulk_adding/css/bulk.scss
+++ b/bulk_adding/static/bulk_adding/css/bulk.scss
@@ -20,6 +20,10 @@
             padding: 0 0.5em;
             display: inline-block;
             list-style: none;
+
+            &.highlight {
+                background-color: gold;
+            }
         }
     }
 

--- a/bulk_adding/static/bulk_adding/css/bulk.scss
+++ b/bulk_adding/static/bulk_adding/css/bulk.scss
@@ -11,19 +11,18 @@
     }
 
     .other-names {
-        margin-left: 0;
-        & > :first-child {
-            padding: 0;
-        }
-        li {
-            font-size: 0.8em;
-            padding: 0 0.5em;
-            display: inline-block;
-            list-style: none;
+        font-size: 0.9em;
+        margin: 0 -0.5em 0.5em -0.5em;
 
-            &.highlight {
-                background-color: gold;
-            }
+        li {
+            list-style: none;
+            float: left;
+            margin: 0 0.5em;
+        }
+
+        .highlight {
+            background-color: gold;
+            padding: 0 0.4em;
         }
     }
 

--- a/bulk_adding/static/bulk_adding/css/bulk.scss
+++ b/bulk_adding/static/bulk_adding/css/bulk.scss
@@ -9,4 +9,18 @@
             margin-right: 0.5em;
         }
     }
+
+    .other-names {
+        margin-left: 0;
+        & > :first-child {
+            padding: 0;
+        }
+        li {
+            font-size: 0.8em;
+            padding: 0 0.5em;
+            display: inline-block;
+            list-style: none;
+        }
+    }
+
 }

--- a/bulk_adding/static/bulk_adding/js/bulk.js
+++ b/bulk_adding/static/bulk_adding/js/bulk.js
@@ -12,17 +12,34 @@ $(function(){
             $form.find('#altnameerr').remove();
             $form.find('.alert').remove();
             $form.find('.errorlist').remove();
+            $name = $form.find('input[name="name"]').val();
             $.ajax({
                 url: $link.attr('href'),
                 type: "POST",
                 data: {
                     csrfmiddlewaretoken: $form.find('input[type="hidden"]').val(),
-                    name : $form.find('input[name="name"]').val(),
+                    name : $name,
                     source : $form.find('input[name="source"]').val()
                 },
 
                 success: function(json) {
                     if (json['success']) {
+                        $other = $person.find('.other-names');
+                        if ($other.length == 0) {
+                            $first_name = $person.find('>:first-child');
+                            $first_name.after('<ul class="other-names"><li>Other names:</li></ul>');
+                            $other = $person.find('.other-names');
+                        }
+                        $names = $other.find('.other-name');
+                        $names.remove()
+                        for (var i = 0; i < json.names.length; i++) {
+                            var name = json.names[i];
+                            var highlight = '';
+                            if (name == $name) {
+                                highlight = ' highlight';
+                            }
+                            $other.append('<li class="other-name' + highlight + '">' + json.names[i] + '</li>');
+                        }
                         $form.remove();
                     } else {
                         if (json['errors']) {

--- a/bulk_adding/static/bulk_adding/js/bulk.js
+++ b/bulk_adding/static/bulk_adding/js/bulk.js
@@ -3,13 +3,43 @@ $(function(){
         e.preventDefault();
 
         $person = $(this).parents('li');
+        $link = $person.find('.js-bulk-known-person-alternate-name')
         $form = $( $('.js-bulk-known-person-alternate-name-form').html() );
         $form.appendTo($person);
         $form.find('input[type="text"]').focus();
 
         $form.on('submit', function(){
-            console.log( $form.serializeArray() );
-            // :TODO: $.post(...)
+            $form.find('#altnameerr').remove();
+            $form.find('.alert').remove();
+            $form.find('.errorlist').remove();
+            $.ajax({
+                url: $link.attr('href'),
+                type: "POST",
+                data: {
+                    csrfmiddlewaretoken: $form.find('input[type="hidden"]').val(),
+                    name : $form.find('input[name="name"]').val(),
+                    source : $form.find('input[name="source"]').val()
+                },
+
+                success: function(json) {
+                    if (json['success']) {
+                        $form.remove();
+                    } else {
+                        if (json['errors']) {
+                            for (var err in json.errors) {
+                                if (!json.errors.hasOwnProperty(err)) { continue; }
+                                el = $form.find('input[name="' + err + '"]');
+                                el.before('<ul class="errorlist"><li>' + json.errors[err] + '</li></ul>')
+                            }
+                        }
+                    }
+                },
+
+                error: function(xhr,errmsg,err) {
+                    $form.prepend("<div class='alert-box alert radius' id='altnameerr'>There was a problem adding the name, please try again</div>");
+                }
+            });
+            return false;
         });
 
         $form.on('click', '.js-bulk-known-person-alternate-name-cancel', function(){

--- a/bulk_adding/static/bulk_adding/js/bulk.js
+++ b/bulk_adding/static/bulk_adding/js/bulk.js
@@ -1,0 +1,19 @@
+$(function(){
+    $('.js-bulk-known-person-alternate-name').on('click', function(e){
+        e.preventDefault();
+
+        $person = $(this).parents('li');
+        $form = $( $('.js-bulk-known-person-alternate-name-form').html() );
+        $form.appendTo($person);
+        $form.find('input[type="text"]').focus();
+
+        $form.on('submit', function(){
+            console.log( $form.serializeArray() );
+            // :TODO: $.post(...)
+        });
+
+        $form.on('click', '.js-bulk-known-person-alternate-name-cancel', function(){
+            $form.remove();
+        });
+    });
+});

--- a/bulk_adding/templates/bulk_add/add_form.html
+++ b/bulk_adding/templates/bulk_add/add_form.html
@@ -49,7 +49,7 @@
             <ul class="other-names">
               <li>Other names:</li>
             {% endif %}
-            <li>{{ name }}</li>
+            <li class="other-name">{{ name }}</li>
             {% if forloop.last %}</ul>{% endif %}
         {% endfor %}
         <a href="{% url 'person-update' person.pk%}" class="button secondary tiny">

--- a/bulk_adding/templates/bulk_add/add_form.html
+++ b/bulk_adding/templates/bulk_add/add_form.html
@@ -44,6 +44,14 @@
         <a href="{% url 'person-view' person.pk %}" target="_blank">
             <strong>{{ person }}</strong> ({{ person.party.name }})
         </a>
+        {% for name in person.other_names.all %}
+            {% if forloop.first %}
+            <ul class="other-names">
+              <li>Other names:</li>
+            {% endif %}
+            <li>{{ name }}</li>
+            {% if forloop.last %}</ul>{% endif %}
+        {% endfor %}
         <a href="{% url 'person-update' person.pk%}" class="button secondary tiny">
             Edit candidate
         </a>

--- a/bulk_adding/templates/bulk_add/add_form.html
+++ b/bulk_adding/templates/bulk_add/add_form.html
@@ -46,8 +46,8 @@
         </a>
         {% for name in person.other_names.all %}
             {% if forloop.first %}
-            <ul class="other-names">
-              <li>Other names:</li>
+            <ul class="other-names clearfix">
+              <li>Also known as:</li>
             {% endif %}
             <li class="other-name">{{ name }}</li>
             {% if forloop.last %}</ul>{% endif %}

--- a/bulk_adding/templates/bulk_add/add_form.html
+++ b/bulk_adding/templates/bulk_add/add_form.html
@@ -47,7 +47,7 @@
         <a href="{% url 'person-update' person.pk%}" class="button secondary tiny">
             Edit candidate
         </a>
-        <a href="#" class="button secondary tiny js-bulk-known-person-alternate-name">
+        <a href="{% url 'person-other-name-create' person.pk %}" class="button secondary tiny js-bulk-known-person-alternate-name">
             Nomination paper shows different name variant
         </a>
         <!-- <a href="#" class="button secondary tiny">
@@ -57,10 +57,14 @@
   {% endfor %}
 </ul>
 <script type="text/html" class="js-bulk-known-person-alternate-name-form">
-    <form action="." method="post">
+<form action="" method="post">
+        {% csrf_token %}
         <p>
             <label for="alt-name">Name as it appears on nomination paper:</label>
-            <input id="alt-name" type="text">
+            <input id="alt-name" name="name" type="text">
+        </p>
+        <p>
+            <input id="alt-source" name="source" type="hidden" value="{{ official_document.source_url }}">
         </p>
         <p>
             <button type="button" class="button secondary js-bulk-known-person-alternate-name-cancel">Cancel</button>

--- a/bulk_adding/templates/bulk_add/add_form.html
+++ b/bulk_adding/templates/bulk_add/add_form.html
@@ -1,7 +1,16 @@
 {% extends "base.html" %}
 {% load humanize %}
+{% load pipeline %}
 
 {% block title %}Add candidates from nomination paper{% endblock %}
+
+{% block extra_css %}
+{% stylesheet 'bulk_adding' %}
+{% endblock %}
+
+{% block extra_js %}
+{% javascript 'bulk_adding' %}
+{% endblock %}
 
 {% block content %}
 <h2>Add candidates to {{ election_obj.name }}: <a href="{% url 'constituency' election=election_obj.slug post_id=post_extra.slug ignored_slug=post_extra.base.area.name|slugify %}">{{ post_extra.base.area.name }}</a></h2>
@@ -29,18 +38,36 @@
 {% if known_people %}
 <h3>There {{ known_people|pluralize:"is,are" }} {{ known_people|length|apnumber }} candidate{{ known_people|pluralize }} listed in this area already:</h3>
 <p>If {{ known_people|pluralize:"this person is,any of these people are" }} not listed on the nomination paper, please press edit and mark them as not standing in this specific election.</p>
-<ul>
+<ul class="bulk-add__known-people">
   {% for person in known_people %}
     <li>
         <a href="{% url 'person-view' person.pk %}" target="_blank">
-            {{ person }} ({{ person.party.name }})
+            <strong>{{ person }}</strong> ({{ person.party.name }})
         </a>
         <a href="{% url 'person-update' person.pk%}" class="button secondary tiny">
-            edit
+            Edit candidate
         </a>
+        <a href="#" class="button secondary tiny js-bulk-known-person-alternate-name">
+            Nomination paper shows different name variant
+        </a>
+        <!-- <a href="#" class="button secondary tiny">
+            Not standing
+        </a> -->
     </li>
   {% endfor %}
 </ul>
+<script type="text/html" class="js-bulk-known-person-alternate-name-form">
+    <form action="." method="post">
+        <p>
+            <label for="alt-name">Name as it appears on nomination paper:</label>
+            <input id="alt-name" type="text">
+        </p>
+        <p>
+            <button type="button" class="button secondary js-bulk-known-person-alternate-name-cancel">Cancel</button>
+            <button type="submit" class="button primary">Add alternate name</button>
+        </p>
+    </form>
+</script>
 {% endif %}
 <form method=POST id="bulk_add_form">
   {% if known_people %}

--- a/mysite/settings/conf.py
+++ b/mysite/settings/conf.py
@@ -364,6 +364,12 @@ def get_settings(conf_file_leafname, election_app=None, tests=False):
                     ),
                     'output_filename': 'css/official_documents.css',
                 },
+                'bulk_adding': {
+                    'source_filenames': (
+                        'bulk_adding/css/bulk.scss',
+                    ),
+                    'output_filename': 'css/bulk_adding.css',
+                },
                 'all': {
                     'source_filenames': (
                         'candidates/style.scss',
@@ -385,6 +391,12 @@ def get_settings(conf_file_leafname, election_app=None, tests=False):
                         'moderation_queue/js/crop.js',
                     ),
                     'output_filename': 'js/image-review.js',
+                },
+                'bulk_adding': {
+                    'source_filenames': (
+                        'bulk_adding/js/bulk.js',
+                    ),
+                    'output_filename': 'js/bulk_adding.js',
                 },
                 'all': {
                     'source_filenames': (


### PR DESCRIPTION
This adds an inline form for adding to the alternative names of existing candidates on the bulk editing page.

![screen shot 2017-05-09 at 10 30 17](https://cloud.githubusercontent.com/assets/5310/25844492/8d26d5fc-34a2-11e7-96a7-a535862a3b03.png)
![screen shot 2017-05-09 at 10 30 30](https://cloud.githubusercontent.com/assets/5310/25844496/8ef16406-34a2-11e7-82a7-ca5a39c30f76.png)
![alternate-names](https://cloud.githubusercontent.com/assets/739624/25853394/877b4238-34c4-11e7-8fff-393c50edc6b2.png)

