### PR TITLE
Small measure to help deal with vandalism incidents

### DIFF
--- a/candidates/middleware.py
+++ b/candidates/middleware.py
@@ -6,6 +6,7 @@ from requests.adapters import ConnectionError
 
 from django.conf import settings
 from django.contrib.sites.models import Site
+from django.contrib.auth import logout
 from django.core.mail import send_mail
 from django.core.urlresolvers import reverse
 from django.http import Http404, HttpResponseRedirect
@@ -100,3 +101,12 @@ class DisableCachingForAuthenticatedUsers(object):
                 add_never_cache_headers(response)
 
         return response
+
+
+class LogoutDisabledUsersMiddleware(object):
+
+    def process_request(self, request):
+        if hasattr(request, 'user') and \
+           request.user.is_authenticated() and \
+           not request.user.is_active:
+            logout(request)

--- a/candidates/tests/test_logging_out_banned_users.py
+++ b/candidates/tests/test_logging_out_banned_users.py
@@ -1,0 +1,19 @@
+from __future__ import unicode_literals
+
+from django_webtest import WebTest
+
+from .auth import TestUserMixin
+
+class TestLoggingOutMiddleware(TestUserMixin, WebTest):
+
+    def test_no_logout_if_is_active(self):
+        self.app.get('/', user=self.user)
+        response = self.app.get('/')
+        self.assertIn('Sign out', response.text)
+
+    def test_logout_after_set_inactive(self):
+        self.app.get('/', user=self.user)
+        self.user.is_active = False
+        self.user.save()
+        response = self.app.get('/')
+        self.assertIn('Sign in to edit', response.text)

--- a/elections/uk/settings.py
+++ b/elections/uk/settings.py
@@ -23,6 +23,8 @@ PEOPLE_LIABLE_TO_VANDALISM = {
     8372, # Nicola Sturgeon
     737, # Ruth Davidson
 
+    34605, # Matt Furey-King (due to a vandalism incident)
+
     # Below we include the person ID of anyone who is currently a minister.
     # This list was generated from:
     #

--- a/mysite/settings/conf.py
+++ b/mysite/settings/conf.py
@@ -277,6 +277,7 @@ def get_settings(conf_file_leafname, election_app=None, tests=False):
             'django.middleware.common.CommonMiddleware',
             'django.middleware.csrf.CsrfViewMiddleware',
             'django.contrib.auth.middleware.AuthenticationMiddleware',
+            'candidates.middleware.LogoutDisabledUsersMiddleware',
             'candidates.middleware.CopyrightAssignmentMiddleware',
             'candidates.middleware.DisallowedUpdateMiddleware',
             'django.contrib.messages.middleware.MessageMiddleware',


### PR DESCRIPTION
This pull request does two things, to help deal with a recent vandalism incident:

* Force the logout of users who have `is_active` set to `False` (which is the recommended way to disable user accounts).
* Add the candidate whose profile was vandalised to the `PEOPLE_LIABLE_TO_VANDALISM` list so edits of that person's profile appear in the "needs review" channel.