### PR TITLE
Migrate SuggestedPostLock to be associated with a PostExtraElection

### DIFF
--- a/candidates/views/constituencies.py
+++ b/candidates/views/constituencies.py
@@ -106,21 +106,25 @@ class ConstituencyDetailView(ElectionMixin, TemplateView):
         context['candidates_locked'] = is_post_locked(mp_post, self.election_data)
 
         if hasattr(mp_post, 'extra'):
-            context['has_lock_suggestion'] = any(
-                [spl.election_for_suggestion for spl in
-                SuggestedPostLock.objects.filter(post_extra=mp_post.extra)])
+            # FIXME: Sym has a pending change which adds the
+            # PostExtraElection to the context earlier anyway, so this
+            # is just temporary.
+            pee = PostExtraElection.objects.get(
+                postextra=mp_post.extra,
+                election=self.election_data)
+
+            context['has_lock_suggestion'] = \
+                SuggestedPostLock.objects.filter(postextraelection=pee).exists()
 
             context['suggest_lock_form'] = SuggestedPostLockForm(
-                initial={
-                    'post_extra': mp_post.extra
-                },
+                initial={'postextraelection': pee},
             )
 
             if self.request.user.is_authenticated():
                 context['user_has_suggested_lock'] = \
                     SuggestedPostLock.objects.filter(
                         user=self.request.user,
-                        post_extra=mp_post.extra
+                        postextraelection=pee,
                     ).exists()
 
         context['lock_form'] = ToggleLockForm(

--- a/candidates/views/constituencies.py
+++ b/candidates/views/constituencies.py
@@ -293,7 +293,7 @@ class ConstituencyListView(ElectionMixin, TemplateView):
                 election=self.election_data
             ).order_by('postextra__base__label') \
             .select_related('postextra__base') \
-            .prefetch_related('postextra__suggestedpostlock_set')
+            .prefetch_related('suggestedpostlock_set')
 
         return context
 

--- a/elections/models.py
+++ b/elections/models.py
@@ -195,7 +195,7 @@ class Election(models.Model):
                     'postextraelection_set',
                     PostExtraElection.objects.select_related('postextra__base') \
                         .order_by('postextra__base__label')\
-                        .prefetch_related('postextra__suggestedpostlock_set')
+                        .prefetch_related('suggestedpostlock_set')
                 ),
             )
         if not include_noncurrent:

--- a/elections/uk/templates/uk/constituency.html
+++ b/elections/uk/templates/uk/constituency.html
@@ -46,7 +46,7 @@
         {% if request.user.is_authenticated %}
           {% if not user_has_suggested_lock %}
             {% if not candidates_locked %}
-                {% if election_data.show_official_documents and official_documents %}
+                {% if election_data.show_official_documents and some_official_documents %}
                 <form method=post id="suggest_lock_form" action="{% url 'constituency-suggest-lock' election_id=election %}">
                     {% csrf_token %}
                     <h3>Suggest locking</h3>
@@ -62,7 +62,7 @@
                     the list is final.</p>
 
 
-                    {{ suggest_lock_form.post_extra }}
+                    {{ suggest_lock_form.postextraelection }}
 
                     {{ suggest_lock_form.justification.label_tag }}
                     <label for="{{ suggest_lock_form.justification.id_for_label }}">{{ suggest_lock_form.justification.help_text }}</label>

--- a/elections/uk/tests/test_post_view.py
+++ b/elections/uk/tests/test_post_view.py
@@ -1,0 +1,56 @@
+from __future__ import unicode_literals
+
+from django_webtest import WebTest
+
+from official_documents.models import OfficialDocument
+
+from nose.plugins.attrib import attr
+
+from candidates.models import PostExtraElection
+from candidates.tests.auth import TestUserMixin
+from candidates.tests.uk_examples import UK2015ExamplesMixin
+
+
+@attr(country='uk')
+class TestConstituencyDetailView(TestUserMixin, UK2015ExamplesMixin, WebTest):
+
+    def test_suggest_post_lock_offered_with_document_when_unlocked(self):
+        OfficialDocument.objects.create(
+            election=self.election,
+            post=self.edinburgh_east_post_extra.base,
+            source_url='http://example.com',
+            document_type=OfficialDocument.NOMINATION_PAPER,
+            uploaded_file="sopn.pdf"
+        )
+        response = self.app.get(
+            '/election/2015/post/14419/edinburgh-east',
+            user=self.user,
+        )
+        self.assertIn('suggest_lock_form', response.forms)
+
+    def test_suggest_post_lock_not_offered_without_document_when_unlocked(self):
+        response = self.app.get(
+            '/election/2015/post/14419/edinburgh-east',
+            user=self.user,
+        )
+        self.assertNotIn('suggest_lock_form', response.forms)
+        
+    def test_suggest_post_lock_not_offered_with_document_when_locked(self):
+        pee = PostExtraElection.objects.get(
+            election__slug='2015',
+            postextra__slug='14419',
+        )
+        pee.candidates_locked = True
+        pee.save()
+        OfficialDocument.objects.create(
+            election=self.election,
+            post=self.edinburgh_east_post_extra.base,
+            source_url='http://example.com',
+            document_type=OfficialDocument.NOMINATION_PAPER,
+            uploaded_file="sopn.pdf"
+        )
+        response = self.app.get(
+            '/election/2015/post/14419/edinburgh-east',
+            user=self.user,
+        )
+        self.assertNotIn('suggest_lock_form', response.forms)

--- a/elections/uk/tests/test_post_view.py
+++ b/elections/uk/tests/test_post_view.py
@@ -2,6 +2,7 @@ from __future__ import unicode_literals
 
 from django_webtest import WebTest
 
+from moderation_queue.models import SuggestedPostLock
 from official_documents.models import OfficialDocument
 
 from nose.plugins.attrib import attr
@@ -34,7 +35,7 @@ class TestConstituencyDetailView(TestUserMixin, UK2015ExamplesMixin, WebTest):
             user=self.user,
         )
         self.assertNotIn('suggest_lock_form', response.forms)
-        
+
     def test_suggest_post_lock_not_offered_with_document_when_locked(self):
         pee = PostExtraElection.objects.get(
             election__slug='2015',
@@ -54,3 +55,31 @@ class TestConstituencyDetailView(TestUserMixin, UK2015ExamplesMixin, WebTest):
             user=self.user,
         )
         self.assertNotIn('suggest_lock_form', response.forms)
+
+    def test_create_suggested_post_lock(self):
+        OfficialDocument.objects.create(
+            election=self.election,
+            post=self.edinburgh_east_post_extra.base,
+            source_url='http://example.com',
+            document_type=OfficialDocument.NOMINATION_PAPER,
+            uploaded_file="sopn.pdf"
+        )
+        response = self.app.get(
+            '/election/2015/post/14419/edinburgh-east',
+            user=self.user,
+        )
+        form = response.forms['suggest_lock_form']
+        form['justification'] = 'I liked totally reviewed the SOPN'
+        response = form.submit()
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(
+            response.location,
+            'http://localhost:80/election/2015/post/14419/edinburgh-east')
+
+        suggested_locks = SuggestedPostLock.objects.all()
+        self.assertEqual(suggested_locks.count(), 1)
+        suggested_lock = suggested_locks.get()
+        self.assertEqual(suggested_lock.postextraelection.postextra.slug, '14419')
+        self.assertEqual(suggested_lock.postextraelection.election.slug, '2015')
+        self.assertEqual(suggested_lock.user, self.user)
+        self.assertEqual(suggested_lock.justification, 'I liked totally reviewed the SOPN')

--- a/moderation_queue/forms.py
+++ b/moderation_queue/forms.py
@@ -69,9 +69,9 @@ class PhotoReviewForm(forms.Form):
 class SuggestedPostLockForm(forms.ModelForm):
     class Meta:
         model = SuggestedPostLock
-        fields = ['justification', 'post_extra',]
+        fields = ['justification', 'postextraelection',]
         widgets = {
-            'post_extra': forms.HiddenInput(),
+            'postextraelection': forms.HiddenInput(),
             'justification': forms.Textarea(
                 attrs={'rows': 1, 'columns': 72}
             )

--- a/moderation_queue/migrations/0018_suggestedpostlock_postextraelection.py
+++ b/moderation_queue/migrations/0018_suggestedpostlock_postextraelection.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('candidates', '0036_postextra_election_unique_togther'),
+        ('moderation_queue', '0017_suggestedpostlock'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='suggestedpostlock',
+            name='postextraelection',
+            field=models.ForeignKey(blank=True, to='candidates.PostExtraElection', null=True),
+        ),
+    ]

--- a/moderation_queue/migrations/0019_migrate_post_extra_to_postextraelection.py
+++ b/moderation_queue/migrations/0019_migrate_post_extra_to_postextraelection.py
@@ -1,0 +1,75 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from collections import defaultdict
+import os
+
+from django.db import migrations, models
+
+def migrate_post_extra_to_postextraelection(apps, schema_editor):
+    SuggestedPostLock = apps.get_model('moderation_queue', 'SuggestedPostLock')
+    for spl in SuggestedPostLock.objects.all():
+        # If there's more than one postextraelection, then make sure
+        # that we create new SuggestedPostLocks for the rest of them:
+        postextraelections = spl.post_extra.postextraelection_set.all()
+        use_for_original, use_for_new_list = \
+            postextraelections[0], postextraelections[1:]
+        # Update the SuggestedPostLock on the original:
+        spl.use_for_original.postextraelection = use_for_original
+        spl.save()
+        # Then if there are any other PostExtraElection objects
+        # associated with the post, create new SuggestPostLocks with
+        # the same metadata for those as well.
+        for postextraelection in use_for_new_list:
+            SuggestedPostLock.objects.create(
+                postextraelection=postextraelection,
+                post_extra=spl.post_extra,
+                user=spl.user,
+                justification=spl.justification
+            )
+    
+def migrate_postextraelection_to_post_extra(apps, schema_editor):
+    # The reverse migration here will probably lose data, since we're
+    # moving from the more expressive model (you can have a suggested
+    # post lock for just one election that a post is associated with)
+    # to the less expressive mmodel (a suggested post lock is for a
+    # post, not specifying which election it applies to). So by
+    # default, this migration will raise an exception to stop you
+    # losing data on rolling back. If you wish to run this reverse
+    # migration anyway, (e.g. in your local dev environment) please
+    # set the environment variable ALLOW_LOSSY_REVERSE_MIGRATIONS to
+    # '1', in which case the exception won't be raised, and a rollback
+    # will be attempted anyway.
+    if os.environ.get('ALLOW_LOSSY_REVERSE_MIGRATIONS') != '1':
+        raise Exception(
+            'Cannot reverse the 0019_migrate_post_extra_to_postextraelection ' \
+            'migration as it will lose data. See the migration file for ' \
+            'details on how to do this anyway.'
+        )    
+    SuggestedPostLock = apps.get_model('moderation_queue', 'SuggestedPostLock')
+    # Group these by postextra, user and justification:
+    grouped = defaultdict(list)
+    for spl in list(SuggestedPostLock.objects.all()):
+        key = (spl.postextraelection.postextra, spl.user, spl.justification)
+        grouped[key].append(spl)
+    # Now just keep one SuggestedPostLock in each of these groups:
+    for t, spls_in_group in grouped.items():
+        to_keep, to_delete_list = spls_in_group[0], spls_in_group[1:]
+        to_keep.post_extra = to_keep.postextraelection.postextra
+        to_keep.save()
+        for to_delete in to_delete_list:
+            to_delete.delete()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('moderation_queue', '0018_suggestedpostlock_postextraelection'),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            migrate_post_extra_to_postextraelection,
+            migrate_postextraelection_to_post_extra,
+        )
+    ]

--- a/moderation_queue/migrations/0020_postextraelection_not_null.py
+++ b/moderation_queue/migrations/0020_postextraelection_not_null.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('moderation_queue', '0019_migrate_post_extra_to_postextraelection'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='suggestedpostlock',
+            name='postextraelection',
+            field=models.ForeignKey(to='candidates.PostExtraElection'),
+        ),
+    ]

--- a/moderation_queue/migrations/0021_remove_suggestedpostlock_post_extra.py
+++ b/moderation_queue/migrations/0021_remove_suggestedpostlock_post_extra.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('moderation_queue', '0020_postextraelection_not_null'),
+    ]
+
+    operations = [
+        migrations.RemoveField(
+            model_name='suggestedpostlock',
+            name='post_extra',
+        ),
+    ]

--- a/moderation_queue/models.py
+++ b/moderation_queue/models.py
@@ -97,7 +97,6 @@ class QueuedImage(models.Model):
 
 class SuggestedPostLock(models.Model):
     postextraelection = models.ForeignKey(PostExtraElection)
-    post_extra = models.ForeignKey(PostExtra)
     user = models.ForeignKey(User, blank=False, null=False)
     created = models.DateTimeField(auto_now_add=True)
     updated = models.DateTimeField(auto_now=True)

--- a/moderation_queue/models.py
+++ b/moderation_queue/models.py
@@ -29,8 +29,8 @@ class CopyrightOptions:
            "on this site")),
         (PROFILE_PHOTO,
          _("This is the candidate's public profile photo from social "
-         "media (e.g. Twitter, Facebook) or their official campaign "
-         "page")),
+           "media (e.g. Twitter, Facebook) or their official campaign "
+           "page")),
         (OTHER,
          _("Other")),
     )
@@ -100,7 +100,8 @@ class SuggestedPostLock(models.Model):
     user = models.ForeignKey(User, blank=False, null=False)
     created = models.DateTimeField(auto_now_add=True)
     updated = models.DateTimeField(auto_now=True)
-    justification = models.TextField(blank=True,
+    justification = models.TextField(
+        blank=True,
         help_text="e.g I've reviewed the nomination paper for this area")
 
     @property

--- a/moderation_queue/models.py
+++ b/moderation_queue/models.py
@@ -96,7 +96,7 @@ class QueuedImage(models.Model):
 
 
 class SuggestedPostLock(models.Model):
-    postextraelection = models.ForeignKey(PostExtraElection, blank=True, null=True)
+    postextraelection = models.ForeignKey(PostExtraElection)
     post_extra = models.ForeignKey(PostExtra)
     user = models.ForeignKey(User, blank=False, null=False)
     created = models.DateTimeField(auto_now_add=True)

--- a/moderation_queue/models.py
+++ b/moderation_queue/models.py
@@ -103,15 +103,3 @@ class SuggestedPostLock(models.Model):
     justification = models.TextField(
         blank=True,
         help_text="e.g I've reviewed the nomination paper for this area")
-
-    @property
-    def election_for_suggestion(self):
-        # This might look like a poor alternative to:
-        #    self.post_extra.elections.filter(current=True)[0]
-        # However, that would negate any advantage from prefetching
-        # the elections in the get_queryset of SuggestLockReviewListView.
-        # Calling .filter() on a prefetched relationship causes an extra
-        # query where as iterating over .all() doesn't.
-        for election in self.post_extra.elections.all():
-            if election.current:
-                return election

--- a/moderation_queue/models.py
+++ b/moderation_queue/models.py
@@ -7,7 +7,7 @@ from django.utils.translation import ugettext_lazy as _
 
 from popolo.models import Person
 
-from candidates.models import PostExtra
+from candidates.models import PostExtra, PostExtraElection
 
 from compat import python_2_unicode_compatible
 
@@ -96,6 +96,7 @@ class QueuedImage(models.Model):
 
 
 class SuggestedPostLock(models.Model):
+    postextraelection = models.ForeignKey(PostExtraElection, blank=True, null=True)
     post_extra = models.ForeignKey(PostExtra)
     user = models.ForeignKey(User, blank=False, null=False)
     created = models.DateTimeField(auto_now_add=True)

--- a/moderation_queue/templates/moderation_queue/suggestedpostlock_review.html
+++ b/moderation_queue/templates/moderation_queue/suggestedpostlock_review.html
@@ -2,11 +2,10 @@
 
 {% block content %}
 <h1>Posts with lock suggestions</h1>
-{% regroup object_list by post_extra.base.label as suggestions_list %}
+{% regroup object_list by postextraelection as suggestions_list %}
 {% for suggestion_post in suggestions_list %}
     {% with suggestion_post.list.0 as suggestion %}
-        {% if suggestion.election_for_suggestion %}
-                <h3><a href="{% url 'constituency' election=suggestion.election_for_suggestion.slug post_id=suggestion.post_extra.slug ignored_slug=suggestion.post_extra.base.label|slugify %}">{{ suggestion_post.grouper }}</a></h3>
+        <h3><a href="{% url 'constituency' election=suggestion_post.grouper.election.slug post_id=suggestion_post.grouper.postextra.slug ignored_slug=suggestion_post.grouper.postextra.short_label|slugify %}">{{ suggestion_post.grouper.postextra.short_label }} in the {{ suggestion_post.grouper.election.name }}</a></h3>
         <ul>
         {% for suggestion in suggestion_post.list %}
         <li>
@@ -18,7 +17,6 @@
         </li>
         {% endfor %}
         </ul>
-        {% endif %}
     {% endwith %}
 {% endfor %}
 <ul>

--- a/moderation_queue/tests/test_queue.py
+++ b/moderation_queue/tests/test_queue.py
@@ -553,8 +553,11 @@ class SOPNReviewRequiredTest(UK2015ExamplesMixin, TestUserMixin, WebTest):
         self.assertContains(response, 'Dulwich')
 
     def test_sopn_review_view_document_with_suggested_lock_not_included(self):
+        postextraelection = self.dulwich_post_extra.postextraelection_set.get(
+            election=self.election
+        )
         SuggestedPostLock.objects.create(
-            post_extra=self.dulwich_post_extra,
+            postextraelection=postextraelection,
             user=self.user,
             justification='test data'
         )

--- a/moderation_queue/tests/test_queue.py
+++ b/moderation_queue/tests/test_queue.py
@@ -24,7 +24,7 @@ from nose.plugins.attrib import attr
 
 from popolo.models import Person
 from ..models import QueuedImage, PHOTO_REVIEWERS_GROUP_NAME, SuggestedPostLock
-from candidates.models import LoggedAction, ImageExtra
+from candidates.models import LoggedAction, ImageExtra, PostExtraElection
 from official_documents.models import OfficialDocument
 from mysite.helpers import mkdir_p
 
@@ -516,8 +516,12 @@ class SuggestedLockReviewTests(UK2015ExamplesMixin, TestUserMixin, WebTest):
         self.assertNotContains(response, '<h3>')
 
     def test_suggested_lock_review_view_with_suggestions(self):
+        pee = PostExtraElection.objects.get(
+            postextra=self.dulwich_post_extra,
+            election=self.election
+        )
         SuggestedPostLock.objects.create(
-            post_extra=self.dulwich_post_extra,
+            postextraelection=pee,
             user=self.user,
             justification='test data'
         )

--- a/moderation_queue/views.py
+++ b/moderation_queue/views.py
@@ -479,13 +479,18 @@ class SuggestLockView(LoginRequiredMixin, CreateView):
             })
 
 class SuggestLockReviewListView(ListView):
+    '''This is the view which lists all post lock suggestions that need review
+
+    Most people will get to this by clicking on the red highlighted 'Post lock suggestions'
+    counter in the header.'''
+
     template_name = "moderation_queue/suggestedpostlock_review.html"
 
     def get_queryset(self):
         return SuggestedPostLock.objects.filter(
-            post_extra__postextraelection__candidates_locked=False).select_related(
-                'user', 'post_extra__base',
-            ).prefetch_related('post_extra__elections')
+            postextraelection__candidates_locked=False).select_related(
+                'user', 'postextraelection__postextra__base', 'postextraelection__election'
+            )
 
 
 class SOPNReviewRequiredView(ListView):

--- a/moderation_queue/views.py
+++ b/moderation_queue/views.py
@@ -12,6 +12,7 @@ from django.contrib.sites.models import Site
 from django.contrib import messages
 from django.core.mail import send_mail
 from django.core.urlresolvers import reverse
+from django.db.models import F
 from django.http import HttpResponseRedirect
 from django.shortcuts import render, get_object_or_404
 from django.template.loader import render_to_string
@@ -494,15 +495,18 @@ class SuggestLockReviewListView(ListView):
 
 
 class SOPNReviewRequiredView(ListView):
+    '''List all post that have a nominations paper, but no lock suggestion'''
+
     template_name = "moderation_queue/sopn-review-required.html"
 
     def get_queryset(self):
         """
-        PostExtras with a document but no lock suggestion
+        PostExtraElection objects with a document but no lock suggestion
         """
-        return PostExtraElection.objects.exclude(
-            postextra__base__officialdocument=None).filter(
-                postextra__suggestedpostlock=None,
+        return PostExtraElection.objects \
+            .filter(
+                postextra__base__officialdocument__election=F('election'),
+                suggestedpostlock__isnull=True,
                 candidates_locked=False,
                 election__current=True).select_related(
                     'postextra__base', 'election').order_by(

--- a/moderation_queue/views.py
+++ b/moderation_queue/views.py
@@ -22,6 +22,7 @@ from django.views.generic import ListView, TemplateView, CreateView
 
 from PIL import Image as PillowImage
 from braces.views import LoginRequiredMixin
+from slugify import slugify
 
 from auth_helpers.views import GroupRequiredMixin
 from candidates.management.images import get_file_md5sum
@@ -458,8 +459,10 @@ class PhotoReview(GroupRequiredMixin, TemplateView):
 
 
 class SuggestLockView(LoginRequiredMixin, CreateView):
+    '''This handles creating a SuggestedPostLock from a form submission'''
+
     model = SuggestedPostLock
-    fields = ['justification', 'post_extra']
+    fields = ['justification', 'postextraelection']
 
     def form_valid(self, form):
         user = self.request.user
@@ -475,8 +478,8 @@ class SuggestLockView(LoginRequiredMixin, CreateView):
     def get_success_url(self):
         return reverse('constituency', kwargs={
                 'election': self.kwargs['election_id'],
-                'post_id': self.object.post_extra.slug,
-                'ignored_slug': self.object.post_extra.slug
+                'post_id': self.object.postextraelection.postextra.slug,
+                'ignored_slug': slugify(self.object.postextraelection.postextra.short_label),
             })
 
 class SuggestLockReviewListView(ListView):

--- a/mysite/context_processors.py
+++ b/mysite/context_processors.py
@@ -69,7 +69,7 @@ def add_notification_data(request):
         result['photos_for_review'] = \
             QueuedImage.objects.filter(decision='undecided').count()
         result['suggestions_to_lock'] = \
-            SuggestedPostLock.objects.filter(post_extra__postextraelection__candidates_locked=False).count()
+            SuggestedPostLock.objects.filter(postextraelection__candidates_locked=False).count()
     return result
 
 

--- a/official_documents/templates/official_documents/posts_for_document.html
+++ b/official_documents/templates/official_documents/posts_for_document.html
@@ -15,13 +15,13 @@
     area{{ document_posts.count|pluralize }}.</p>
 
 <ul>
-  {% for document, locked in document_posts %}
+  {% for document, locked, lock_suggested in document_posts %}
     <li>
      <a href="{% url 'constituency' election=document.election.slug post_id=document.post.extra.slug ignored_slug=document.post.extra.base.label|slugify %}">
         {{ document.post.extra.base.label }}</a>
         {% if locked %}
          - <abbr title="Candidates verified and post locked">🔒</abbr>
-        {% elif document.post.extra.suggestedpostlock_set.exists %}
+        {% elif lock_suggested %}
         - <abbr title="Someone suggested locking this post">🔓</abbr>
         {% else %}
         <a href="{% url 'bulk_add' election=document.election.slug post_id=document.post.extra.slug %}" class="button tiny">

--- a/official_documents/views.py
+++ b/official_documents/views.py
@@ -56,8 +56,6 @@ class PostsForDocumentView(DetailView):
             source_url=self.object.source_url
         ).select_related(
             'post__extra', 'election'
-        ).prefetch_related(
-            'post__extra__suggestedpostlock_set'
         )
 
         """
@@ -67,7 +65,14 @@ class PostsForDocumentView(DetailView):
         make the code and the template unpleasant.
         """
         context['document_posts'] = [
-            (document, is_post_locked(document.post, document.election))
+            (
+                document,
+                is_post_locked(document.post, document.election),
+                SuggestedPostLock.objects.filter(
+                    postextraelection__postextra=document.post.extra,
+                    postextraelection__election=document.election,
+                ).exists()
+            )
             for document in documents
         ]
         return context


### PR DESCRIPTION
This is a followup to @struan's change to migrate `candidates_locked` from `PostExtra` to `PostExtraElection`. This similarly updates `SuggestedPostLock`, which previously was only specific to a `PostExtra`, not the the post + election combination represented by a `PostExtraElection`.

I've split this change up into the migrations, and then approximately a commit per class that needed to be updated, which I hope makes it easier to follow, even if the site wouldn't completely work until all of them had been applied.

This commit also adds some tests for some more of the existing suggested post lock functionality.