### PR TITLE
Fix unnecessary recreation of memberships losing CandidateResult data

### DIFF
--- a/bulk_adding/tests.py
+++ b/bulk_adding/tests.py
@@ -2,13 +2,15 @@ import json
 
 from django.core.management import call_command
 from django_webtest import WebTest
-from popolo.models import Person
+from popolo.models import Membership, Person
 
+from candidates.tests.test_update_view import membership_id_set
 from candidates.tests.auth import TestUserMixin
 
 from official_documents.models import OfficialDocument
 
 from nose.plugins.attrib import attr
+from candidates.tests import factories
 from candidates.tests.uk_examples import UK2015ExamplesMixin
 
 
@@ -111,3 +113,114 @@ class TestBulkAdding(TestUserMixin, UK2015ExamplesMixin, WebTest):
         self.assertEqual(
             membership.post.label,
             'Member of Parliament for Dulwich and West Norwood')
+
+    def test_adding_to_existing_person(self):
+        existing_person = factories.PersonExtraFactory.create(
+            base__id='1234567',
+            base__name='Bart Simpson'
+        ).base
+        existing_membership = factories.CandidacyExtraFactory.create(
+            election=self.local_election,
+            base__person=existing_person,
+            base__post=self.local_post.base,
+            base__on_behalf_of=self.labour_party_extra.base
+        ).base
+        memberships_before = membership_id_set(existing_person)
+        # Now try adding that person via bulk add:
+        OfficialDocument.objects.create(
+            election=self.election,
+            post=self.dulwich_post_extra.base,
+            source_url='http://example.com',
+            document_type=OfficialDocument.NOMINATION_PAPER,
+            uploaded_file="sopn.pdf"
+        )
+
+        response = self.app.get(
+            '/bulk_adding/2015/65808/',
+            user=self.user
+        )
+
+        form = response.forms['bulk_add_form']
+        form['form-0-name'] = 'Bart Simpson'
+        form['form-0-party'] = self.green_party_extra.base.id
+
+        response = form.submit()
+        self.assertEqual(response.status_code, 302)
+
+        # This takes us to a page with a radio button for adding them
+        # as a new person or alternative radio buttons if any
+        # candidates with similar names were found.
+        response = response.follow()
+        form = response.forms[1]
+        form['form-0-select_person'].select('1234567')
+        response = form.submit()
+
+        person = Person.objects.get(name='Bart Simpson')
+        memberships_after = membership_id_set(person)
+        new_memberships = memberships_after - memberships_before
+        self.assertEqual(len(new_memberships), 1)
+        new_membership = Membership.objects.get(pk=list(new_memberships)[0])
+        self.assertEqual(new_membership.post, self.dulwich_post_extra.base)
+        self.assertEqual(new_membership.on_behalf_of, self.green_party_extra.base)
+        same_memberships = memberships_before & memberships_after
+        self.assertEqual(len(same_memberships), 1)
+        same_membership = Membership.objects.get(pk=list(same_memberships)[0])
+        self.assertEqual(same_membership.post, self.local_post.base)
+        self.assertEqual(same_membership.on_behalf_of, self.labour_party_extra.base)
+        self.assertEqual(same_membership.id, existing_membership.id)
+
+    def test_adding_to_existing_person_same_election(self):
+        # This could happen if someone's missed that there was the
+        # same person already listed on the first page, but then
+        # spotted them on the review page and said to merge them then.
+        existing_person = factories.PersonExtraFactory.create(
+            base__id='1234567',
+            base__name='Bart Simpson'
+        ).base
+        existing_membership = factories.CandidacyExtraFactory.create(
+            election=self.election,
+            base__person=existing_person,
+            # !!! This is the line that differs from the previous test:
+            base__post=self.dulwich_post_extra.base,
+            base__on_behalf_of=self.labour_party_extra.base
+        ).base
+        memberships_before = membership_id_set(existing_person)
+        # Now try adding that person via bulk add:
+        OfficialDocument.objects.create(
+            election=self.election,
+            post=self.dulwich_post_extra.base,
+            source_url='http://example.com',
+            document_type=OfficialDocument.NOMINATION_PAPER,
+            uploaded_file="sopn.pdf"
+        )
+
+        response = self.app.get(
+            '/bulk_adding/2015/65808/',
+            user=self.user
+        )
+
+        form = response.forms['bulk_add_form']
+        form['form-0-name'] = 'Bart Simpson'
+        form['form-0-party'] = self.green_party_extra.base.id
+
+        response = form.submit()
+        self.assertEqual(response.status_code, 302)
+
+        # This takes us to a page with a radio button for adding them
+        # as a new person or alternative radio buttons if any
+        # candidates with similar names were found.
+        response = response.follow()
+        form = response.forms[1]
+        form['form-0-select_person'].select('1234567')
+        response = form.submit()
+
+        person = Person.objects.get(name='Bart Simpson')
+        memberships_after = membership_id_set(person)
+        new_memberships = memberships_after - memberships_before
+        self.assertEqual(len(new_memberships), 0)
+        same_memberships = memberships_before & memberships_after
+        self.assertEqual(len(same_memberships), 1)
+        same_membership = Membership.objects.get(pk=list(same_memberships)[0])
+        self.assertEqual(same_membership.post, self.dulwich_post_extra.base)
+        self.assertEqual(same_membership.on_behalf_of, self.green_party_extra.base)
+        self.assertEqual(same_membership.id, existing_membership.id)

--- a/bulk_adding/views.py
+++ b/bulk_adding/views.py
@@ -14,7 +14,9 @@ from braces.views import LoginRequiredMixin
 
 from auth_helpers.views import GroupRequiredMixin, user_in_group
 from elections.models import Election
-from candidates.models import PostExtra, PostExtraElection, PersonExtra, MembershipExtra
+from candidates.models import (
+    PostExtra, PostExtraElection, PersonExtra, MembershipExtra,
+    raise_if_unsafe_to_delete)
 from candidates.models.auth import check_creation_allowed, check_update_allowed
 from candidates.views.version_data import get_change_metadata, get_client_ip
 from candidates.views.people import get_call_to_action_flash_message
@@ -202,6 +204,7 @@ class BulkAddReviewView(BaseBulkAddView):
                 extra__election=election,
                 role=election.candidate_membership_role,
             ):
+            raise_if_unsafe_to_delete(old_membership)
             old_membership.delete()
 
         change_metadata = get_change_metadata(

--- a/cached_counts/tests.py
+++ b/cached_counts/tests.py
@@ -105,7 +105,20 @@ class CachedCountTestCase(UK2015ExamplesMixin, WebTest):
                                 ],
                                 "role": "Member of Parliament"
                             }
-                        ]
+                        ],
+                        text_type(self.local_election.election_date.isoformat()): [
+                            {
+                                "elections": [
+                                    {
+                                        "html_id": "local-maidstone-2016-05-05",
+                                        "id": "local.maidstone.2016-05-05",
+                                        "name": "Maidstone local election",
+                                        "total": 0,
+                                    }
+                                ],
+                                "role": "Local Councillor",
+                            },
+                        ],
                     }
                 },
                 {
@@ -140,6 +153,9 @@ class CachedCountTestCase(UK2015ExamplesMixin, WebTest):
             [
                 ('<td>2015 General Election</td>',
                  '<td><a href="/election/2015/post/65913/camberwell-and-peckham">Member of Parliament for Camberwell and Peckham</a></td>',
+                 '<td>0</td>'),
+                ('<td>Maidstone local election</td>',
+                 '<td><a href="/election/local.maidstone.2016-05-05/post/DIW:E05005004/shepway-south-ward">Shepway South Ward</a></td>',
                  '<td>0</td>'),
                 ('<td>2015 General Election</td>',
                  '<td><a href="/election/2015/post/14420/edinburgh-north-and-leith">Member of Parliament for Edinburgh North and Leith</a></td>',

--- a/candidates/models/__init__.py
+++ b/candidates/models/__init__.py
@@ -19,6 +19,8 @@ from .popolo_extra import PartySet
 from .popolo_extra import ImageExtra
 from .popolo_extra import parse_approximate_date
 from .popolo_extra import PostExtraElection
+from .popolo_extra import raise_if_unsafe_to_delete
+from .popolo_extra import UnsafeToDelete
 
 from .field_mappings import CSV_ROW_FIELDS
 

--- a/candidates/models/popolo_extra.py
+++ b/candidates/models/popolo_extra.py
@@ -47,6 +47,7 @@ want a join or not.
 
 """
 
+
 def update_person_from_form(person, person_extra, form):
     form_data = form.cleaned_data.copy()
     # The date is returned as a datetime.date, so if that's set, turn
@@ -73,6 +74,7 @@ def update_person_from_form(person, person_extra, form):
     except TwitterAPITokenMissing:
         pass
     for election_data in form.elections_with_fields:
+        # Interpret the form data relating to this election:
         post_id = form_data.get('constituency_' + election_data.slug)
         standing = form_data.pop('standing_' + election_data.slug, 'standing')
         if post_id:
@@ -86,42 +88,90 @@ def update_person_from_form(person, person_extra, form):
         else:
             party = None
             party_list_position = None
-        # Get a queryset of the existing candidacies:
-        candidacy_qs = Membership.objects.filter(
-            extra__election=election_data,
-            role=election_data.candidate_membership_role,
-            person__extra=person_extra
-        )
-        # Preserve the 'elected' property of MembershipExtra, which
-        # isn't in the form:
-        elected_saved = dict(
-            candidacy_qs.values_list('extra__election__slug', 'extra__elected')
-        )
-        # Remove any existing memberships; we'll recreate them if the
-        # person's actually standing. (Since MembershipExtra depends
-        # on Membership, this will delete any corresponding Membership.)
-        candidacy_qs.delete()
-        # Remove any indication that they're not standing in that
-        # election. Similarly we'll recreate it if necessary:
-        person_extra.not_standing.remove(election_data)
+            post = None
+        # Now update the candidacies and not_standing based on those values:
         if standing == 'standing':
-            # Create the new membership:
-            membership = Membership.objects.create(
-                post=post,
-                on_behalf_of=party,
-                person=person,
-                role=election_data.candidate_membership_role,
-            )
-            MembershipExtra.objects.create(
-                base=membership,
-                party_list_position=party_list_position,
-                election=election_data,
-                elected=elected_saved.get(election_data.slug)
-            )
+            mark_as_standing(
+                person_extra, election_data, post, party, party_list_position)
         elif standing == 'not-standing':
-            from .constraints import check_no_candidancy_for_election
-            check_no_candidancy_for_election(person, election_data)
-            person_extra.not_standing.add(election_data)
+            mark_as_not_standing(person_extra, election_data, post)
+        else:
+            mark_as_unsure_if_standing(person_extra, election_data, post)
+
+
+def mark_as_standing(person_extra, election_data, post, party, party_list_position):
+    # First, if the person is marked as "not standing" in that
+    # election, remove that record:
+    person_extra.not_standing.remove(election_data)
+    membership_ids_to_remove = set()
+    membership = None
+    # This person might already be marked as standing for this
+    # post. In that case, we need to make sure we preserve that
+    # existing membership, since there may be metadata attached to it
+    # (such as the extra.elected property or CandidateResult records)
+    # which would be lost if we deleted and recreated the membership.
+    # Go through the person's existing candidacies for this election:
+    for existing_membership in Membership.objects.filter(
+        extra__election=election_data,
+        role=election_data.candidate_membership_role,
+        person__extra=person_extra,
+    ):
+        if existing_membership.post == post:
+            membership = existing_membership
+        else:
+            membership_ids_to_remove.add(existing_membership.id)
+    # If there was no existing membership, we need to create one:
+    if not membership:
+        membership = Membership.objects.create(
+            post=post,
+            person=person_extra.base,
+            role=election_data.candidate_membership_role,
+        )
+        MembershipExtra.objects.create(
+            base=membership,
+            election=election_data,
+        )
+    # Update the party list position in case it's changed:
+    membership_extra = membership.extra
+    membership_extra.party_list_position = party_list_position
+    membership_extra.save()
+    # Update the party, in case it's changed:
+    membership.on_behalf_of = party
+    membership.save()
+    # Now remove any memberships that shouldn't now be there:
+    for membership_to_remove in Membership.objects.filter(
+            pk__in=membership_ids_to_remove):
+        membership_to_remove.delete()
+
+
+def mark_as_not_standing(person_extra, election_data, post):
+    # Remove any existing candidacy:
+    for membership in Membership.objects.filter(
+        extra__election=election_data,
+        role=election_data.candidate_membership_role,
+        person__extra=person_extra,
+        # n.b. we are planning to make "not standing" post
+        # specific in the future, in which case we would also want
+        # this line:
+        # post__extra__slug=post_slug,
+    ):
+        membership.delete()
+    from .constraints import check_no_candidancy_for_election
+    check_no_candidancy_for_election(person_extra.base, election_data)
+    person_extra.not_standing.add(election_data)
+
+
+def mark_as_unsure_if_standing(person_extra, election_data, post):
+    # Remove any existing candidacy:
+    for membership in Membership.objects.filter(
+        extra__election=election_data,
+        role=election_data.candidate_membership_role,
+        person__extra=person_extra
+    ):
+        membership.delete()
+    # Now remove any entry that indicates that they're standing in
+    # this election:
+    person_extra.not_standing.remove(election_data)
 
 
 class localparserinfo(parser.parserinfo):

--- a/candidates/tests/test_api.py
+++ b/candidates/tests/test_api.py
@@ -225,7 +225,7 @@ class TestAPI(UK2015ExamplesMixin, WebTest):
         organizations = organizations_resp.json
 
         self.assertEqual(organizations['count'], len(organizations['results']))
-        self.assertEqual(organizations['count'], 6)
+        self.assertEqual(organizations['count'], 7)
 
     def test_api_organization(self):
         organizations_resp = self.app.get('/api/v0.9/organizations/')
@@ -250,7 +250,7 @@ class TestAPI(UK2015ExamplesMixin, WebTest):
         elections = elections_resp.json
 
         self.assertEqual(elections['count'], len(elections['results']))
-        self.assertEqual(elections['count'], 2)
+        self.assertEqual(elections['count'], 3)
 
     def test_api_election(self):
         elections_resp = self.app.get('/api/v0.9/elections/')
@@ -275,7 +275,7 @@ class TestAPI(UK2015ExamplesMixin, WebTest):
         posts = posts_resp.json
 
         self.assertEqual(posts['count'], len(posts['results']))
-        self.assertEqual(posts['count'], 4)
+        self.assertEqual(posts['count'], 5)
 
     def test_api_post(self):
         posts_resp = self.app.get('/api/v0.9/posts/')

--- a/candidates/tests/test_constituency_view.py
+++ b/candidates/tests/test_constituency_view.py
@@ -413,21 +413,6 @@ class TestConstituencyDetailView(TestUserMixin, UK2015ExamplesMixin, WebTest):
         )
 
     def test_return_404_when_post_not_associated_with_election(self):
-        local_council = OrganizationExtraFactory.create(
-            base__name='Maidstone',
-            slug='local-authority:maidstone',
-        ).base
-        local_election = ElectionFactory.create(
-            slug='local.maidstone.2016-05-05',
-            organization=local_council,
-        )
-        PostExtraFactory(
-            elections=(local_election,),
-            slug='DIW:E05005004',
-            base__label='Shepway South Ward',
-            party_set=self.gb_parties,
-            base__organization=local_council,
-        ).base
         # Now that post is not associated with the 2015 election, so
         # viewing a page with election: 2015 and post: DIW:E05005004
         # should return a 404.

--- a/candidates/tests/test_constraints.py
+++ b/candidates/tests/test_constraints.py
@@ -27,7 +27,7 @@ class PairedConstraintCheckTests(UK2015ExamplesMixin, TestCase):
     def test_base_with_no_extra_detected(self):
         unpaired_post = Post.objects.create(organization=self.commons)
         expected_errors = [
-            'There were 5 Post objects, but 4 PostExtra objects',
+            'There were 6 Post objects, but 5 PostExtra objects',
             'The Post object with ID {} had no corresponding ' \
             'PostExtra object'.format(unpaired_post.id)
             ]

--- a/candidates/tests/test_group_elections.py
+++ b/candidates/tests/test_group_elections.py
@@ -42,12 +42,18 @@ class TestElectionGrouping(UK2015ExamplesMixin, TestCase):
                         'dates': OrderedDict([
                             (datetime.date(2016, 5, 5), [
                                 {
+                                    'role': 'Local Councillor',
+                                    'elections': [
+                                        {'election': self.local_election},
+                                    ]
+                                },
+                                {
                                     'role': 'Member of the Scottish Parliament',
                                     'elections': [
                                         {'election': self.sp_c_election},
                                         {'election': self.sp_r_election},
                                     ]
-                                }
+                                },
                             ]),
                             (self.election.election_date, [
                                 {
@@ -100,6 +106,9 @@ class TestElectionGrouping(UK2015ExamplesMixin, TestCase):
         edinburgh_north_earlier = get_election_extra(
             self.edinburgh_north_post_extra, self.earlier_election
         )
+        local_council_pee = get_election_extra(
+            self.local_post, self.local_election
+        )
         with self.assertNumQueries(4):
             self.assertEqual(
                 Election.group_and_order_elections(include_postextraelections=True),
@@ -108,6 +117,17 @@ class TestElectionGrouping(UK2015ExamplesMixin, TestCase):
                         'current': True,
                         'dates': OrderedDict([
                             (datetime.date(2016, 5, 5), [{
+                                'role': 'Local Councillor',
+                                'elections': [
+                                    {
+                                        'postextraelections': [
+                                            local_council_pee
+                                        ],
+                                        'election': self.local_election,
+                                    }
+                                ]
+                            },
+                            {
                                 'role': 'Member of the Scottish Parliament',
                                 'elections': [
                                     {
@@ -168,6 +188,11 @@ class TestElectionGrouping(UK2015ExamplesMixin, TestCase):
                     {
                         'current': True,
                         'dates': OrderedDict([
+                            (self.local_election.election_date, [{
+                                'role': 'Local Councillor', 'elections': [
+                                    {'election': self.local_election}
+                                ]
+                            }]),
                             (self.election.election_date, [{
                                 'role': 'Member of Parliament', 'elections': [
                                     {'election': self.election}

--- a/candidates/tests/test_group_elections.py
+++ b/candidates/tests/test_group_elections.py
@@ -17,6 +17,8 @@ def get_election_extra(postextra, election):
 
 class TestElectionGrouping(UK2015ExamplesMixin, TestCase):
 
+    maxDiff = None
+
     def setUp(self):
         super(TestElectionGrouping, self).setUp()
         self.sp_c_election = ElectionFactory(

--- a/candidates/tests/test_merge_view.py
+++ b/candidates/tests/test_merge_view.py
@@ -409,24 +409,6 @@ class TestMergePeopleView(TestUserMixin, UK2015ExamplesMixin, WebTest):
             base__name='Stuart Robert Jeffrey',
         ).base
 
-        local_council = factories.OrganizationExtraFactory.create(
-            base__name='Maidstone',
-            slug='local-authority:maidstone',
-        ).base
-        # Make sure that the local election and post in that election exist:
-        local_election = factories.ElectionFactory.create(
-            slug='local.maidstone.2016-05-05',
-            organization=local_council,
-        )
-        factories.PostExtraFactory.create(
-            elections=(local_election,),
-            slug='DIW:E05005004',
-            base__label='Shepway South Ward',
-            party_set=self.gb_parties,
-            base__organization=local_council,
-            # base__area=area_extra.base,
-        )
-
         # And create the two Westminster posts:
         factories.PostExtraFactory.create(
             elections=(self.election, self.earlier_election),

--- a/candidates/tests/uk_examples.py
+++ b/candidates/tests/uk_examples.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 
+from datetime import date
+
 from . import factories
 
 class UK2015ExamplesMixin(object):
@@ -115,3 +117,23 @@ class UK2015ExamplesMixin(object):
                 group=cons['country'],
             )
             setattr(self, cons['attr'], pe)
+
+        # Also create a local election and post:
+        self.local_council = factories.OrganizationExtraFactory.create(
+            base__name='Maidstone',
+            slug='local-authority:maidstone',
+        ).base
+        self.local_election = factories.ElectionFactory.create(
+            slug='local.maidstone.2016-05-05',
+            organization=self.local_council,
+            name='Maidstone local election',
+            for_post_role='Local Councillor',
+            election_date=date(2016, 5, 5),
+        )
+        self.local_post = factories.PostExtraFactory.create(
+            elections=(self.local_election,),
+            slug='DIW:E05005004',
+            base__label='Shepway South Ward',
+            party_set=self.gb_parties,
+            base__organization=self.local_council,
+        )

--- a/candidates/views/people.py
+++ b/candidates/views/people.py
@@ -247,7 +247,8 @@ class MergePeopleView(GroupRequiredMixin, View):
             revert_person_from_version_data(
                 primary_person,
                 primary_person_extra,
-                merged_person_version_data
+                merged_person_version_data,
+                part_of_merge=True,
             )
         # Make sure the secondary person's version history is appended, so it
         # isn't lost.

--- a/elections/uk/tests/test_custom_merge.py
+++ b/elections/uk/tests/test_custom_merge.py
@@ -23,22 +23,6 @@ class TestUKResultsPreserved(TestUserMixin, UK2015ExamplesMixin, WebTest):
             base__id='10000',
             base__name='Harriet Ruth Harman',
         ).base
-        # And an extra election to create a candidacy of:
-        local_council = factories.OrganizationExtraFactory.create(
-            base__name='Maidstone',
-            slug='local-authority:maidstone',
-        ).base
-        self.local_election = factories.ElectionFactory.create(
-            slug='local.maidstone.2016-05-05',
-            organization=local_council,
-        )
-        self.local_post = factories.PostExtraFactory.create(
-            elections=(self.local_election,),
-            slug='DIW:E05005004',
-            base__label='Shepway South Ward',
-            party_set=self.gb_parties,
-            base__organization=local_council,
-        )
 
     def test_uk_results_for_secondary_preserved(self):
         factories.CandidacyExtraFactory.create(


### PR DESCRIPTION
CandidateResult has a ForeignKey to Membership, which meant that any deletion and recreation of a membership would lose that CandidateResult (unless it was particularly preserved, e.g. as we've done for merging). This pull request prevents this kind of data loss by:
* Making sure that if an existing membership can be preserved in UpdatePersonView or BulkAddReviewView it will be. (Previously they would be deleted and recreated - this was OK before the introduction of the CandidateResult model, but not since then.)
* Adding checks that whenever a membership is deleted (except in merging, which is handled otherwise) there are no foreign keys that point to it other than the MembershipExtra.

This is a partial fix for #229, but we still need to restore old data that might have been deleted.
