### PR TITLE
Fix pages that errored due to version tree inference failing

### DIFF
--- a/candidates/models/versions.py
+++ b/candidates/models/versions.py
@@ -223,14 +223,13 @@ def get_versions_parent_map(versions_data):
         merged_from = is_a_merge(version)
         if merged_from is None:
             continue
-        number_of_merges += 1
         if merged_from not in person_id_to_ordered_versions:
-            msg = "Found a bogus merge version for person with " \
-                  "ID: {person_id} - no merged history of person " \
-                  "with ID {other_person_id} found"
-            raise Exception(msg.format(
-                person_id=canonical_person_id,
-                other_person_id=merged_from))
+            # This can happen because for some time there was a bug
+            # where the history of the secondary person wasn't
+            # included on merging; just treat this as any other
+            # version in that case.
+            continue
+        number_of_merges += 1
         last_version_id_of_other = \
             person_id_to_ordered_versions[merged_from][-1]['version_id']
         version_id_to_parent_ids[version_id].append(last_version_id_of_other)

--- a/candidates/models/versions.py
+++ b/candidates/models/versions.py
@@ -191,7 +191,7 @@ def get_versions_parent_map(versions_data):
     version_id_to_parent_ids = {}
     if not versions_data:
         return version_id_to_parent_ids
-    canonical_person_id = versions_data[-1]['data']['id']
+    canonical_person_id = versions_data[0]['data']['id']
     ordered_versions = sorted(versions_data, key=version_timestamp_key)
     person_id_to_ordered_versions = defaultdict(list)
     # Divide all the version with the same ID into separate ordered

--- a/candidates/tests/test_version_tree.py
+++ b/candidates/tests/test_version_tree.py
@@ -163,7 +163,7 @@ class TestVersionTree(TestCase):
             }
         )
 
-    def test_bogus_merge_unknown_other(self):
+    def test_secondary_history_missing(self):
         versions = [
             {
                 "data": {
@@ -192,12 +192,14 @@ class TestVersionTree(TestCase):
                 "version_id": "53e1260ec3946bbf"
             }
         ]
-        with self.assertRaisesRegexp(
-                Exception,
-                r'Found a bogus merge version for person with ID: 2009 - no '
-                r'merged history of person with ID 123456789 found'
-        ):
-            get_versions_parent_map(versions)
+        self.assertEqual(
+            get_versions_parent_map(versions),
+            {
+                '53e1260ec3946bbf': [],
+                '36198267ad42acb1': ['53e1260ec3946bbf'],
+                '407db6845dbb0007': ['36198267ad42acb1'],
+            }
+        )
 
     def test_other_person_earlier(self):
         versions = [

--- a/candidates/tests/test_version_tree.py
+++ b/candidates/tests/test_version_tree.py
@@ -320,6 +320,6 @@ class TestVersionTree(TestCase):
         with self.assertRaisesRegexp(
                 Exception,
                 r'It looks like there was a bogus merge version for person ' \
-                r'with ID 567; there were 2 merge versions and 2 person IDs.'
+                r'with ID 2009; there were 2 merge versions and 2 person IDs.'
         ):
             get_versions_parent_map(versions)


### PR DESCRIPTION
This fixes all but one page which was erroring due to the new code that infers the version tree, as reported in #194, and fixes a bug in the exception message raised in that final case.