### PR TITLE
Cope with the version in a LoggedAction not being found for its person

### DIFF
--- a/candidates/models/__init__.py
+++ b/candidates/models/__init__.py
@@ -11,6 +11,7 @@ from .merge import merge_popit_people
 
 from .popolo_extra import AreaExtra
 from .popolo_extra import MultipleTwitterIdentifiers
+from .popolo_extra import VersionNotFound
 from .popolo_extra import PersonExtra
 from .popolo_extra import OrganizationExtra
 from .popolo_extra import PostExtra

--- a/candidates/models/db.py
+++ b/candidates/models/db.py
@@ -8,6 +8,8 @@ from django.contrib.auth.models import User
 from django.core.urlresolvers import reverse
 from django.db import models
 from django.db.models.signals import post_save
+from django.utils.html import escape
+from django.utils.six import text_type
 
 from slugify import slugify
 
@@ -110,10 +112,14 @@ class LoggedAction(models.Model):
 
     @property
     def diff_html(self):
+        from candidates.models import VersionNotFound
         if not self.person:
             return ''
-        return self.person.extra.diff_for_version(
-            self.popit_person_new_version, inline_style=True)
+        try:
+            return self.person.extra.diff_for_version(
+                self.popit_person_new_version, inline_style=True)
+        except VersionNotFound as e:
+            return '<p>{0}</p>'.format(escape(text_type(e)))
 
 
 class PersonRedirect(models.Model):

--- a/candidates/models/popolo_extra.py
+++ b/candidates/models/popolo_extra.py
@@ -325,6 +325,10 @@ class MultipleTwitterIdentifiers(Exception):
     pass
 
 
+class VersionNotFound(Exception):
+    pass
+
+
 @python_2_unicode_compatible
 class PersonExtra(HasImageMixin, models.Model):
     base = models.OneToOneField(Person, related_name='extra')
@@ -522,7 +526,7 @@ class PersonExtra(HasImageMixin, models.Model):
                 break
         if not right_version_diff:
             msg = "Couldn't find version {0} for person with ID {1}"
-            raise Exception(msg.format(version_id, self.base.id))
+            raise VersionNotFound(msg.format(version_id, self.base.id))
         template = loader.get_template('candidates/_diffs_against_parents.html')
         context = Context({
             'diffs_against_all_parents': right_version_diff['diffs'],


### PR DESCRIPTION
There seem to be quite a few cases where a LoggedAction refers to a
version_id which isn't present in the person's version history. This
could happen due to the (now fixed) bad transaction handling in the
Twitter username update (#262), for example. At the moment this makes
/feeds/needs-review.xml return a 500 error - the presence of some of
these cases shouldn't stop the whole feed from working, so this commit
changes the behaviour to catch the exception if a version is not found
and output a warning in the HTML instead.