### PR TITLE
Add a command to cache the ouput of /api/v0.9/persons/ to a directory

### DIFF
--- a/candidates/management/commands/candidates_cache_persons_api.py
+++ b/candidates/management/commands/candidates_cache_persons_api.py
@@ -1,0 +1,115 @@
+from __future__ import print_function, unicode_literals
+
+import json
+import os
+from datetime import datetime
+from os.path import exists, join
+
+
+from django.core.management.base import BaseCommand
+from django.test import Client
+from django.utils.six.moves.urllib_parse import urlsplit, parse_qs
+
+from mysite.helpers import mkdir_p
+
+
+def hostname_and_secure(url):
+    split_url = urlsplit(url)
+    return (split_url.netloc, split_url.scheme == 'https')
+
+
+def path_and_query(url):
+    split_url = urlsplit(url)
+    return split_url.path + '?' + split_url.query
+
+
+def page_from_url(url):
+    page_values = parse_qs(urlsplit(url).query).get('page')
+    if page_values:
+        return int(page_values[0])
+    return 1
+
+
+def page_filename(page_number):
+    return 'page-{0:06d}.json'.format(page_number)
+
+
+def update_latest_symlink(output_directory, subdirectory):
+    tmp_symlink_location = join(output_directory, 'new')
+    symlink_location = join(output_directory, 'latest')
+    if exists(tmp_symlink_location):
+        os.remove(symlink_location)
+    os.symlink(subdirectory, tmp_symlink_location)
+    os.rename(tmp_symlink_location, symlink_location)
+
+
+class Command(BaseCommand):
+
+    help = "Cache the output of the /api/v0.9/persons endpoint to a directory"
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            'OUTPUT-DIRECTORY',
+            help='The directory to write output to')
+        parser.add_argument(
+            'DIRECTORY-URL',
+            help='The URL which that directory will be served at')
+        parser.add_argument(
+            '--page-size',
+            type=int,
+            help='How many people should be output per file (max 200)'
+        )
+
+    def rewrite_link(self, url):
+        if not url:
+            return None
+        page = page_from_url(url)
+        filename = page_filename(page)
+        return '{0}{1}/{2}'.format(self.directory_url, self.timestamp, filename)
+
+    def get(self, url):
+        kwargs = {'SERVER_NAME': self.hostname}
+        if self.secure:
+            kwargs['wsgi.url_scheme'] = 'https'
+            kwargs['secure'] = True
+        return self.client.get(url, **kwargs)
+
+    def rewrite_next_and_previous_links(self, data):
+        data['next'] = self.rewrite_link(data['next'])
+        data['previous'] = self.rewrite_link(data['previous'])
+
+    def get_api_results_to_directory(self, json_directory, page_size):
+        url = '/api/v0.9/persons/?page_size={0}&format=json'.format(page_size)
+        while url:
+            page = page_from_url(url)
+            output_filename = join(json_directory, page_filename(page))
+            response = self.get(url)
+            if response.status_code != 200:
+                msg = "Unexpected response {0} from {1}"
+                raise Exception(msg.format(response.status_code, url))
+            data = json.loads(response.content.decode('utf-8'))
+            original_next_url = data['next']
+            self.rewrite_next_and_previous_links(data)
+            with open(output_filename, 'w') as f:
+                json.dump(data, f, indent=4, sort_keys=True)
+            # Now make sure the next URL works with the test client:
+            if original_next_url:
+                url = path_and_query(original_next_url)
+            else:
+                url = None
+
+    def handle(self, *args, **options):
+        self.client = Client()
+        self.directory_url = options['DIRECTORY-URL']
+        if not self.directory_url.endswith('/'):
+            self.directory_url = self.directory_url + '/'
+        self.hostname, self.secure = hostname_and_secure(self.directory_url)
+        mkdir_p(options['OUTPUT-DIRECTORY'])
+        self.timestamp = datetime.now().strftime('%Y-%m-%dT%H:%M:%S')
+        json_directory = join(options['OUTPUT-DIRECTORY'], self.timestamp)
+        mkdir_p(json_directory)
+        page_size = options['page_size']
+        if not page_size:
+            page_size = 200
+        self.get_api_results_to_directory(json_directory, page_size)
+        update_latest_symlink(options['OUTPUT-DIRECTORY'], self.timestamp)


### PR DESCRIPTION
When a new instance of WCIVF (whocanivotefor.co.uk) is brought up, it goes
through every page of `/api/v0.9/persons/` to get the candidate data. This
ties up one worker of the server for a long time in any case, but in order
to scale WCIVF we might need to bring up multiple instances nearly
simultaneously which would really make the YNR server suffer. To avoid
this impacting the YNR instance too much, we've decided to cache the
results of these calls to disk (once a day probably) where they can be
served effeciently as static files by nginx.  WCIVF can then do a cheaper
API query to find just the people who have changed since a particular time.

The new command introduced in this commit should make it easy to
generate a version of this data in a format that is easy to
serve as static files. You can invoke it, for example, like:

    ./manage.py candidates_cache_persons_api \
       /var/www/ynr-media/cached-persons \
       https://candidates.democracyclub.org.uk/media/cached-persons

That will take some minutes to run, but will create a directory
structure under `/var/www/ynr-media` that looks like:

```
└── cached-persons
    ├── 2017-05-14T17:03:01
    │   ├── page-000001.json
    │   ├── page-000002.json
    │   ├── page-000003.json
            ...
    │   └── page-000165.json
    ├── 2017-05-14T17:09:13
    │   ├── page-000001.json
    │   ├── page-000002.json
    │   ├── page-000003.json
            ...
    │   └── page-000165.json
    └── latest -> 2017-05-14T17:09:13
```

... which you should then be able to iterate over as with the API as
normal, starting at:

```
https://candidates.democracyclub.org.uk/media/cached-persons/latest/page-000001.json
```

... since the command rewrites the "next" and "previous" URLs in the
response to go to the correct `page-XXXXXX.json` file's URL. This means
that nginx will have to be configured to follow symlinks when serving
static files.

This uses the Django test client to fetch the API results, which seems
to be a pretty simple approach.

(This was @symroe's idea - I just did the implementation.)
