### PR TITLE
Small fixes for "needs review" feed summary HTML for Slack

### DIFF
--- a/candidates/models/popolo_extra.py
+++ b/candidates/models/popolo_extra.py
@@ -205,6 +205,16 @@ def paired_object_safe_to_delete(base_object):
     return True
 
 
+def squash_whitespace(s):
+    # Take any run of more than one whitespace character, and replace
+    # it either with a newline (if that replaced text contained a
+    # newline) or a space (otherwise).
+    return re.sub(
+        r'(?ims)\s+',
+        lambda m: '\n' if '\n' in m.group(0) else ' ',
+        s)
+
+
 class localparserinfo(parser.parserinfo):
     MONTHS = [
         ('Jan', _l('Jan'), 'January', _l('January')),
@@ -533,7 +543,7 @@ class PersonExtra(HasImageMixin, models.Model):
             'inline_style': inline_style,
         })
         rendered = template.render(context)
-        return '<dl>{0}</dl>'.format(rendered)
+        return squash_whitespace('<dl>{0}</dl>'.format(rendered))
 
     def record_version(self, change_metadata):
         versions = []

--- a/candidates/templates/candidates/_diffs_against_parents.html
+++ b/candidates/templates/candidates/_diffs_against_parents.html
@@ -14,7 +14,7 @@
       <p class="version-diff">
         {% for operation in diff %}
           {% if operation.op == 'add' %}
-             <span class="version-op-add"{% if inline_style %} style="color: #0a6b0c"{% endif %}>{% trans "Added:" %} {{ operation.path }} => {{ operation.value|prettyjson }}</span>
+             <span class="version-op-add"{% if inline_style %} style="color: #0a6b0c"{% endif %}>{% trans "Added:" %} {{ operation.path }} =&gt; {{ operation.value|prettyjson }}</span>
           {% elif operation.op == 'remove' %}
              <span class="version-op-remove"{% if inline_style %} style="color: #8e2424"{% endif %}>{% trans "Removed:" %} {{ operation.path }}
               {% blocktrans trimmed with previous=operation.previous_value|prettyjson %}

--- a/candidates/tests/test_version_diffs.py
+++ b/candidates/tests/test_version_diffs.py
@@ -1452,14 +1452,14 @@ class TestSingleVersionRendering(UK2015ExamplesMixin, TestCase):
                 self.example_person_extra.diff_for_version('3fc494d54f61a157')),
             '<dl>'
             '<dt>Changes made compared to parent 2f07734529a83242</dt>'
-            '<dd><p class="version-diff"><span class="version-op-add">Added: other_names/0/note => &quot;Maiden name&quot;</span><br/></p></dd>'
+            '<dd><p class="version-diff"><span class="version-op-add">Added: other_names/0/note =&gt; &quot;Maiden name&quot;</span><br/></p></dd>'
             '</dl>')
 
     def test_get_zero_parent_diff(self):
         self.assertEqual(
             tidy_html_whitespace(
                 self.example_person_extra.diff_for_version('2f07734529a83242')),
-            '''<dl><dt>Changes made in initial version</dt><dd><p class="version-diff"><span class="version-op-add">Added: honorific_prefix => &quot;Mrs&quot;</span><br/><span class="version-op-add">Added: id => &quot;6704&quot;</span><br/><span class="version-op-add">Added: identifiers => [ { &quot;identifier&quot;: &quot;13445&quot;, &quot;scheme&quot;: &quot;yournextmp-candidate&quot; } ]</span><br/><span class="version-op-add">Added: name => &quot;Sarah Jones&quot;</span><br/><span class="version-op-add">Added: other_names => [ { &quot;name&quot;: &quot;Sarah Smith&quot; } ]</span><br/></p></dd></dl>''')
+            '''<dl><dt>Changes made in initial version</dt><dd><p class="version-diff"><span class="version-op-add">Added: honorific_prefix =&gt; &quot;Mrs&quot;</span><br/><span class="version-op-add">Added: id =&gt; &quot;6704&quot;</span><br/><span class="version-op-add">Added: identifiers =&gt; [ { &quot;identifier&quot;: &quot;13445&quot;, &quot;scheme&quot;: &quot;yournextmp-candidate&quot; } ]</span><br/><span class="version-op-add">Added: name =&gt; &quot;Sarah Jones&quot;</span><br/><span class="version-op-add">Added: other_names =&gt; [ { &quot;name&quot;: &quot;Sarah Smith&quot; } ]</span><br/></p></dd></dl>''')
 
     def test_include_inline_style_colouring(self):
         self.assertEqual(
@@ -1468,5 +1468,5 @@ class TestSingleVersionRendering(UK2015ExamplesMixin, TestCase):
                     '3fc494d54f61a157', inline_style=True)),
             '<dl>'
             '<dt>Changes made compared to parent 2f07734529a83242</dt>'
-            '<dd><p class="version-diff"><span class="version-op-add" style="color: #0a6b0c">Added: other_names/0/note => &quot;Maiden name&quot;</span><br/></p></dd>'
+            '<dd><p class="version-diff"><span class="version-op-add" style="color: #0a6b0c">Added: other_names/0/note =&gt; &quot;Maiden name&quot;</span><br/></p></dd>'
             '</dl>')


### PR DESCRIPTION
These are a couple of small changes that'll hopefully make Slack render diffs in the `/feeds/needs-review.xml` feed better. (It seems to just strip out HTML tags, but preserve the whitespace that was around them.)