### PR TITLE
bulk_adding: Fix formatting of the first other name added via AJAX

### DIFF
--- a/bulk_adding/static/bulk_adding/js/bulk.js
+++ b/bulk_adding/static/bulk_adding/js/bulk.js
@@ -89,7 +89,7 @@ $(function(){
                         $other = $person.find('.other-names');
                         if ($other.length == 0) {
                             $first_name = $person.find('>:first-child');
-                            $first_name.after('<ul class="other-names"><li>Other names:</li></ul>');
+                            $first_name.after('<ul class="other-names clearfix"><li>Other names:</li></ul>');
                             $other = $person.find('.other-names');
                         }
                         $names = $other.find('.other-name');


### PR DESCRIPTION
The first name to be added was appearing like this:

![bad-formatting](https://cloud.githubusercontent.com/assets/7907/25986059/c5bbe570-36e5-11e7-9965-4e3111a2a599.png)

... because the list created with Javascript was missing a clearfix - with this fix it appears like this:

![good-formatting](https://cloud.githubusercontent.com/assets/7907/25986079/ea14f40c-36e5-11e7-9bec-214520892a2a.png)
