### PR TITLE
Bulk edit mark not standing

### DIFF
--- a/bulk_adding/static/bulk_adding/css/bulk.scss
+++ b/bulk_adding/static/bulk_adding/css/bulk.scss
@@ -26,4 +26,15 @@
         }
     }
 
+    .js-bulk-known-person-not-standing {
+        display: none;
+    }
+}
+
+.js {
+    .bulk-add__known-people {
+        .js-bulk-known-person-not-standing {
+            display: inline;
+        }
+    }
 }

--- a/bulk_adding/static/bulk_adding/js/bulk.js
+++ b/bulk_adding/static/bulk_adding/js/bulk.js
@@ -61,7 +61,12 @@ $(function(){
 
         $person = $(this).parents('li');
         $link = $person.find('.js-bulk-known-person-alternate-name')
-        $form = $( $('.js-bulk-known-person-alternate-name-form').html() );
+        $form = $person.find('form');
+        // don't add the form twice
+        if ($form.length == 0) {
+            $form = $( $('.js-bulk-known-person-alternate-name-form').html() );
+            $form.appendTo($person);
+        }
         $form.appendTo($person);
         $form.find('input[type="text"]').focus();
 

--- a/bulk_adding/static/bulk_adding/js/bulk.js
+++ b/bulk_adding/static/bulk_adding/js/bulk.js
@@ -1,4 +1,61 @@
 $(function(){
+    $('body').removeClass('no-js').addClass('js');
+
+    $('.js-bulk-known-person-not-standing').on('click', function(e){
+        e.preventDefault();
+
+        $person = $(this).parents('li');
+        $link = $person.find('.js-bulk-known-person-not-standing')
+        $form = $person.find('form');
+        // don't add the form twice
+        if ($form.length == 0) {
+            $form = $( $('.js-bulk-known-person-not-standing-form').html() );
+            $form.appendTo($person);
+        }
+        $form.find('input[type="text"]').focus();
+
+        $form.on('submit', function(){
+            $form.find('#candidacyerr').remove();
+            $form.find('.alert').remove();
+            $form.find('.errorlist').remove();
+            $source = $form.find('input[name="source"]').val();
+            $.ajax({
+                url: $link.attr('href'),
+                type: "POST",
+                data: {
+                    csrfmiddlewaretoken: $form.find('input[type="hidden"]').val(),
+                    person_id: $link.data('person-id'),
+                    post_id: $link.data('post-id'),
+                    source : $form.find('input[name="source"]').val()
+                },
+
+                success: function(json) {
+                    if (json['success']) {
+                        $person.remove();
+                    } else {
+                        if (json['errors']) {
+                            for (var err in json.errors) {
+                                if (!json.errors.hasOwnProperty(err)) { continue; }
+                                el = $form.find('input[name="' + err + '"]');
+                                el.before('<ul class="errorlist"><li>' + json.errors[err] + '</li></ul>')
+                            }
+                        }
+                    }
+                },
+
+                error: function(xhr,errmsg,err) {
+                    $form.prepend("<div class='alert-box alert radius' id='candidacyerr'>There was a problem removing the candidacy, please try again</div>");
+                }
+            });
+            return false;
+        });
+
+
+        $form.on('click', '.js-bulk-known-person-not-standing-cancel', function(){
+            $form.remove();
+        });
+    });
+
     $('.js-bulk-known-person-alternate-name').on('click', function(e){
         e.preventDefault();
 

--- a/bulk_adding/templates/bulk_add/add_form.html
+++ b/bulk_adding/templates/bulk_add/add_form.html
@@ -58,9 +58,9 @@
         <a href="{% url 'person-other-name-create' person.pk %}" class="button secondary tiny js-bulk-known-person-alternate-name">
             Nomination paper shows different name variant
         </a>
-        <!-- <a href="#" class="button secondary tiny">
+        <a data-person-id="{{ person.pk }}" data-post-id="{{ post_extra.slug }}" href="{% url 'candidacy-delete' election=election %}" class="button secondary tiny js-bulk-known-person-not-standing">
             Not standing
-        </a> -->
+        </a>
     </li>
   {% endfor %}
 </ul>
@@ -77,6 +77,19 @@
         <p>
             <button type="button" class="button secondary js-bulk-known-person-alternate-name-cancel">Cancel</button>
             <button type="submit" class="button primary">Add alternate name</button>
+        </p>
+    </form>
+</script>
+<script type="text/html" class="js-bulk-known-person-not-standing-form">
+<form action="" method="post">
+        {% csrf_token %}
+        <p>
+            Are you sure you want to mark this candidate as not standing?
+            <input id="alt-source" name="source" type="hidden" value="{{ official_document.source_url }}">
+        </p>
+        <p>
+            <button type="button" class="button secondary js-bulk-known-person-not-standing-cancel">Cancel</button>
+            <button type="submit" class="button primary">Mark Not Standing</button>
         </p>
     </form>
 </script>

--- a/candidates/views/candidacies.py
+++ b/candidates/views/candidacies.py
@@ -4,6 +4,7 @@ from django.views.generic import FormView
 from django.utils.translation import ugettext as _
 from django.shortcuts import get_object_or_404
 from django.db import transaction
+from django.http import JsonResponse
 
 from braces.views import LoginRequiredMixin
 
@@ -121,7 +122,22 @@ class CandidacyDeleteView(ElectionMixin, LoginRequiredMixin, FormView):
 
             person.extra.record_version(change_metadata)
             person.extra.save()
+        if self.request.is_ajax():
+            return JsonResponse({'success': True})
         return get_redirect_to_post(self.election, post)
+
+    def form_invalid(self, form):
+        result = super(
+            CandidacyDeleteView, self
+        ).form_invalid(form)
+        if self.request.is_ajax():
+            data = {
+                'success': False,
+                'errors': form.errors
+            }
+            return JsonResponse(data)
+
+        return result
 
     def get_context_data(self, **kwargs):
         context = super(CandidacyDeleteView, self).get_context_data(**kwargs)


### PR DESCRIPTION
Add a JS only button to the bulk editing form to allow existing candidates to be marked as not standing without leaving the page. It sets the URL for the SOPN as the source.

![screen shot 2017-05-09 at 17 27 37](https://cloud.githubusercontent.com/assets/5310/25861508/df7cf3b0-34dc-11e7-951a-5f03b3240a52.png)
![screen shot 2017-05-09 at 17 32 12](https://cloud.githubusercontent.com/assets/5310/25861735/7792bc3e-34dd-11e7-9ec1-e87df6294e50.png)
