### PR TITLE
bulk_adding: Improvements to the 'previous candidacy' shown on review

### DIFF
--- a/bulk_adding/forms.py
+++ b/bulk_adding/forms.py
@@ -48,11 +48,18 @@ class BaseBulkAddReviewFormSet(BaseBulkAddFormSet):
         """
         name = suggestion.name
         try:
-            if suggestion.object.memberships.all().exists():
-                name = "<strong>{}</strong> (previously stood in the {} as a {} candidate)".format(
-                    name,
-                    suggestion.object.memberships.all().first().extra.election,
-                    suggestion.object.memberships.all().first().on_behalf_of.name,
+            candidacy = suggestion.object.memberships \
+                        .select_related(
+                            'post__extra',
+                            'on_behalf_of',
+                            'extra__election') \
+                        .order_by('-extra__election__election_date').first()
+            if candidacy:
+                name = "<strong>{name}</strong> (previously stood in {post} in the {election} as a {party} candidate)".format(
+                    name=name,
+                    post=candidacy.post.extra.short_label,
+                    election=candidacy.extra.election.name,
+                    party=candidacy.on_behalf_of.name,
                 )
                 name = SafeText(name)
         except AttributeError:


### PR DESCRIPTION
The previous candidacy shown on the bulk adding review page was being
arbitrarily chosen. After this commit, the candidacy from the
most recent election will be shown instead. This commit also
incorporates the name of the post, which is useful for telling how
distant the earlier consistuency was.