### PR TITLE
Add redirects of person IDs (the PersonRedirect model) to the API

### DIFF
--- a/candidates/serializers.py
+++ b/candidates/serializers.py
@@ -472,3 +472,15 @@ class ComplexPopoloFieldSerializer(serializers. HyperlinkedModelSerializer):
             'info_type_key', 'info_type', 'old_info_type', 'info_value_key',
             'order',
         )
+
+
+class PersonRedirectSerializer(serializers.HyperlinkedModelSerializer):
+    class Meta:
+        model = candidates_models.PersonRedirect
+        fields = ('id', 'url', 'old_person_id', 'new_person_id')
+
+    url = serializers.HyperlinkedIdentityField(
+        view_name='personredirect-detail',
+        lookup_field='old_person_id',
+        lookup_url_kwarg='old_person_id',
+    )

--- a/candidates/tests/test_api.py
+++ b/candidates/tests/test_api.py
@@ -18,7 +18,7 @@ from .factories import (
 )
 from .uk_examples import UK2015ExamplesMixin
 
-from candidates.models import LoggedAction
+from candidates.models import LoggedAction, PersonRedirect
 
 
 class TestAPI(UK2015ExamplesMixin, WebTest):
@@ -298,6 +298,28 @@ class TestAPI(UK2015ExamplesMixin, WebTest):
             post['label'],
             'Member of Parliament for Dulwich and West Norwood'
         )
+
+    def test_api_person_redirects(self):
+        PersonRedirect.objects.create(old_person_id='1234', new_person_id='42')
+        PersonRedirect.objects.create(old_person_id='5678', new_person_id='12')
+        person_redirects_resp = self.app.get('/api/v0.9/person_redirects/')
+        person_redirects = person_redirects_resp.json
+        self.assertEqual(
+            person_redirects['results'][0]['old_person_id'], 1234)
+        self.assertEqual(
+            person_redirects['results'][0]['new_person_id'], 42)
+        self.assertEqual(
+            person_redirects['results'][1]['old_person_id'], 5678)
+        self.assertEqual(
+            person_redirects['results'][1]['new_person_id'], 12)
+
+    def test_api_person_redirect(self):
+        PersonRedirect.objects.create(old_person_id='1234', new_person_id='42')
+        url = '/api/v0.9/person_redirects/1234/'
+        person_redirect_resp = self.app.get(url)
+        person_redirect = person_redirect_resp.json
+        self.assertEqual(person_redirect['old_person_id'], 1234)
+        self.assertEqual(person_redirect['new_person_id'], 42)
 
     def test_api_version_info(self):
         version_resp = self.app.get('/version.json')

--- a/candidates/urls.py
+++ b/candidates/urls.py
@@ -32,6 +32,7 @@ api_router.register(r'logged_actions', views.LoggedActionViewSet)
 api_router.register(r'extra_fields', views.ExtraFieldViewSet)
 api_router.register(r'simple_fields', views.SimplePopoloFieldViewSet)
 api_router.register(r'complex_fields', views.ComplexPopoloFieldViewSet)
+api_router.register(r'person_redirects', views.PersonRedirectViewSet)
 
 api_router.register(r'council_elections', CouncilElectionViewSet)
 api_router.register(r'candidate_results', CandidateResultViewSet)

--- a/candidates/views/api.py
+++ b/candidates/views/api.py
@@ -433,3 +433,9 @@ class ComplexPopoloFieldViewSet(viewsets.ModelViewSet):
     queryset = extra_models.ComplexPopoloField.objects.order_by('id')
     serializer_class = serializers.ComplexPopoloFieldSerializer
     pagination_class = ResultsSetPagination
+
+class PersonRedirectViewSet(viewsets.ReadOnlyModelViewSet):
+    queryset = extra_models.PersonRedirect.objects.order_by('id')
+    lookup_field = 'old_person_id'
+    serializer_class = serializers.PersonRedirectSerializer
+    pagination_class = ResultsSetPagination


### PR DESCRIPTION
At the moment you can't easily tell which old person IDs redirect to new
people - these PersonRedirect objects are created on merging two
candidates and deleting one of them. The API endpoint introduced in
this commit provides a way for API consumers to map IDs that disappear
to the person they were merged into.

Fixes #241