### PR TITLE
Add redirects for merged people to the CSV output

### DIFF
--- a/candidates/management/commands/candidates_create_csv.py
+++ b/candidates/management/commands/candidates_create_csv.py
@@ -9,7 +9,7 @@ from django.core.management.base import BaseCommand, CommandError
 from django.db import reset_queries
 
 from candidates.csv_helpers import list_to_csv
-from candidates.models import PersonExtra
+from candidates.models import PersonExtra, PersonRedirect
 from candidates.models.fields import get_complex_popolo_fields
 from elections.models import Election
 
@@ -73,7 +73,8 @@ class Command(BaseCommand):
         ):
             for d in person_extra.as_list_of_dicts(
                 election,
-                base_url=self.options['site_base_url']
+                base_url=self.options['site_base_url'],
+                redirects=self.redirects,
             ):
                 all_people.append(d)
                 if d['elected'] == 'True':
@@ -92,6 +93,7 @@ class Command(BaseCommand):
 
         self.options = options
         self.complex_popolo_fields = get_complex_popolo_fields()
+        self.redirects = PersonRedirect.all_redirects_dict()
 
         for election in all_elections:
             if election is None:

--- a/candidates/models/db.py
+++ b/candidates/models/db.py
@@ -1,5 +1,6 @@
 from __future__ import unicode_literals
 
+from collections import defaultdict
 from datetime import datetime, timedelta
 from functools import reduce
 
@@ -124,6 +125,16 @@ class PersonRedirect(models.Model):
     after two people are merged'''
     old_person_id = models.IntegerField()
     new_person_id = models.IntegerField()
+
+    @classmethod
+    def all_redirects_dict(cls):
+        new_to_sorted_old = defaultdict(list)
+        for old, new in cls.objects.values_list(
+                'old_person_id', 'new_person_id'):
+            new_to_sorted_old[new].append(old)
+        for v in new_to_sorted_old.values():
+            v.sort()
+        return new_to_sorted_old
 
 
 class UserTermsAgreement(models.Model):

--- a/candidates/models/field_mappings.py
+++ b/candidates/models/field_mappings.py
@@ -32,4 +32,5 @@ CSV_ROW_FIELDS = [
     'election_current',
     'party_lists_in_use',
     'party_list_position',
+    'old_person_ids',
 ]

--- a/candidates/tests/test_constituency_view.py
+++ b/candidates/tests/test_constituency_view.py
@@ -153,6 +153,7 @@ class TestConstituencyDetailView(TestUserMixin, UK2015ExamplesMixin, WebTest):
                 'party_list_position': '',
                 'image_copyright': '',
                 'name': 'Tessa Jowell',
+                'old_person_ids': '',
                 'gender': '',
                 'linkedin_url': '',
                 'image_uploading_user': '',

--- a/candidates/tests/test_csv_export.py
+++ b/candidates/tests/test_csv_export.py
@@ -8,7 +8,7 @@ from os.path import join
 from django.conf import settings
 from django.test import TestCase
 
-from candidates.models import PersonExtra, ImageExtra
+from candidates.models import PersonExtra, ImageExtra, PersonRedirect
 from ..csv_helpers import list_to_csv
 
 from . import factories
@@ -119,7 +119,7 @@ class CSVTests(TestUserMixin, UK2015ExamplesMixin, TestCase):
             person_dict_list = person_extra.as_list_of_dicts(self.election)
         self.assertEqual(len(person_dict_list), 1)
         person_dict = person_dict_list[0]
-        self.assertEqual(len(person_dict), 31)
+        self.assertEqual(len(person_dict), 32)
         self.assertEqual(person_dict['id'], 2009)
 
     def test_as_dict_2010(self):
@@ -131,7 +131,7 @@ class CSVTests(TestUserMixin, UK2015ExamplesMixin, TestCase):
             person_dict_list = person_extra.as_list_of_dicts(self.earlier_election)
         self.assertEqual(len(person_dict_list), 1)
         person_dict = person_dict_list[0]
-        self.assertEqual(len(person_dict), 31)
+        self.assertEqual(len(person_dict), 32)
         self.assertEqual(person_dict['id'], 2009)
 
     def test_csv_output(self):
@@ -140,18 +140,23 @@ class CSVTests(TestUserMixin, UK2015ExamplesMixin, TestCase):
             'election_date': date_in_near_future,
             'earlier_election_date': date_in_near_future - timedelta(days=FOUR_YEARS_IN_DAYS),
         }
+        PersonRedirect.objects.create(old_person_id=12, new_person_id=1953)
+        PersonRedirect.objects.create(old_person_id=56, new_person_id=1953)
         example_output = (
-            'id,name,honorific_prefix,honorific_suffix,gender,birth_date,election,party_id,party_name,post_id,post_label,mapit_url,elected,email,twitter_username,facebook_page_url,party_ppc_page_url,facebook_personal_url,homepage_url,wikipedia_url,linkedin_url,image_url,proxy_image_url_template,image_copyright,image_uploading_user,image_uploading_user_notes,twitter_user_id,election_date,election_current,party_lists_in_use,party_list_position\r\n'
-            '2009,Tessa Jowell,Ms,DBE,female,,2015,party:53,Labour Party,65913,Camberwell and Peckham,http://mapit.mysociety.org/area/65913,,jowell@example.com,,,,,,,,{image_url},,example-license,john,A photo of Tessa Jowell,,{election_date},True,False,\r\n'.format(image_url=tessa_image_url, **d) + \
-            '2009,Tessa Jowell,Ms,DBE,female,,2010,party:53,Labour Party,65808,Dulwich and West Norwood,http://mapit.mysociety.org/area/65808,,jowell@example.com,,,,,,,,{image_url},,example-license,john,A photo of Tessa Jowell,,{earlier_election_date},False,False,\r\n'.format(image_url=tessa_image_url, **d) + \
-            '1953,Daith\xed McKay,,,male,,2015,party:39,Sinn F\xe9in,66135,North Antrim,http://mapit.mysociety.org/area/66135,,,,,,,,,,,,,,,,{election_date},True,False,\r\n'.format(**d) + \
-            '1953,Daith\xed McKay,,,male,,2010,party:39,Sinn F\xe9in,66135,North Antrim,http://mapit.mysociety.org/area/66135,,,,,,,,,,,,,,,,{earlier_election_date},False,False,\r\n'.format(**d)
+            'id,name,honorific_prefix,honorific_suffix,gender,birth_date,election,party_id,party_name,post_id,post_label,mapit_url,elected,email,twitter_username,facebook_page_url,party_ppc_page_url,facebook_personal_url,homepage_url,wikipedia_url,linkedin_url,image_url,proxy_image_url_template,image_copyright,image_uploading_user,image_uploading_user_notes,twitter_user_id,election_date,election_current,party_lists_in_use,party_list_position,old_person_ids\r\n'
+            '2009,Tessa Jowell,Ms,DBE,female,,2015,party:53,Labour Party,65913,Camberwell and Peckham,http://mapit.mysociety.org/area/65913,,jowell@example.com,,,,,,,,{image_url},,example-license,john,A photo of Tessa Jowell,,{election_date},True,False,,\r\n'.format(image_url=tessa_image_url, **d) + \
+            '2009,Tessa Jowell,Ms,DBE,female,,2010,party:53,Labour Party,65808,Dulwich and West Norwood,http://mapit.mysociety.org/area/65808,,jowell@example.com,,,,,,,,{image_url},,example-license,john,A photo of Tessa Jowell,,{earlier_election_date},False,False,,\r\n'.format(image_url=tessa_image_url, **d) + \
+            '1953,Daith\xed McKay,,,male,,2015,party:39,Sinn F\xe9in,66135,North Antrim,http://mapit.mysociety.org/area/66135,,,,,,,,,,,,,,,,{election_date},True,False,,12;56\r\n'.format(**d) + \
+            '1953,Daith\xed McKay,,,male,,2010,party:39,Sinn F\xe9in,66135,North Antrim,http://mapit.mysociety.org/area/66135,,,,,,,,,,,,,,,,{earlier_election_date},False,False,,12;56\r\n'.format(**d)
         )
         gb_person_extra = get_person_extra_with_joins(self.gb_person_extra.id)
         ni_person_extra = get_person_extra_with_joins(self.ni_person_extra.id)
         # After the select_related and prefetch_related calls on
         # PersonExtra, there should only be one query per PersonExtra:
+        redirects = PersonRedirect.all_redirects_dict()
         with self.assertNumQueries(2):
-            list_of_dicts = gb_person_extra.as_list_of_dicts(None)
-            list_of_dicts += ni_person_extra.as_list_of_dicts(None)
+            list_of_dicts = gb_person_extra.as_list_of_dicts(
+                None, redirects=redirects)
+            list_of_dicts += ni_person_extra.as_list_of_dicts(
+                None, redirects=redirects)
         self.assertEqual(list_to_csv(list_of_dicts), example_output)

--- a/candidates/views/constituencies.py
+++ b/candidates/views/constituencies.py
@@ -30,7 +30,8 @@ from ..forms import NewPersonForm, ToggleLockForm, ConstituencyRecordWinnerForm
 from ..models import (
     TRUSTED_TO_LOCK_GROUP_NAME, get_edits_allowed, is_post_locked,
     RESULT_RECORDERS_GROUP_NAME, LoggedAction, PostExtra, OrganizationExtra,
-    MembershipExtra, PartySet, SimplePopoloField, ExtraField, PostExtraElection
+    MembershipExtra, PartySet, SimplePopoloField, ExtraField, PostExtraElection,
+    PersonRedirect
 )
 from official_documents.models import OfficialDocument
 from results.models import ResultEvent
@@ -265,6 +266,7 @@ class ConstituencyDetailCSVView(ElectionMixin, View):
     http_method_names = ['get']
 
     def get(self, request, *args, **kwargs):
+        redirects = PersonRedirect.all_redirects_dict()
         post = Post.objects \
             .select_related('extra') \
             .get(extra__slug=kwargs['post_id'])
@@ -276,7 +278,8 @@ class ConstituencyDetailCSVView(ElectionMixin, View):
                 ) \
                 .select_related('base__person') \
                 .prefetch_related('base__person__extra'):
-            for d in me.base.person.extra.as_list_of_dicts(self.election_data):
+            for d in me.base.person.extra.as_list_of_dicts(
+                    self.election_data, redirects=redirects):
                 all_people.append(d)
 
         filename = "{election}-{constituency_slug}.csv".format(


### PR DESCRIPTION
This enables consumers of the CSV files to tell, when a person's row
disappears from that file, which other person they had been merged into.

This implementation is probably more complex than you'd think it should be
to avoid doing more than one query on PersonRedirect when generating a
CSV file.

Fixes #242