### PR TITLE
Reuse database connections for up to a minute when DEBUG is False

### DIFF
--- a/mysite/settings/conf.py
+++ b/mysite/settings/conf.py
@@ -140,6 +140,10 @@ def get_settings(conf_file_leafname, election_app=None, tests=False):
                 'PASSWORD': conf.get('YNMP_DB_PASS'),
                 'HOST':     conf.get('YNMP_DB_HOST'),
                 'PORT':     conf.get('YNMP_DB_PORT'),
+                # Note that there are various comments on the web
+                # suggesting that settings CONN_MAX_AGE != 0 is a bad
+                # idea when eventlet or gevent workers are being used.
+                'CONN_MAX_AGE': 0 if debug else 60,
             }
         }
     else:


### PR DESCRIPTION
This commits sets CONN_MAX_AGE in the DATABASE setting to 60 seconds,
meaning that a database connection can be reused for up to a minute by a
thread. We hope this will improve performance since many queries are
used to produce some pages, and reconnecting to the database server each
time is a waste.

The documentation for this feature, with a couple of important caveats,
is here:

   https://docs.djangoproject.com/en/1.8/ref/databases/#persistent-connections

Note the comment I've added, referring to the problem that this is
likely to be ineffective (or harmful) with eventlet or gevent workers.