### PR TITLE
Home page speed up

### DIFF
--- a/candidates/migrations/0037_auto_20170510_2200.py
+++ b/candidates/migrations/0037_auto_20170510_2200.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('candidates', '0036_postextra_election_unique_togther'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='loggedaction',
+            name='created',
+            field=models.DateTimeField(auto_now_add=True, db_index=True),
+        ),
+    ]

--- a/candidates/models/db.py
+++ b/candidates/models/db.py
@@ -51,7 +51,7 @@ class LoggedAction(models.Model):
     person = models.ForeignKey(Person, blank=True, null=True)
     action_type = models.CharField(max_length=64)
     popit_person_new_version = models.CharField(max_length=32)
-    created = models.DateTimeField(auto_now_add=True)
+    created = models.DateTimeField(auto_now_add=True, db_index=True)
     updated = models.DateTimeField(auto_now=True)
     ip_address = models.CharField(max_length=50, blank=True, null=True)
     source = models.TextField()

--- a/candidates/views/mixins.py
+++ b/candidates/views/mixins.py
@@ -24,7 +24,7 @@ class ContributorsMixin(object):
         for title, since in boards:
             interesting_actions=LoggedAction.objects.exclude(
                 action_type='set-candidate-not-elected'
-            ).select_related('user')
+            )
 
             if since:
                 qs = interesting_actions.filter(created__gt=since)

--- a/elections/uk/views/frontpage.py
+++ b/elections/uk/views/frontpage.py
@@ -139,45 +139,12 @@ class ConstituencyPostcodeFinderView(ContributorsMixin, FormView):
             context['votes_percent'] = 0
 
         # context['council_election_percent'] = council_confirmed / council_total * 100
-        scotland_election_ids = [
-            "local.aberdeen-city.2017-05-04",
-            "local.aberdeenshire.2017-05-04",
-            "local.angus.2017-05-04",
-            "local.argyll-and-bute.2017-05-04",
-            "local.clackmannanshire.2017-05-04",
-            "local.eilean-siar.2017-05-04",
-            "local.dumfries-and-galloway.2017-05-04",
-            "local.dundee-city.2017-05-04",
-            "local.east-ayrshire.2017-05-04",
-            "local.east-dunbartonshire.2017-05-04",
-            "local.east-lothian.2017-05-04",
-            "local.east-renfrewshire.2017-05-04",
-            "local.city-of-edinburgh.2017-05-04",
-            "local.falkirk.2017-05-04",
-            "local.fife.2017-05-04",
-            "local.glasgow-city.2017-05-04",
-            "local.highland.2017-05-04",
-            "local.inverclyde.2017-05-04",
-            "local.midlothian.2017-05-04",
-            "local.moray.2017-05-04",
-            "local.north-ayrshire.2017-05-04",
-            "local.north-lanarkshire.2017-05-04",
-            "local.orkney-islands.2017-05-04",
-            "local.perth-and-kinross.2017-05-04",
-            "local.renfrewshire.2017-05-04",
-            "local.the-scottish-borders.2017-05-04",
-            "local.shetland-islands.2017-05-04",
-            "local.south-ayrshire.2017-05-04",
-            "local.south-lanarkshire.2017-05-04",
-            "local.stirling.2017-05-04",
-            "local.west-dunbartonshire.2017-05-04",
-            "local.west-lothian.2017-05-04",
-        ]
 
-        election_qs = Election.objects.filter(
-            election_date="2017-05-04").exclude(slug__in=scotland_election_ids)
-        context['scotland_sopn_progress'] = self.sopn_progress_by_election(
-            election_qs=election_qs)
+
+        # election_qs = Election.objects.filter(
+        #     election_date="2017-05-04").exclude(slug__in=scotland_election_ids)
+        # context['scotland_sopn_progress'] = self.sopn_progress_by_election(
+        #     election_qs=election_qs)
 
         task_count = PersonTask.objects.unfinished_tasks().count()
         if task_count > 0:

--- a/elections/uk/views/frontpage.py
+++ b/elections/uk/views/frontpage.py
@@ -105,7 +105,7 @@ class ConstituencyPostcodeFinderView(ContributorsMixin, FormView):
         context['postcode_form'] = kwargs.get('form') or PostcodeForm()
         context['show_postcode_form'] = True
         context['show_name_form'] = False
-        context['top_users'] = self.get_leaderboards()[1]['rows'][:8]
+        context['top_users'] = self.get_leaderboards(all_time=False)[0]['rows'][:8]
         context['recent_actions'] = self.get_recent_changes_queryset()[:5]
         context['election_data'] = Election.objects.current().by_date().last()
         context['hide_search_form'] = True


### PR DESCRIPTION
Two commits: one cleaning up some old code in the home page view and the other cleaning up some mixins.

Doing this because after the home page is no longer cached, it can be very slow to load.

Before these change it was taking ~500ms and ~83 queries to load the logged in (with all admin permissions) home page, after it's 21 and ~77ms.

This also reduces the number of queries needed to load the leaderboard, but doesn't reduce the total time taken to run the queries by very much.