### PR TITLE
Don't limit the number of search results

### DIFF
--- a/candidates/views/search.py
+++ b/candidates/views/search.py
@@ -70,6 +70,4 @@ class PersonSearch(SearchView):
     def get_context_data(self, **kwargs):
         context = super(PersonSearch, self).get_context_data(**kwargs)
         context['looks_like_postcode'] = is_valid_postcode(context['query'])
-        # Only return 5 results
-        context['object_list'] = context['object_list'][:5]
         return context


### PR DESCRIPTION
The number of search results has being limited to 5 results in all cases,
since the commit 09a263f9 on the basis that "With the number of
candidates we have, any matches below the first 5 aren't normally
relevant at all."  However, now we have a lot more candidates in the
database now, and a search for a common name (e.g. "Chandler" or "Philip")
misses many people with that name.

I've looked at picking a cutoff value based on Elasticsearch's 'score'
for each result, but can't find one that works satisfactorily across a
variety of searches (with the very old version of Elasticsearch we're
using, anyway).

So, I think it's best not to arbitrarily limit the number of search
results returned, since this will help to reduce the confusion caused
when people with common names don't appear in search results. This
commit just removes the limit on the number of search results
returned - in practice even without this limit, the number of results
is pretty reasonable whatever I use as a search term.