### PR TITLE
Remove duplicate gutter either side of header nav

### DIFF
--- a/mysite/templates/generic_base.html
+++ b/mysite/templates/generic_base.html
@@ -71,40 +71,32 @@
       </div>
     </div>
     <div class="header__nav">
-      <div class="container">
-        <div class="row">
-          <div class="columns large-6">
-            <ul class="nav-links">
-              {% block menu_bar_links %}
-                <li class="nav-links__item"><a href="{% url 'help-about' %}">{% trans "About" %}</a></li>
-                <li class="nav-links__item"><a href="{% url 'posts' %}">{% trans "Posts" %}</a></li>
-                <li class="nav-links__item"><a href="{% url 'reports_home' %}">{% trans "Numbers" %}</a></li>
-              {% endblock %}
-            </ul>
-          </div>
+      <div class="row">
 
-
-        {% if not hide_search_form %}
-          <div class="column large-6">
-            <form id="person_search_header" class="header__nav__search" action="{% url 'person-search' %}">
-              <div class="row collapse postfix-radius">
-                <div class="columns large-8">
-                  <input type="text" name="q" placeholder="{% trans 'Enter a name or postcode' %}">
-                </div>
-                <div class="columns large-4">
-                  <button type="submit" class="postfix">{% trans 'Search' %}</button>
-                </div>
-              </div>
-            </form>
-          </div>
-          {% endif %}
-
-
-
+        <div class="columns large-6">
+          <ul class="nav-links">
+            {% block menu_bar_links %}
+              <li class="nav-links__item"><a href="{% url 'help-about' %}">{% trans "About" %}</a></li>
+              <li class="nav-links__item"><a href="{% url 'posts' %}">{% trans "Posts" %}</a></li>
+              <li class="nav-links__item"><a href="{% url 'reports_home' %}">{% trans "Numbers" %}</a></li>
+            {% endblock %}
+          </ul>
         </div>
 
-
-
+      {% if not hide_search_form %}
+        <div class="column large-6">
+          <form id="person_search_header" class="header__nav__search" action="{% url 'person-search' %}">
+            <div class="row collapse postfix-radius">
+              <div class="columns large-8">
+                <input type="text" name="q" placeholder="{% trans 'Enter a name or postcode' %}">
+              </div>
+              <div class="columns large-4">
+                <button type="submit" class="postfix">{% trans 'Search' %}</button>
+              </div>
+            </div>
+          </form>
+        </div>
+      {% endif %}
 
       </div>
     </div>


### PR DESCRIPTION
Super small styling fix – just to remove the double gutter that was causing the `.header_nav` and search box not to line up properly with the rest of the page grid.

(Sorry the diff looks kinda scary – I re-indented it all, after removing the `.container` wrapper. https://github.com/DemocracyClub/yournextrepresentative/pull/187/files?w=1 is a cleaner diff view, without the whitespace changes.)

**Before:** (desktop)

![screen shot 2017-05-09 at 15 35 03](https://cloud.githubusercontent.com/assets/739624/25856167/1c1c28a0-34cd-11e7-8e56-e23431384167.png)

**After:** (desktop)

![screen shot 2017-05-09 at 15 31 45](https://cloud.githubusercontent.com/assets/739624/25856170/1f70e7f2-34cd-11e7-8a4f-a89202ac990f.png)

**After:** (mobile)

![screen shot 2017-05-09 at 15 32 07](https://cloud.githubusercontent.com/assets/739624/25856177/226435f4-34cd-11e7-80f3-d1fcfe2564ae.png)
