### PR TITLE
Fix LoggedAction.post_election_guess for posts just in past elections

### DIFF
--- a/candidates/models/db.py
+++ b/candidates/models/db.py
@@ -72,21 +72,14 @@ class LoggedAction(models.Model):
         rather than a Post and an Election (or a PostExtraElection).
         """
         from candidates.models import PostExtraElection
-        from elections.models import Election
         if self.post:
-            try:
-                election = self.post.extra.elections.filter(
-                    current=True).first()
-            except Election.DoesNotExist:
-                election = self.post.extra.elections.first()
-
-            pee = PostExtraElection.objects.get(
+            election = self.post.extra.elections.filter(
+                current=True).first() or \
+                self.post.extra.elections.first()
+            return PostExtraElection.objects.get(
                 election=election,
                 postextra=self.post.extra
             )
-
-            return pee
-
 
     @property
     def subject_url(self):

--- a/candidates/tests/test_logged_action.py
+++ b/candidates/tests/test_logged_action.py
@@ -1,6 +1,6 @@
 from django.test import TestCase
 
-from candidates.models import LoggedAction
+from candidates.models import LoggedAction, PostExtraElection
 
 from .auth import TestUserMixin
 from .uk_examples import UK2015ExamplesMixin
@@ -56,4 +56,52 @@ class TestLoggedAction(TestUserMixin, UK2015ExamplesMixin, TestCase):
         self.assertEqual(
             action.subject_html,
             '<a href="/election/2015/post/65913/camberwell-and-peckham">Camberwell and Peckham (65913)</a>',
+        )
+
+    def test_guess_of_postextraelection_current(self):
+        action = LoggedAction.objects.create(
+            user=self.user,
+            action_type='constituency-lock',
+            ip_address='127.0.0.1',
+            post=self.camberwell_post_extra.base,
+            popit_person_new_version='1234567890abcdef',
+            source='Just for tests...',
+        )
+        self.assertEqual(
+            action.post_election_guess,
+            PostExtraElection.objects.get(
+                election=self.election,
+                postextra=self.camberwell_post_extra)
+        )
+
+    def test_guess_of_postextraelection_past(self):
+        ced_area_type = factories.AreaTypeFactory.create(name='CED')
+        past_election = factories.ElectionFactory.create(
+            current=False,
+            name='2017 Essex County Council local election',
+            election_date='2017-05-04',
+            area_types=(ced_area_type,),
+        )
+        council = factories.OrganizationFactory.create(
+            name='Essex County Council')
+        post = factories.PostExtraFactory.create(
+            elections=(past_election,),
+            slug='CED:19782',
+            base__label='CED:19782',
+            party_set=self.gb_parties,
+            base__organization=council,
+        ).base
+        action = LoggedAction.objects.create(
+            user=self.user,
+            action_type='constituency-lock',
+            ip_address='127.0.0.1',
+            post=post,
+            popit_person_new_version='1234567890abcdef',
+            source='Just for tests...',
+        )
+        self.assertEqual(
+            action.post_election_guess,
+            PostExtraElection.objects.get(
+                election=past_election,
+                postextra=post.extra)
         )


### PR DESCRIPTION
The fallback of looking for any election associated with the post if
there was no current one was never called. This commit fixes that and
adds a test for that code path.