### PR TITLE
RemovedInDjango19Warning: make RedirectView.permanent=False explicit

### DIFF
--- a/elections/uk/views/redirects.py
+++ b/elections/uk/views/redirects.py
@@ -68,6 +68,8 @@ class OfficialDocumentsRedirect(RedirectView):
 
 class WhoPostcodeRedirect(RedirectView):
 
+    permanent = False
+
     def get_redirect_url(self, *args, **kwargs):
         postcode = self.request.GET.get('postcode', '')
         if is_valid_postcode(postcode):


### PR DESCRIPTION
We've been getting this warning whenever running "./manage.py runserver":

  RemovedInDjango19Warning: Default value of 'RedirectView.permanent' will change from True to False in Django 1.9. Set an explicit value to silence this warning.
    views.WhoPostcodeRedirect.as_view()

So this commit sets the value explicitly to what was happening anyway
under Django 1.8 - sending a temporary redirect (302).