### PR TITLE
Make login options clearer

### DIFF
--- a/candidates/static/candidates/_accounts.scss
+++ b/candidates/static/candidates/_accounts.scss
@@ -1,0 +1,54 @@
+.socialaccount_ballot {
+    max-width: 30em; // to match form.login
+}
+
+.socialaccount_providers {
+    list-style: none;
+    margin-left: 0;
+
+    @media (min-width: $small-breakpoint) {
+        @include flex-container();
+        margin: 1em -0.5em;
+
+        li {
+            margin: 0 0.5em;
+        }
+    }
+}
+
+.socialaccount_provider {
+    @include button-base();
+    @include button-size($button-med, true);
+    @include single-transition(background-color);
+
+    &.facebook {
+        $bg: #3b5998;
+        $bg-hover: scale-color($bg, $lightness: $button-function-factor);
+        @include button-style($bg, $button-radius, false, $bg-hover, $bg-hover);
+    }
+
+    &.google {
+        $bg: #ea4335;
+        $bg-hover: scale-color($bg, $lightness: $button-function-factor);
+        @include button-style($bg, $button-radius, false, $bg-hover, $bg-hover);
+    }
+
+    &.twitter {
+        $bg: #1da1f2;
+        $bg-hover: scale-color($bg, $lightness: $button-function-factor);
+        @include button-style($bg, $button-radius, false, $bg-hover, $bg-hover);
+    }
+}
+
+.login-or {
+    border-top: 1px solid #ddd;
+    text-align: center;
+    margin-bottom: 0.5em;
+
+    span {
+        position: relative;
+        top: -0.75em;
+        background: #fff;
+        padding: 0 1em;
+    }
+}

--- a/candidates/static/candidates/_accounts.scss
+++ b/candidates/static/candidates/_accounts.scss
@@ -52,3 +52,28 @@
         padding: 0 1em;
     }
 }
+
+.login-signup-tabs {
+    @include flex-container();
+    margin: 0 0 1.5em 0;
+    text-align: center;
+    line-height: 1.2em; // make text look better when tabs wrap on narrow screens
+    max-width: 30em; // to match form.login
+
+    & > * {
+        @include flex(1 1 auto);
+        padding: 1em;
+    }
+
+    & > span {
+        border: 1px solid #ddd;
+        border-bottom: 0;
+        border-radius: $button-radius;
+        border-bottom-left-radius: 0;
+        border-bottom-right-radius: 0;
+    }
+
+    & > a {
+        border-bottom: 1px solid #ddd;
+    }
+}

--- a/candidates/static/candidates/mixins.scss
+++ b/candidates/static/candidates/mixins.scss
@@ -32,3 +32,11 @@ $high_dpi_screen: '-webkit-min-device-pixel-ratio: 1.5), (min-resolution: 144dpi
     @content;
   }
 }
+
+@mixin flex-container() {
+  display: -webkit-box;
+  display: -moz-box;
+  display: -ms-flexbox;
+  display: -webkit-flex;
+  display: flex;
+}

--- a/candidates/static/candidates/mixins.scss
+++ b/candidates/static/candidates/mixins.scss
@@ -40,3 +40,11 @@ $high_dpi_screen: '-webkit-min-device-pixel-ratio: 1.5), (min-resolution: 144dpi
   display: -webkit-flex;
   display: flex;
 }
+
+@mixin flex($values) {
+  -webkit-box-flex: $values;
+  -moz-box-flex: $values;
+  -webkit-flex: $values;
+  -ms-flex: $values;
+  flex: $values;
+}

--- a/candidates/static/candidates/style.scss
+++ b/candidates/static/candidates/style.scss
@@ -73,3 +73,4 @@ $high_dpi_screen: '-webkit-min-device-pixel-ratio: 1.5), (min-resolution: 144dpi
 @import "leaderboards";
 @import "search";
 @import "data_timeline";
+@import "accounts";

--- a/mysite/forms.py
+++ b/mysite/forms.py
@@ -2,7 +2,7 @@ from __future__ import unicode_literals
 
 from django import forms
 
-from allauth.account.forms import LoginForm
+from allauth.account.forms import LoginForm, SignupForm
 
 from django.utils.translation import ugettext_lazy as _
 
@@ -12,3 +12,14 @@ class CustomLoginForm(LoginForm):
     def __init__(self, *args, **kwargs):
         super(CustomLoginForm, self).__init__(*args, **kwargs)
         self.fields['login'].label = _('Username or email address')
+        # Remove the placeholder text, which just adds noise:
+        for field in ('login', 'password'):
+            del self.fields[field].widget.attrs['placeholder']
+
+
+class CustomSignupForm(SignupForm):
+
+    def __init__(self, *args, **kwargs):
+        super(CustomSignupForm, self).__init__(*args, **kwargs)
+        for field in ('username', 'email', 'password1', 'password2'):
+            del self.fields[field].widget.attrs['placeholder']

--- a/mysite/settings/conf.py
+++ b/mysite/settings/conf.py
@@ -296,6 +296,7 @@ def get_settings(conf_file_leafname, election_app=None, tests=False):
         'ACCOUNT_EMAIL_REQUIRED': True,
         'ACCOUNT_FORMS': {
             'login': 'mysite.forms.CustomLoginForm',
+            'signup': 'mysite.forms.CustomSignupForm',
         },
         'ACCOUNT_USERNAME_REQUIRED': True,
         'ACCOUNT_USERNAME_VALIDATORS': 'mysite.helpers.allauth_validators',

--- a/mysite/templates/account/login.html
+++ b/mysite/templates/account/login.html
@@ -6,7 +6,7 @@
 {% block head_title %}{% trans "Sign In" %}{% endblock %}
 
 {% block hero %}
-  <h1>{% trans "Sign in, or create an account" %}</h1>
+  <h1>{% trans "Sign in" %}</h1>
 {% endblock %}
 
 {% block content %}
@@ -14,27 +14,13 @@
 {% get_providers as socialaccount_providers %}
 
 {% if socialaccount_providers  %}
-<p>
-    {% blocktrans trimmed with site.name as site_name %}
-    If you've created an account on this site before then
-     please sign in with your username and password or one of the social account providers below.
-    {% endblocktrans %}
-</p>
-
-<div class="socialaccount_ballot">
-  <ul class="socialaccount_providers">
-    {% include "socialaccount/snippets/provider_list.html" with process="login" %}
-  </ul>
-
-  <p class="login-or">{% trans 'Or sign in with your email/username and password:' %}</p>
-
-</div>
-
-{% include "socialaccount/snippets/login_extra.html" %}
-
-{% else %}
-<p>{% blocktrans trimmed %}If you have not created an account yet, then please
-<a href="{{ signup_url }}">sign up</a> first.{% endblocktrans %}</p>
+  <div class="socialaccount_ballot">
+    <ul class="socialaccount_providers">
+      {% include "socialaccount/snippets/provider_list.html" with process="login" %}
+    </ul>
+    <p class="login-or"><span>{% trans 'Or' %}</span></p>
+  </div>
+  {% include "socialaccount/snippets/login_extra.html" %}
 {% endif %}
 
 <form class="login" method="POST" action="{% url 'account_login' %}">
@@ -43,11 +29,15 @@
   {% if redirect_field_value %}
   <input type="hidden" name="{{ redirect_field_name }}" value="{{ redirect_field_value }}" />
   {% endif %}
-  <button class="button primaryAction" type="submit">{% trans "Sign in" %}</button>
-  <a class="button secondary secondaryAction tiny" href="{% url 'account_reset_password' %}">{% trans "Forgot password?" %}</a>
+  <p>
+    <button class="button" type="submit">{% trans "Sign in" %}</button>
+    <a class="button secondary" href="{% url 'account_reset_password' %}">{% trans "Forgot password?" %}</a>
+  </p>
 </form>
 
-<p>Or if you've not used this site before, create a new account:</p>
+<h2>Don’t have an account?</h2>
+
+<p>If you’ve not used this site before, create a new account:</p>
 <p><a href="{{ signup_url }}" class="button primaryAction">Create an account</a></p>
 
 {% endblock %}

--- a/mysite/templates/account/login.html
+++ b/mysite/templates/account/login.html
@@ -23,6 +23,11 @@
   {% include "socialaccount/snippets/login_extra.html" %}
 {% endif %}
 
+<div class="login-signup-tabs">
+    <span>I have an account</span>
+    <a href="{{ signup_url }}">I don’t have an account</a>
+</div>
+
 <form class="login" method="POST" action="{% url 'account_login' %}">
   {% csrf_token %}
   {{ form.as_p }}
@@ -34,10 +39,5 @@
     <a class="button secondary" href="{% url 'account_reset_password' %}">{% trans "Forgot password?" %}</a>
   </p>
 </form>
-
-<h2>Don’t have an account?</h2>
-
-<p>If you’ve not used this site before, create a new account:</p>
-<p><a href="{{ signup_url }}" class="button primaryAction">Create an account</a></p>
 
 {% endblock %}

--- a/mysite/templates/account/signup.html
+++ b/mysite/templates/account/signup.html
@@ -1,31 +1,44 @@
 {% extends "account/base.html" %}
 
 {% load i18n %}
+{% load account socialaccount %}
 
-{% block head_title %}{% trans "Signup" %}{% endblock %}
+{% block head_title %}{% trans "Create an account" %}{% endblock %}
 
 {% block hero %}
-  <h1>{% trans "Sign Up" %}</h1>
+  <h1>{% trans "Create an account" %}</h1>
 {% endblock %}
 
 {% block content %}
 
-<p>{% blocktrans %}Already have an account? Then please <a href="{{ login_url }}">sign in</a>.{% endblocktrans %}</p>
-<p>Usernames are made public, so please don't use personal information like an email address as your username</p>
+{% get_providers as socialaccount_providers %}
+
+{% if socialaccount_providers  %}
+  <div class="socialaccount_ballot">
+    <ul class="socialaccount_providers">
+      {% include "socialaccount/snippets/provider_list.html" with process="login" %}
+    </ul>
+    <p class="login-or"><span>{% trans 'Or' %}</span></p>
+  </div>
+  {% include "socialaccount/snippets/login_extra.html" %}
+{% endif %}
+
+<div class="login-signup-tabs">
+    <a href="{{ login_url }}">I have an account</a>
+    <span>I don’t have an account</span>
+</div>
+
 <form class="signup" id="signup_form" method="post" action="{% url 'account_signup' %}">
   {% csrf_token %}
 
+  <p>Usernames are made public, so please don't use personal information like an email address as your username.</p>
 
   {{ form.as_p }}
-
 
   {% if redirect_field_value %}
   <input type="hidden" name="{{ redirect_field_name }}" value="{{ redirect_field_value }}" />
   {% endif %}
-  <button class="button" type="submit">{% trans "Sign Up" %}</button>
+  <button class="button" type="submit">{% trans "Create account" %}</button>
 </form>
 
-
 {% endblock %}
-
-

--- a/mysite/templates/socialaccount/snippets/provider_list.html
+++ b/mysite/templates/socialaccount/snippets/provider_list.html
@@ -1,0 +1,21 @@
+{% load socialaccount %}
+
+{% get_providers as socialaccount_providers %}
+
+{% for provider in socialaccount_providers %}
+{% if provider.id == "openid" %}
+{% for brand in provider.get_brands %}
+<li>
+  <a title="{{brand.name}}"
+     class="socialaccount_provider {{provider.id}} {{brand.id}}"
+     href="{% provider_login_url provider.id openid=brand.openid_url process=process %}"
+     >Sign in with {{brand.name}}</a>
+</li>
+{% endfor %}
+{% endif %}
+<li>
+  <a title="{{provider.name}}" class="socialaccount_provider {{provider.id}}"
+     href="{% provider_login_url provider.id process=process scope=scope auth_params=auth_params %}">Sign in with {{provider.name}}</a>
+</li>
+{% endfor %}
+


### PR DESCRIPTION
Attempt at fixing #183.

* More prominent social login buttons, using social network brand colours.
* Social login buttons now appear on both the Signup and Login pages (since they _should_ work for both new and returning users).
* New "tab" component to navigate between Signup and Login – brings the "I need an account" decision further up the page in a natural way.
* Signup and Login pages share almost identical styling, to make the "tab" UX convincing.
* Lots of superfluous text removed from both pages.

**Login – narrow screen:**

![login-narrow](https://cloud.githubusercontent.com/assets/739624/25893905/b13b5de4-3571-11e7-87c9-b426c83e1019.png)

**Login – wide screen:**

![login](https://cloud.githubusercontent.com/assets/739624/25893908/b5941c50-3571-11e7-8d22-7c28466629cc.png)

**Signup – narrow screen:**

![signup-narrow](https://cloud.githubusercontent.com/assets/739624/25893912/ba841efe-3571-11e7-8e5b-8a876feea4da.png)

**Signup – wide screen:**

![signup](https://cloud.githubusercontent.com/assets/739624/25893916/beef09a4-3571-11e7-8024-1507d60e265b.png)
