### PR TITLE
candidates_cache_api_to_directory: fix a bug that prevented pruning

### DIFF
--- a/candidates/management/commands/candidates_cache_api_to_directory.py
+++ b/candidates/management/commands/candidates_cache_api_to_directory.py
@@ -58,7 +58,7 @@ def prune(output_directory):
     latest_symlink = join(output_directory, 'latest')
     if exists(latest_symlink):
         current_timestamped_directory = os.readlink(latest_symlink)
-        timestamped_directories_to_remove.remove(
+        timestamped_directories_to_remove.discard(
             current_timestamped_directory)
     # Don't remove any directory dated in the last 36 hours:
     remove_before = datetime.now() - timedelta(hours=36)


### PR DESCRIPTION
Unfortunately, the tests for this command didn't include the typical
case where a latest symlink was present and its target was also in the 4
most recently created directories, and the prune() function errored in
that case. This commit should fix that and adds a better test.