### PR TITLE
Separate out your own post lock suggestions and put them at the bottom

### DIFF
--- a/moderation_queue/templates/moderation_queue/suggestedpostlock_review.html
+++ b/moderation_queue/templates/moderation_queue/suggestedpostlock_review.html
@@ -2,26 +2,32 @@
 
 {% block content %}
 <h1>Posts with lock suggestions</h1>
-{% regroup object_list by postextraelection as suggestions_list %}
-{% for suggestion_post in suggestions_list %}
-    {% with suggestion_post.list.0 as suggestion %}
-        <h3><a href="{% url 'constituency' election=suggestion_post.grouper.election.slug post_id=suggestion_post.grouper.postextra.slug ignored_slug=suggestion_post.grouper.postextra.short_label|slugify %}">{{ suggestion_post.grouper.postextra.short_label }} in the {{ suggestion_post.grouper.election.name }}</a></h3>
-        <ul>
-        {% for suggestion in suggestion_post.list %}
-        <li>
-          User {{ suggestion.user }} suggested locking this.
-          {% if suggestion.justification %}
-          They said:
-          <blockquote>{{ suggestion.justification }}</blockquote>
-          {% endif %}
-        </li>
-        {% endfor %}
-        </ul>
-    {% endwith %}
+{% for object_list in others_and_my_suggestions %}
+  {% if forloop.first %}
+    <h2>Suggestions to review</h2>
+  {% endif %}
+  {% if forloop.last %}
+    <h2>My own lock suggestions</h2>
+    <p>Someone else needs to review these:</p>
+  {% endif %}
+
+  {% regroup object_list by postextraelection as suggestions_list %}
+  {% for suggestion_post in suggestions_list %}
+      {% with suggestion_post.list.0 as suggestion %}
+          <h3><a href="{% url 'constituency' election=suggestion_post.grouper.election.slug post_id=suggestion_post.grouper.postextra.slug ignored_slug=suggestion_post.grouper.postextra.short_label|slugify %}">{{ suggestion_post.grouper.postextra.short_label }} in the {{ suggestion_post.grouper.election.name }}</a></h3>
+          <ul>
+          {% for suggestion in suggestion_post.list %}
+          <li>
+            User {{ suggestion.user }} suggested locking this.
+            {% if suggestion.justification %}
+            They said:
+            <blockquote>{{ suggestion.justification }}</blockquote>
+            {% endif %}
+          </li>
+          {% endfor %}
+          </ul>
+      {% endwith %}
+  {% endfor %}
+
 {% endfor %}
-<ul>
-  {# {% for suggestion in  %} #}
-  {# <li>{{ suggestion.post_extra.base.label }}</li> #}
-  {# {% endfor %} #}
-</ul>
 {% endblock content %}

--- a/moderation_queue/tests/test_queue.py
+++ b/moderation_queue/tests/test_queue.py
@@ -523,9 +523,17 @@ class SuggestedLockReviewTests(UK2015ExamplesMixin, TestUserMixin, WebTest):
             base__on_behalf_of=self.labour_party_extra.base
         )
 
-    def test_suggested_lock_review_view_no_suggestions(self):
+    def test_login_required(self):
         url = reverse('suggestions-to-lock-review-list')
         response = self.app.get(url)
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(
+            response.location,
+            'http://localhost:80/accounts/login/?next=/moderation/suggest-lock/')
+
+    def test_suggested_lock_review_view_no_suggestions(self):
+        url = reverse('suggestions-to-lock-review-list')
+        response = self.app.get(url, user=self.user)
         self.assertEqual(response.status_code, 200)
         self.assertNotContains(response, '<h3>')
 
@@ -540,7 +548,7 @@ class SuggestedLockReviewTests(UK2015ExamplesMixin, TestUserMixin, WebTest):
             justification='test data'
         )
         url = reverse('suggestions-to-lock-review-list')
-        response = self.app.get(url)
+        response = self.app.get(url, user=self.user)
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, '<h3>')
 


### PR DESCRIPTION
As suggested by Sam Smith (@samsmith), when you go to the page of
suggested post locks to review, you're not meant to be reviewing your
own suggestions, so this commit separates out your own suggestions and
puts them in a section at the bottom of the page.

This commit also makes being authenticated a requirement to view this
page - this isn't a big deal, since you need to be authenticated and
have the ability to lock to see the link to this page anyway. (Not
having to deal with anonymous users makes the logic slightly simpler.)

Fixes #99