### PR TITLE
Add photo policy text

### DIFF
--- a/candidates/templates/candidates/about.html
+++ b/candidates/templates/candidates/about.html
@@ -67,6 +67,14 @@ The privacy policy of this site can be found
 <a href="{{ url }}">here</a>.
 {% endblocktrans %}</p>
 
+<h3>{% trans "Photo Policy" %}</h3>
+
+{% url 'help-photo-policy' as url %}
+<p>{% blocktrans trimmed %}
+The photo policy of this site can be found
+<a href="{{ url }}">here</a>.
+{% endblocktrans %}</p>
+
 <h3>{% trans "Disclaimer" %}</h3>
 
 <p>{% blocktrans trimmed %}

--- a/candidates/templates/candidates/photo-policy.html
+++ b/candidates/templates/candidates/photo-policy.html
@@ -1,0 +1,18 @@
+{% extends 'base.html' %}
+{% load i18n %}
+
+{% block body_class %}{% endblock %}
+
+{% block title %}{% trans "Photo policy" %}{% endblock %}
+
+{% block hero %}
+  <h1>{% trans "Photo policy" %}</h1>
+{% endblock %}
+
+{% block content %}
+
+<div class="help-about">
+{% include 'moderation_queue/_photo-policy.html' %}
+</div>
+
+{% endblock %}

--- a/candidates/tests/test_help_pages.py
+++ b/candidates/tests/test_help_pages.py
@@ -2,6 +2,22 @@ from django_webtest import WebTest
 
 
 class TestHelpPages(WebTest):
+    def test_about_page(self):
+        response = self.app.get('/help/about')
+        self.assertContains(response, '<h1>About this site</h1>')
+
+    def test_about_page_links_to_privacy_policy(self):
+        response = self.app.get('/help/about')
+        self.assertContains(response, '<a href="/help/privacy">here</a>')
+
+    def test_about_page_links_to_photo_policy(self):
+        response = self.app.get('/help/about')
+        self.assertContains(response, '<a href="/help/photo-policy">here</a>')
+
+    def test_privacy_policy(self):
+        response = self.app.get('/help/privacy')
+        self.assertContains(response, '<h1>Privacy policy</h1>')
+
     def test_photo_policy(self):
         response = self.app.get('/help/photo-policy')
         self.assertContains(response, '<h1>Photo policy</h1>')

--- a/candidates/tests/test_help_pages.py
+++ b/candidates/tests/test_help_pages.py
@@ -1,0 +1,7 @@
+from django_webtest import WebTest
+
+
+class TestHelpPages(WebTest):
+    def test_photo_policy(self):
+        response = self.app.get('/help/photo-policy')
+        self.assertContains(response, '<h1>Photo policy</h1>')

--- a/candidates/urls.py
+++ b/candidates/urls.py
@@ -247,6 +247,11 @@ patterns_to_format = [
         'name': 'help-privacy'
     },
     {
+        'pattern': r'^help/photo-policy$',
+        'view': TemplateView.as_view(template_name="candidates/photo-policy.html"),
+        'name': 'help-photo-policy'
+    },
+    {
         'pattern': r'^copyright-question$',
         'view': views.AskForCopyrightAssigment.as_view(),
         'name': 'ask-for-copyright-assignment'

--- a/elections/uk/templates/candidates/about.html
+++ b/elections/uk/templates/candidates/about.html
@@ -90,6 +90,14 @@ The privacy policy of this site can be found
 <a href="{{ url }}">here</a>.
 {% endblocktrans %}</p>
 
+<h3>{% trans "Photo Policy" %}</h3>
+
+{% url 'help-photo-policy' as url %}
+<p>{% blocktrans trimmed %}
+The photo policy of this site can be found
+<a href="{{ url }}">here</a>.
+{% endblocktrans %}</p>
+
 <h3>{% trans "Disclaimer" %}</h3>
 
 <p>{% blocktrans trimmed %}

--- a/moderation_queue/templates/moderation_queue/_photo-policy.html
+++ b/moderation_queue/templates/moderation_queue/_photo-policy.html
@@ -1,0 +1,10 @@
+<h2>Photo policy</h2>
+
+<p><strong>The photo must be a clear, recent, colour headshot of the candidate.</strong></p>
+
+<p>
+  No text or party logos may be included in the photo, unless an unavoidable
+  part of the background or a small rosette/badge that doesn’t interfere with
+  the rule above. Any photo containing party text or logos should be replaced
+  by a plain photo whenever one is available.
+</p>

--- a/moderation_queue/templates/moderation_queue/_photo-policy.html
+++ b/moderation_queue/templates/moderation_queue/_photo-policy.html
@@ -1,10 +1,12 @@
-<h2>Photo policy</h2>
+{% load i18n %}
 
-<p><strong>The photo must be a clear, recent, colour headshot of the candidate.</strong></p>
+<h2>{% trans 'Photo policy' %}</h2>
 
-<p>
+<p><strong>{% trans 'The photo must be a clear, recent, colour headshot of the candidate.' %}</strong></p>
+
+<p>{% blocktrans trimmed %}
   No text or party logos may be included in the photo, unless an unavoidable
   part of the background or a small rosette/badge that doesn’t interfere with
   the rule above. Any photo containing party text or logos should be replaced
   by a plain photo whenever one is available.
-</p>
+{% endblocktrans %}</p>

--- a/moderation_queue/templates/moderation_queue/photo-review.html
+++ b/moderation_queue/templates/moderation_queue/photo-review.html
@@ -26,17 +26,7 @@
 
   <p>{{ form.errors }}</p>
 
-  <h2>Photo policy</h2>
-
-  <p><strong>The photo must be a clear, recent, colour headshot of the candidate.</strong></p>
-
-  <p>
-    No text or party logos may be included in the photo, unless an unavoidable
-    part of the background or a small rosette/badge that doesn’t interfere with
-    the rule above. Any photo containing party text or logos should be replaced
-    by a plain photo whenever one is available.
-  </p>
-
+  {% include 'moderation_queue/_photo-policy.html' %}
 
   {% url 'person-view' person.id person.name|slugify as url %}
   <p>{% blocktrans trimmed with name=person.name party=person.extra.last_party.name %}

--- a/moderation_queue/templates/moderation_queue/photo-upload-new.html
+++ b/moderation_queue/templates/moderation_queue/photo-upload-new.html
@@ -13,6 +13,7 @@
 
 {% block content %}
 
+{% include 'moderation_queue/_photo-policy.html' %}
 {% include 'moderation_queue/_photo-upload-form.html' with person_id=person.id %}
 
 {% endblock %}

--- a/moderation_queue/tests/test_queue.py
+++ b/moderation_queue/tests/test_queue.py
@@ -237,7 +237,14 @@ class PhotoReviewTests(UK2015ExamplesMixin, WebTest):
         )
         response = self.app.get(review_url, user=self.test_reviewer)
         self.assertEqual(response.status_code, 200)
-        # For the moment this is just a smoke test...
+
+    def test_shows_photo_policy_text(self):
+        review_url = reverse(
+            'photo-review',
+            kwargs={'queued_image_id': self.q1.id}
+        )
+        response = self.app.get(review_url, user=self.test_reviewer)
+        self.assertContains(response, 'Photo policy')
 
     @patch('moderation_queue.views.send_mail')
     @override_settings(DEFAULT_FROM_EMAIL='admins@example.com')

--- a/moderation_queue/tests/test_queue.py
+++ b/moderation_queue/tests/test_queue.py
@@ -2,7 +2,6 @@
 
 from __future__ import unicode_literals
 
-import os
 from os.path import join, realpath, dirname
 import re
 from shutil import rmtree
@@ -24,15 +23,12 @@ from nose.plugins.attrib import attr
 
 from popolo.models import Person
 from ..models import QueuedImage, PHOTO_REVIEWERS_GROUP_NAME, SuggestedPostLock
-from candidates.models import LoggedAction, ImageExtra, PostExtraElection
+from candidates.models import LoggedAction, PostExtraElection
 from official_documents.models import OfficialDocument
 from mysite.helpers import mkdir_p
 
 from candidates.tests.factories import (
-    AreaTypeFactory, ElectionFactory, PostExtraFactory,
-    ParliamentaryChamberFactory, PersonExtraFactory,
-    CandidacyExtraFactory, PartyExtraFactory,
-    PartyFactory, PartySetFactory, AreaFactory
+    PersonExtraFactory, CandidacyExtraFactory,
 )
 from candidates.tests.uk_examples import UK2015ExamplesMixin
 from candidates.tests.auth import TestUserMixin
@@ -85,13 +81,13 @@ class PhotoReviewTests(UK2015ExamplesMixin, WebTest):
             base__person=person_2009.base,
             base__post=self.dulwich_post_extra.base,
             base__on_behalf_of=self.labour_party_extra.base
-            )
+        )
         CandidacyExtraFactory.create(
             election=self.election,
             base__person=person_2007.base,
             base__post=self.dulwich_post_extra.base,
             base__on_behalf_of=self.labour_party_extra.base
-            )
+        )
 
         self.site = Site.objects.create(domain='example.com', name='YNR')
         self.test_upload_user = User.objects.create_user(
@@ -136,7 +132,7 @@ class PhotoReviewTests(UK2015ExamplesMixin, WebTest):
             user=self.test_reviewer
         )
         self.q_no_uploading_user = QueuedImage.objects.create(
-            why_allowed = 'profile-photo',
+            why_allowed='profile-photo',
             justification_for_use='Auto imported from Twitter',
             decision='undecided',
             image=self.storage_filename,
@@ -508,13 +504,13 @@ class SuggestedLockReviewTests(UK2015ExamplesMixin, TestUserMixin, WebTest):
             base__person=person_2009.base,
             base__post=self.dulwich_post_extra.base,
             base__on_behalf_of=self.labour_party_extra.base
-            )
+        )
         CandidacyExtraFactory.create(
             election=self.election,
             base__person=person_2007.base,
             base__post=self.dulwich_post_extra.base,
             base__on_behalf_of=self.labour_party_extra.base
-            )
+        )
 
     def test_suggested_lock_review_view_no_suggestions(self):
         url = reverse('suggestions-to-lock-review-list')

--- a/moderation_queue/tests/test_queue.py
+++ b/moderation_queue/tests/test_queue.py
@@ -181,6 +181,17 @@ class PhotoReviewTests(UK2015ExamplesMixin, WebTest):
         self.assertEqual(queued_image.person.id, 2009)
         self.assertEqual(queued_image.user, self.test_upload_user)
 
+    def test_shows_photo_policy_text_in_photo_upload_page(self):
+        upload_form_url = reverse(
+            'photo-upload',
+            kwargs={'person_id': '2009'}
+        )
+        response = self.app.get(
+            upload_form_url,
+            user=self.test_upload_user
+        )
+        self.assertContains(response, 'Photo policy')
+
     def test_photo_review_queue_view_not_logged_in(self):
         queue_url = reverse('photo-review-list')
         response = self.app.get(queue_url)
@@ -234,7 +245,7 @@ class PhotoReviewTests(UK2015ExamplesMixin, WebTest):
         response = self.app.get(review_url, user=self.test_reviewer)
         self.assertEqual(response.status_code, 200)
 
-    def test_shows_photo_policy_text(self):
+    def test_shows_photo_policy_text_in_photo_review_page(self):
         review_url = reverse(
             'photo-review',
             kwargs={'queued_image_id': self.q1.id}


### PR DESCRIPTION
## Relevant issues

* Closes https://github.com/DemocracyClub/yournextrepresentative/issues/144
* Part 2 of https://github.com/DemocracyClub/yournextrepresentative/issues/150#issuecomment-300105984

## Screenshots

The photo review already had a photo policy:

![photo-review](https://cloud.githubusercontent.com/assets/2157089/25859014/28db465e-34d5-11e7-88af-c24401d8efb3.png)

So a partial template was extracted with the text and added to the upload photo page as well:

![upload-photo](https://cloud.githubusercontent.com/assets/2157089/25859045/3e1b1e18-34d5-11e7-9f7a-9c24ae10b630.png)

A dedicated page was made for this policy so that it could be linked from the About page as issue 144 requires:

![own-page](https://cloud.githubusercontent.com/assets/2157089/25859139/83b29fa0-34d5-11e7-807a-f1d451794419.png)

A link was added in the About page:

![about-page](https://cloud.githubusercontent.com/assets/2157089/25859344/2725a7ea-34d6-11e7-9140-43721e177bae.png)


Finally, a link was added to the footer:
![footer](https://cloud.githubusercontent.com/assets/2157089/25859258/e296070a-34d5-11e7-8d3f-4dcfd12a7d72.png)

