### PR TITLE
Show the whole "statement to voters" field on the person page

### DIFF
--- a/elections/uk/templates/candidates/person-view.html
+++ b/elections/uk/templates/candidates/person-view.html
@@ -154,7 +154,7 @@
     {% endif %}
     {% if 'biography' in simple_fields %}
       <dt>{% trans "Statement to voters" %}</dt>
-      <dd class="person_biography">{% if person.biography %}{{ person.biography|linebreaks|truncatewords_html:200 }}{% endif %}</dd>
+      <dd class="person_biography">{% if person.biography %}{{ person.biography|linebreaks }}{% endif %}</dd>
     {% endif %}
   </dl>
 


### PR DESCRIPTION
Quite a few people have been confused by the truncation of their
statement to voters after they've entered it, so let's just show the
whole thing.