### PR TITLE
Reduce the queries needed for the /api/v0.9/posts/ endpoint

### DIFF
--- a/candidates/views/api.py
+++ b/candidates/views/api.py
@@ -342,8 +342,11 @@ class PostViewSet(viewsets.ModelViewSet):
             'party_set',
         ) \
         .prefetch_related(
-            'elections',
-            'elections__area_types',
+            Prefetch(
+                'postextraelection_set',
+                extra_models.PostExtraElection.objects \
+                    .select_related('election')
+            ),
             'base__area__other_identifiers',
             Prefetch(
                 'base__memberships',


### PR DESCRIPTION
The embedded elections serializer is now based on PostExtraElection so
needs a different prefetch to avoid the N+1 queries problem.