### PR TITLE
Add newer apps to the coverage measurement

### DIFF
--- a/run-tests
+++ b/run-tests
@@ -34,7 +34,7 @@ for TEST_SETTINGS_MODULE in "${TEST_SETTINGS_MODULES[@]}"
 do
     if [ "$1" = "--coverage" ]
     then
-        COMMAND="coverage run -a --source=candidates,cached_counts,tasks,moderation_queue,elections --branch manage.py test --nologcapture --noinput --settings=$TEST_SETTINGS_MODULE"
+        COMMAND="coverage run -a --source=alerts,auth_helpers,bulk_adding,cached_counts,candidates,compat,elections,moderation_queue,official_documents,tasks,uk_results --branch manage.py test --nologcapture --noinput --settings=$TEST_SETTINGS_MODULE"
     else
         COMMAND="./manage.py test --nologcapture --noinput --settings=$TEST_SETTINGS_MODULE"
     fi


### PR DESCRIPTION
Several or the more recently added Django applications, like bulk_adding
and uk_results weren't being included in the coverage measurement. This
commit adds them, and orders the list of packages to measure coverage
for alphabetically to make it easier to check in future.