### PR TITLE
Fix /feeds/needs-review.xml for when constituency-lock are included

### DIFF
--- a/candidates/models/db.py
+++ b/candidates/models/db.py
@@ -97,7 +97,7 @@ class LoggedAction(models.Model):
             })
         elif self.person:
             return reverse('person-view', kwargs={'person_id': self.person.id})
-        return None
+        return '/'
 
     @property
     def subject_html(self):


### PR DESCRIPTION
The constituency-lock LoggedAction objects are broken in that they have
the person and post fields set to None (they really should have a post,
but that's a bug). Unfortunately when one of these items appeared in the
needs-review feed, they would then cause the following exception:

  Internal Server Error: /feeds/needs-review.xml
  Traceback (most recent call last):
    File "[...]/local/lib/python2.7/site-packages/django/core/handlers/base.py", line 132, in get_response
      response = wrapped_callback(request, *callback_args, **callback_kwargs)
    File "[...]/local/lib/python2.7/site-packages/django/contrib/syndication/views.py", line 43, in __call__
      feedgen = self.get_feed(obj, request)
    File "[...]/local/lib/python2.7/site-packages/django/contrib/syndication/views.py", line 174, in get_feed
      request.is_secure(),
    File "[...]/local/lib/python2.7/site-packages/django/contrib/syndication/views.py", line 19, in add_domain
      if url.startswith('//'):
  AttributeError: 'NoneType' object has no attribute 'startswith'

This is because the LoggedAction.subject_url method returned None for
these objects. This is a dumb fix for this that returns '/' in this case.