### PR TITLE
Fix a stupid error in the SuggestedPostLock data migration

### DIFF
--- a/moderation_queue/migrations/0019_migrate_post_extra_to_postextraelection.py
+++ b/moderation_queue/migrations/0019_migrate_post_extra_to_postextraelection.py
@@ -15,7 +15,7 @@ def migrate_post_extra_to_postextraelection(apps, schema_editor):
         use_for_original, use_for_new_list = \
             postextraelections[0], postextraelections[1:]
         # Update the SuggestedPostLock on the original:
-        spl.use_for_original.postextraelection = use_for_original
+        spl.postextraelection = use_for_original
         spl.save()
         # Then if there are any other PostExtraElection objects
         # associated with the post, create new SuggestPostLocks with


### PR DESCRIPTION
Mistakenly, my testing of this was against a database with no
SuggestedPostLock objects, so it succeeded despite this error.
Sigh.