### PR TITLE
Fix and update the old results Atom feed code

### DIFF
--- a/candidates/static/candidates/_content.scss
+++ b/candidates/static/candidates/_content.scss
@@ -19,6 +19,11 @@
   margin: 1em;
 }
 
+.feed-example {
+  font-size: 70%;
+  white-space: pre-wrap;
+}
+
 .help-api p {
   margin-top: 0.6em
 }

--- a/candidates/templates/candidates/results.html
+++ b/candidates/templates/candidates/results.html
@@ -24,6 +24,165 @@
   <li><a href="{% url 'atom-results-basic' %}">{% trans "Basic Atom feed" %}</a></li>
 </ul>
 
+<p>Here is an example of the former - this is the contents of
+the feed with additional extra elements with a single
+result:</p>
+
+<pre class="feed-example">
+&lt;?xml version="1.0" encoding="utf-8"?&gt;
+&lt;feed xmlns="http://www.w3.org/2005/Atom" xml:lang="en-gb"&gt;
+  &lt;title&gt;Election results from Democracy Club Candidates (with extra data)&lt;/title&gt;
+  &lt;link href="https://candidates.democracyclub.org.uk/" rel="alternate"/&gt;
+  &lt;link href="https://candidates.democracyclub.org.uk/results/all.atom" rel="self"/&gt;
+  &lt;id&gt;https://candidates.democracyclub.org.uk/&lt;/id&gt;
+  &lt;updated&gt;2017-06-09T10:36:38.110335+00:00&lt;/updated&gt;
+  &lt;entry&gt;
+    &lt;title&gt;David Cameron (Conservative and Unionist Party) won in Witney&lt;/title&gt;
+    &lt;link href="https://candidates.democracyclub.org.uk/#32346" rel="alternate"/&gt;
+    &lt;published&gt;2017-06-09T10:36:38.110335+00:00&lt;/published&gt;
+    &lt;updated&gt;2017-06-09T10:36:38.110335+00:00&lt;/updated&gt;
+    &lt;author&gt;
+      &lt;name&gt;joe&lt;/name&gt;
+    &lt;/author&gt;
+    &lt;id&gt;https://candidates.democracyclub.org.uk/#32346&lt;/id&gt;
+    &lt;summary type="html"&gt;A Democracy Club Candidates volunteer recorded at 2017-06-09 10:36:38 that David Cameron (Conservative and Unionist Party) won the ballot in Witney, quoting the source 'BBC news'.&lt;/summary&gt;
+    &lt;election_slug&gt;parl.2017-06-08&lt;/election_slug&gt;
+    &lt;election_name&gt;2017 General Election&lt;/election_name&gt;
+    &lt;election_date&gt;2017-06-08&lt;/election_date&gt;
+    &lt;post_id&gt;WMC:E14001046&lt;/post_id&gt;
+    &lt;winner_person_id&gt;566&lt;/winner_person_id&gt;
+    &lt;winner_person_name&gt;David Cameron&lt;/winner_person_name&gt;
+    &lt;winner_party_id&gt;party:52&lt;/winner_party_id&gt;
+    &lt;winner_party_name&gt;Conservative and Unionist Party&lt;/winner_party_name&gt;
+    &lt;user_id&gt;3&lt;/user_id&gt;
+    &lt;post_name&gt;Witney&lt;/post_name&gt;
+    &lt;information_source&gt;BBC news&lt;/information_source&gt;
+    &lt;image_url&gt;https://candidates.democracyclub.org.uk/media/images/5517d858249b917507bee4f8.png&lt;/image_url&gt;
+    &lt;parlparse_id&gt;uk.org.publicwhip/person/10777&lt;/parlparse_id&gt;
+  &lt;/entry&gt;
+&lt;/feed&gt;
+</pre>
+
+<p>The corresponding basic Atom feed would look like:</p>
+
+<pre class="feed-example">
+&lt;?xml version="1.0" encoding="utf-8"?&gt;
+&lt;feed xmlns="http://www.w3.org/2005/Atom" xml:lang="en-gb"&gt;
+  &lt;title&gt;Election results from Democracy Club Candidates (with extra data)&lt;/title&gt;
+  &lt;link href="https://candidates.democracyclub.org.uk/" rel="alternate"/&gt;
+  &lt;link href="https://candidates.democracyclub.org.uk/results/all.atom" rel="self"/&gt;
+  &lt;id&gt;https://candidates.democracyclub.org.uk/&lt;/id&gt;
+  &lt;updated&gt;2017-06-09T10:36:38.110335+00:00&lt;/updated&gt;
+  &lt;entry&gt;
+    &lt;title&gt;David Cameron (Conservative and Unionist Party) won in Witney&lt;/title&gt;
+    &lt;link href="https://candidates.democracyclub.org.uk/#32346" rel="alternate"/&gt;
+    &lt;published&gt;2017-06-09T10:36:38.110335+00:00&lt;/published&gt;
+    &lt;updated&gt;2017-06-09T10:36:38.110335+00:00&lt;/updated&gt;
+    &lt;author&gt;
+      &lt;name&gt;joe&lt;/name&gt;
+    &lt;/author&gt;
+    &lt;id&gt;https://candidates.democracyclub.org.uk/#32346&lt;/id&gt;
+    &lt;summary type="html"&gt;A Democracy Club Candidates volunteer recorded at 2017-06-09 10:36:38 that David Cameron (Conservative and Unionist Party) won the ballot in Witney, quoting the source 'BBC news'.&lt;/summary&gt;
+  &lt;/entry&gt;
+&lt;/feed&gt;
+</pre>
+
+<p>
+  If you're using this feed, please be aware that it's possible
+  that a volunteer will record the wrong winner in error. At the
+  moment retractions of results aren't recorded in these results
+  feeds, but we're adding that very soon.
+</p>
+
+<p>
+  This feed contains results from any election, so if you just
+  want to get results for the 2017 General Election, say, you
+  should filter
+  for <tt>&lt;election_slug&gt;parl.2017-06-08&lt;/election_slug&gt;</tt>.
+</p>
+
+<p>
+  The additional XML elements in the extended feed have the following meaning:
+</p>
+
+<dl>
+
+  <dt>election_slug</dt>
+
+  <dd>The election ID
+    from <a href="https://elections.democracyclub.org.uk/">Every
+    Election</a> which is also used in URLs that refer to the election
+    on this site.</dd>
+
+  <dt>election_name</dt>
+
+  <dd>The human-readable name of this election</dd>
+
+  <dt>election_date</dt>
+
+  <dd>The date that the election is took place on</dd>
+
+  <dt>post_id</dt>
+
+  <dd>The ID of the post that the candidate has been elected
+  to. In the case of the 2017 general election in the UK, for
+  example, the post ID of <tt>WMC:E14001046</tt> represents the
+  UK parliament constituency of Witney, which
+  has <a href="https://en.wikipedia.org/wiki/ONS_coding_system">GSS
+  code</a> E14001046.</dd>
+
+  <dt>post_name</dt>
+
+  <dd>This is the human-readable short name of the post, which
+  is typically the name of the constituency or area the
+  candidate has been elected to represent, e.g. "Witney".</dd>
+
+  <dt>winner_person_id</dt>
+
+  <dd>The ID of the candidate who was elected to this post,
+    which is used to identify them on this website (e.g. in
+    URLs)
+  </dd>
+
+  <dt>winner_person_name</dt>
+
+  <dd>The name of the candidate who was elected to this post.</dd>
+
+  <dt>winner_party_id</dt>
+
+  <dd>The ID of the party of the winning candidate. This is used
+  in URLs on this website, and should be based on an official ID
+  for the party. e.g. in the UK, <tt>party:52</tt> is the
+  Conservative party,
+  which <a href="http://search.electoralcommission.org.uk/English/Registrations/PP52">has
+  ID 52 on the Electoral Commission's website</a>.</dd>
+
+  <dt>image_url</dt>
+
+  <dd>If present, a link to a square headshot image of the
+  candidate. (You can read about licensing of the photos
+  on <a href="https://candidates.democracyclub.org.uk/help/about">the
+  About page</a>.)</dd>
+
+  <dt>parlparse_id</dt>
+
+  <dd>If present, this means that the winning candidate has been
+  previously elected, and this is their ID that's used on
+  TheyWorkForYou, PublicWhip and parlparse.</dd>
+
+  <dt>user_id</dt>
+
+  <dd>The ID of the user of this site who recorded that this
+  candidate was elected. This is unlikely to be of any use to
+  you and will likely be removed in the future.</dd>
+
+  <dt>information_source</dt>
+
+  <dd>The source of information that this candidate was indeed
+  elected to that post.</dd>
+
+</dl>
+
 <h2>{% trans "CSV/Excel downloads of election results" %}</h2>
 
   <h3>{% trans "All Elected Candidates" %}</h3>

--- a/candidates/tests/test_record_winner.py
+++ b/candidates/tests/test_record_winner.py
@@ -14,6 +14,7 @@ from .factories import (
 from .dates import processors_after
 from .uk_examples import UK2015ExamplesMixin
 
+from results.models import ResultEvent
 
 class TestRecordWinner(TestUserMixin, UK2015ExamplesMixin, WebTest):
 
@@ -34,20 +35,20 @@ class TestRecordWinner(TestUserMixin, UK2015ExamplesMixin, WebTest):
             organization=self.labour_party_extra.base
         )
 
-        winner = PersonExtraFactory.create(
+        self.winner = PersonExtraFactory.create(
             base__id='4322',
             base__name='Helen Hayes'
         )
 
         CandidacyExtraFactory.create(
             election=self.election,
-            base__person=winner.base,
+            base__person=self.winner.base,
             base__post=self.dulwich_post_extra.base,
             base__on_behalf_of=self.labour_party_extra.base
             )
 
         MembershipFactory.create(
-            person=winner.base,
+            person=self.winner.base,
             organization=self.labour_party_extra.base
         )
 
@@ -112,6 +113,7 @@ class TestRecordWinner(TestUserMixin, UK2015ExamplesMixin, WebTest):
             expect_errors=True,
         )
         self.assertEqual(post_response.status_code, 403)
+        self.assertEqual(0, ResultEvent.objects.count())
 
     def test_record_winner_privileged(self):
         base_record_url = reverse(
@@ -138,6 +140,16 @@ class TestRecordWinner(TestUserMixin, UK2015ExamplesMixin, WebTest):
 
         person = Person.objects.get(id=4322)
         self.assertTrue(person.extra.get_elected(self.election))
+        resultevent = ResultEvent.objects.get()
+        self.assertEqual(resultevent.election, self.election)
+        self.assertEqual(resultevent.winner, self.winner.base)
+        self.assertEqual(resultevent.old_post_id, '65808')
+        self.assertEqual(resultevent.old_post_name, 'Member of Parliament for Dulwich and West Norwood')
+        self.assertEqual(resultevent.post, self.dulwich_post_extra.base)
+        self.assertEqual(resultevent.winner_party, self.labour_party_extra.base)
+        self.assertEqual(resultevent.source, 'BBC website')
+        self.assertEqual(resultevent.user, self.user_who_can_record_results)
+        self.assertEqual(resultevent.parlparse_id, '')
 
     def test_cannot_record_multiple_winners(self):
         base_record_url = reverse(
@@ -175,6 +187,7 @@ class TestRecordWinner(TestUserMixin, UK2015ExamplesMixin, WebTest):
         with self.assertRaises(Exception) as context:
             submission_response = form.submit()
             self.assertEqual('There were already 1 winners' in context.exception)
+        self.assertEqual(1, ResultEvent.objects.count())
 
     def test_record_multiple_winners(self):
         self.election.people_elected_per_post = 2
@@ -221,6 +234,7 @@ class TestRecordWinner(TestUserMixin, UK2015ExamplesMixin, WebTest):
 
         person = Person.objects.get(id=2009)
         self.assertTrue(person.extra.get_elected(self.election))
+        self.assertEqual(2, ResultEvent.objects.count())
 
     def test_record_multiple_winners_per_post_setting(self):
         post_election = PostExtraElection.objects.get(
@@ -271,6 +285,7 @@ class TestRecordWinner(TestUserMixin, UK2015ExamplesMixin, WebTest):
 
         person = Person.objects.get(id=2009)
         self.assertTrue(person.extra.get_elected(self.election))
+        self.assertEqual(2, ResultEvent.objects.count())
 
 class TestRetractWinner(TestUserMixin, UK2015ExamplesMixin, WebTest):
 

--- a/candidates/views/constituencies.py
+++ b/candidates/views/constituencies.py
@@ -454,15 +454,20 @@ class ConstituencyRecordWinnerView(ElectionMixin, GroupRequiredMixin, FormView):
             membership_new_winner.extra.elected = True
             membership_new_winner.extra.save()
 
+            parlparse_id = ''
+            parlparse_identifier = self.person.identifiers.filter(scheme='uk.org.publicwhip').first()
+            if parlparse_identifier:
+                parlparse_id = parlparse_identifier.identifier
             ResultEvent.objects.create(
                 election=self.election_data,
                 winner=self.person,
-                winner_person_name=self.person.name,
-                post_id=self.post_data.extra.slug,
-                post_name=self.post_data.label,
-                winner_party_id=membership_new_winner.on_behalf_of.extra.slug,
+                old_post_id=self.post_data.extra.slug,
+                old_post_name=self.post_data.label,
+                post=self.post_data,
+                winner_party=membership_new_winner.on_behalf_of,
                 source=form.cleaned_data['source'],
                 user=self.request.user,
+                parlparse_id=parlparse_id,
             )
 
             self.person.extra.record_version(change_metadata)

--- a/results/feeds.py
+++ b/results/feeds.py
@@ -19,7 +19,7 @@ class BasicResultEventsFeed(Feed):
     description = _("A basic feed of election results")
 
     def items(self):
-        return ResultEvent.objects.filter(created__gte="2017-05-04") \
+        return ResultEvent.objects.filter(election__current=True) \
             .select_related('user') \
             .select_related('election') \
             .select_related('post__extra') \

--- a/results/feeds.py
+++ b/results/feeds.py
@@ -69,6 +69,9 @@ class ResultEventsAtomFeedGenerator(Atom1Feed):
         super(ResultEventsAtomFeedGenerator, self). \
             add_item_elements(handler, item)
         keys = [
+            'election_slug',
+            'election_name',
+            'election_date',
             'post_id',
             'winner_person_id',
             'winner_person_name',
@@ -101,6 +104,9 @@ class ResultEventsFeed(BasicResultEventsFeed):
             user_id = o.user.id
 
         return {
+            'election_slug': o.election.slug,
+            'election_name': o.election.name,
+            'election_date': o.election.election_date,
             'post_id': o.post.extra.slug if o.post else o.old_post_id,
             'winner_person_id': o.winner.id,
             'winner_person_name': o.winner.name,

--- a/results/feeds.py
+++ b/results/feeds.py
@@ -36,7 +36,7 @@ class BasicResultEventsFeed(Feed):
     def item_description(self, item):
         message = _('A {site_name} volunteer recorded at {datetime} that '
             '{name} ({party}) won the ballot in {cons}, quoting the '
-            "source '{source}').")
+            "source '{source}'.")
         return message.format(
             name=item.winner.name,
             datetime=item.created.strftime("%Y-%m-%d %H:%M:%S"),

--- a/results/migrations/0009_resultevent_election_new.py
+++ b/results/migrations/0009_resultevent_election_new.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('elections', '0012_election_people_elected_per_post'),
+        ('results', '0008_remove_resultevent_winner_popit_person_id'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='resultevent',
+            name='election_new',
+            field=models.ForeignKey(blank=True, to='elections.Election', null=True),
+        ),
+    ]

--- a/results/migrations/0010_resultevent_winner_party_new.py
+++ b/results/migrations/0010_resultevent_winner_party_new.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('popolo', '0002_update_models_from_upstream'),
+        ('results', '0009_resultevent_election_new'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='resultevent',
+            name='winner_party_new',
+            field=models.ForeignKey(blank=True, to='popolo.Organization', null=True),
+        ),
+    ]

--- a/results/migrations/0011_resultevent_post_new.py
+++ b/results/migrations/0011_resultevent_post_new.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('popolo', '0002_update_models_from_upstream'),
+        ('results', '0010_resultevent_winner_party_new'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='resultevent',
+            name='post_new',
+            field=models.ForeignKey(blank=True, to='popolo.Post', null=True),
+        ),
+    ]

--- a/results/migrations/0012_migrate_resultevent_data.py
+++ b/results/migrations/0012_migrate_resultevent_data.py
@@ -1,0 +1,45 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations
+
+
+def migrate_remaining_fields_to_popolo_models(apps, schema_editor):
+    ResultEvent = apps.get_model('results', 'ResultEvent')
+    Organization = apps.get_model('popolo', 'Organization')
+    Post = apps.get_model('popolo', 'Post')
+    Election = apps.get_model('elections', 'Election')
+    for re in ResultEvent.objects.all():
+        # Get the post, if possible (some have been deleted), and the
+        # election based on the existing text-based fields:
+        if re.election == '2015':
+            election_name = '2015 General Election'
+        else:
+            election_name = re.election
+        post = Post.objects.filter(extra__slug=re.post_id).first()
+        if post:
+            election = post.extra.elections.filter(name=election_name).first()
+            if not election:
+                election = post.extra.elections.get(
+                    name=election_name,
+                    election_date__year=re.created.year,
+                )
+        else:
+            election = Election.objects.get(name=re.election)
+        re.election_new = election
+        re.post_new = post
+        # Now get the party of the winner:
+        re.winner_party_new = Organization.objects.get(
+            extra__slug=re.winner_party_id)
+        re.save()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('results', '0011_resultevent_post_new'),
+    ]
+
+    operations = [
+        migrations.RunPython(migrate_remaining_fields_to_popolo_models),
+    ]

--- a/results/migrations/0013_remove_old_fields.py
+++ b/results/migrations/0013_remove_old_fields.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('results', '0012_migrate_resultevent_data'),
+    ]
+
+    operations = [
+        migrations.RemoveField(
+            model_name='resultevent',
+            name='election',
+        ),
+        migrations.RemoveField(
+            model_name='resultevent',
+            name='winner_party_id',
+        ),
+        migrations.RemoveField(
+            model_name='resultevent',
+            name='winner_person_name',
+        ),
+    ]

--- a/results/migrations/0014_rename_election_new_to_election.py
+++ b/results/migrations/0014_rename_election_new_to_election.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('results', '0013_remove_old_fields'),
+    ]
+
+    operations = [
+        migrations.RenameField(
+            model_name='resultevent',
+            old_name='election_new',
+            new_name='election',
+        ),
+    ]

--- a/results/migrations/0015_rename_to_winner_party.py
+++ b/results/migrations/0015_rename_to_winner_party.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('results', '0014_rename_election_new_to_election'),
+    ]
+
+    operations = [
+        migrations.RenameField(
+            model_name='resultevent',
+            old_name='winner_party_new',
+            new_name='winner_party',
+        ),
+    ]

--- a/results/migrations/0016_rename_post_id_to_old_post_id.py
+++ b/results/migrations/0016_rename_post_id_to_old_post_id.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('results', '0015_rename_to_winner_party'),
+    ]
+
+    operations = [
+        migrations.RenameField(
+            model_name='resultevent',
+            old_name='post_id',
+            new_name='old_post_id',
+        ),
+    ]

--- a/results/migrations/0017_rename_post_name_to_old_post_name.py
+++ b/results/migrations/0017_rename_post_name_to_old_post_name.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('results', '0016_rename_post_id_to_old_post_id'),
+    ]
+
+    operations = [
+        migrations.RenameField(
+            model_name='resultevent',
+            old_name='post_name',
+            new_name='old_post_name',
+        ),
+    ]

--- a/results/migrations/0018_fix_2015_resultevent_winners.py
+++ b/results/migrations/0018_fix_2015_resultevent_winners.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations
+
+
+def fix_2015_winners(apps, schema_editor):
+    ResultEvent = apps.get_model('results', 'ResultEvent')
+    Person = apps.get_model('popolo', 'Person')
+    for re in ResultEvent.objects.filter(election__slug=2015):
+        # Through some mistake or other, all the winners of the 2015
+        # were set to the person with ID 1. Find the right person
+        # instead:
+        if re.winner.id == 1:
+            re.winner = Person.objects.get(
+                memberships__extra__elected=True,
+                memberships__extra__election=re.election,
+                memberships__post=re.post_new,
+                memberships__on_behalf_of=re.winner_party)
+            re.save()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('results', '0017_rename_post_name_to_old_post_name'),
+    ]
+
+    operations = [
+        migrations.RunPython(fix_2015_winners),
+    ]

--- a/results/migrations/0019_rename_post_new_to_post.py
+++ b/results/migrations/0019_rename_post_new_to_post.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('results', '0018_fix_2015_resultevent_winners'),
+    ]
+
+    operations = [
+        migrations.RenameField(
+            model_name='resultevent',
+            old_name='post_new',
+            new_name='post',
+        ),
+    ]

--- a/results/migrations/0020_remove_resultevent_proxy_image_url_template.py
+++ b/results/migrations/0020_remove_resultevent_proxy_image_url_template.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('results', '0019_rename_post_new_to_post'),
+    ]
+
+    operations = [
+        migrations.RemoveField(
+            model_name='resultevent',
+            name='proxy_image_url_template',
+        ),
+    ]

--- a/results/models.py
+++ b/results/models.py
@@ -3,7 +3,7 @@ from __future__ import unicode_literals
 from django.contrib.auth.models import User
 from django.db import models
 
-from popolo.models import Person
+from popolo.models import Organization, Person
 from elections.models import Election
 from candidates.models import OrganizationExtra
 
@@ -20,6 +20,7 @@ class ResultEvent(models.Model):
     post_id = models.CharField(blank=False, max_length=256)
     post_name = models.CharField(blank=True, null=True, max_length=1024)
     winner_party_id = models.CharField(blank=True, null=True, max_length=256)
+    winner_party_new = models.ForeignKey(Organization, blank=True, null=True)
     source = models.CharField(max_length=512)
     user = models.ForeignKey(User, blank=True, null=True)
     proxy_image_url_template = \

--- a/results/models.py
+++ b/results/models.py
@@ -13,15 +13,12 @@ class ResultEvent(models.Model):
         ordering = ['created']
 
     created = models.DateTimeField(auto_now_add=True)
-    election = models.CharField(blank=True, null=True, max_length=512)
-    election_new = models.ForeignKey(Election, blank=True, null=True)
+    election = models.ForeignKey(Election, blank=True, null=True)
     winner = models.ForeignKey(Person)
-    winner_person_name = models.CharField(blank=False, max_length=1024)
-    post_id = models.CharField(blank=False, max_length=256)
-    post_name = models.CharField(blank=True, null=True, max_length=1024)
+    old_post_id = models.CharField(blank=False, max_length=256)
+    old_post_name = models.CharField(blank=True, null=True, max_length=1024)
     post_new = models.ForeignKey(Post, blank=True, null=True)
-    winner_party_id = models.CharField(blank=True, null=True, max_length=256)
-    winner_party_new = models.ForeignKey(Organization, blank=True, null=True)
+    winner_party = models.ForeignKey(Organization, blank=True, null=True)
     source = models.CharField(max_length=512)
     user = models.ForeignKey(User, blank=True, null=True)
     proxy_image_url_template = \

--- a/results/models.py
+++ b/results/models.py
@@ -5,7 +5,7 @@ from django.db import models
 
 from popolo.models import Organization, Person, Post
 from elections.models import Election
-from candidates.models import OrganizationExtra
+
 
 class ResultEvent(models.Model):
 
@@ -26,9 +26,7 @@ class ResultEvent(models.Model):
     parlparse_id = models.CharField(blank=True, null=True, max_length=256)
 
     @property
-    def winner_party_name(self):
-        return OrganizationExtra.objects \
-            .select_related('base') \
-            .get(
-                slug=self.winner_party_id
-            ).base.name
+    def short_post_name(self):
+        if self.post:
+            return self.post.extra.short_label
+        return self.old_post_name

--- a/results/models.py
+++ b/results/models.py
@@ -21,8 +21,6 @@ class ResultEvent(models.Model):
     winner_party = models.ForeignKey(Organization, blank=True, null=True)
     source = models.CharField(max_length=512)
     user = models.ForeignKey(User, blank=True, null=True)
-    proxy_image_url_template = \
-        models.CharField(blank=True, null=True, max_length=1024)
     parlparse_id = models.CharField(blank=True, null=True, max_length=256)
 
     @property
@@ -30,3 +28,12 @@ class ResultEvent(models.Model):
         if self.post:
             return self.post.extra.short_label
         return self.old_post_name
+
+    @property
+    def image_url_path(self):
+        url_path = ''
+        for image in self.winner.extra.images.all():
+            if image.is_primary:
+                url_path = image.image.url
+                break
+        return url_path

--- a/results/models.py
+++ b/results/models.py
@@ -17,7 +17,7 @@ class ResultEvent(models.Model):
     winner = models.ForeignKey(Person)
     old_post_id = models.CharField(blank=False, max_length=256)
     old_post_name = models.CharField(blank=True, null=True, max_length=1024)
-    post_new = models.ForeignKey(Post, blank=True, null=True)
+    post = models.ForeignKey(Post, blank=True, null=True)
     winner_party = models.ForeignKey(Organization, blank=True, null=True)
     source = models.CharField(max_length=512)
     user = models.ForeignKey(User, blank=True, null=True)

--- a/results/models.py
+++ b/results/models.py
@@ -4,6 +4,7 @@ from django.contrib.auth.models import User
 from django.db import models
 
 from popolo.models import Person
+from elections.models import Election
 from candidates.models import OrganizationExtra
 
 class ResultEvent(models.Model):
@@ -13,6 +14,7 @@ class ResultEvent(models.Model):
 
     created = models.DateTimeField(auto_now_add=True)
     election = models.CharField(blank=True, null=True, max_length=512)
+    election_new = models.ForeignKey(Election, blank=True, null=True)
     winner = models.ForeignKey(Person)
     winner_person_name = models.CharField(blank=False, max_length=1024)
     post_id = models.CharField(blank=False, max_length=256)

--- a/results/models.py
+++ b/results/models.py
@@ -3,7 +3,7 @@ from __future__ import unicode_literals
 from django.contrib.auth.models import User
 from django.db import models
 
-from popolo.models import Organization, Person
+from popolo.models import Organization, Person, Post
 from elections.models import Election
 from candidates.models import OrganizationExtra
 
@@ -19,6 +19,7 @@ class ResultEvent(models.Model):
     winner_person_name = models.CharField(blank=False, max_length=1024)
     post_id = models.CharField(blank=False, max_length=256)
     post_name = models.CharField(blank=True, null=True, max_length=1024)
+    post_new = models.ForeignKey(Post, blank=True, null=True)
     winner_party_id = models.CharField(blank=True, null=True, max_length=256)
     winner_party_new = models.ForeignKey(Organization, blank=True, null=True)
     source = models.CharField(max_length=512)

--- a/results/tests.py
+++ b/results/tests.py
@@ -53,10 +53,8 @@ class TestResultsFeed(TestUserMixin, UK2015ExamplesMixin, WebTest):
         result_event = ResultEvent.objects.create(
             election=self.election,
             winner=person_extra.base,
-            winner_person_name=person_extra.base.name,
-            post_id=self.dulwich_post_extra.slug,
-            post_name=self.dulwich_post_extra.base.label,
-            winner_party_id=self.labour_party_extra.slug,
+            post=self.dulwich_post_extra.base,
+            winner_party=self.labour_party_extra.base,
             source='Seen on the BBC news',
             user=self.user,
             parlparse_id='uk.org.publicwhip/person/123456',

--- a/results/tests.py
+++ b/results/tests.py
@@ -83,6 +83,9 @@ class TestResultsFeed(TestUserMixin, UK2015ExamplesMixin, WebTest):
     </author>
     <id>http://example.com/#{item_id}</id>
     <summary type="html">A example.com volunteer recorded at {space_separated} that Tessa Jowell (Labour Party) won the ballot in Dulwich and West Norwood, quoting the source 'Seen on the BBC news'.</summary>
+    <election_slug>2015</election_slug>
+    <election_name>2015 General Election</election_name>
+    <election_date>{election_date}</election_date>
     <post_id>65808</post_id>
     <winner_person_id>4322</winner_person_id>
     <winner_person_name>Tessa Jowell</winner_person_name>
@@ -99,6 +102,7 @@ class TestResultsFeed(TestUserMixin, UK2015ExamplesMixin, WebTest):
     space_separated=result_event.created.strftime("%Y-%m-%d %H:%M:%S"),
     item_id=result_event.id,
     user_id=self.user.id,
+    election_date=self.election.election_date,
 )
         self.compare_xml(expected, xml_pretty)
 

--- a/results/tests.py
+++ b/results/tests.py
@@ -15,10 +15,11 @@ from django.utils.feedgenerator import rfc3339_date
 from candidates.tests import factories
 
 from candidates.tests.auth import TestUserMixin
+from candidates.tests.uk_examples import UK2015ExamplesMixin
 from .models import ResultEvent
 
 
-class TestResultsFeed(TestUserMixin, WebTest):
+class TestResultsFeed(TestUserMixin, UK2015ExamplesMixin, WebTest):
 
     maxDiff = None
 
@@ -44,27 +45,18 @@ class TestResultsFeed(TestUserMixin, WebTest):
             self.assertEqual(xml_a, xml_b)
 
     def setUp(self):
-        wmc_area_type = factories.AreaTypeFactory.create()
+        super(TestResultsFeed, self).setUp()
         person_extra = factories.PersonExtraFactory.create(
             base__id='4322',
             base__name='Tessa Jowell'
         )
-        election = factories.ElectionFactory.create(
-            slug='2015',
-            name='2015 General Election',
-            area_types=(wmc_area_type,),
-        )
-        factories.PartyExtraFactory.create(
-            slug='party:53',
-            base__name='Labour Party',
-        )
         result_event = ResultEvent.objects.create(
-            election=election,
+            election=self.election,
             winner=person_extra.base,
             winner_person_name=person_extra.base.name,
-            post_id='65808',
-            post_name='Member of Parliament for Dulwich and West Norwood',
-            winner_party_id='party:53',
+            post_id=self.dulwich_post_extra.slug,
+            post_name=self.dulwich_post_extra.base.label,
+            winner_party_id=self.labour_party_extra.slug,
             source='Seen on the BBC news',
             user=self.user,
             parlparse_id='uk.org.publicwhip/person/123456',

--- a/results/tests.py
+++ b/results/tests.py
@@ -92,7 +92,7 @@ class TestResultsFeed(TestUserMixin, WebTest):
       <name>john</name>
     </author>
     <id>http://example.com/#{item_id}</id>
-    <summary type="html">A example.com volunteer recorded at {space_separated} that Tessa Jowell (Labour Party) won the ballot in Member of Parliament for Dulwich and West Norwood, quoting the source 'Seen on the BBC news').</summary>
+    <summary type="html">A example.com volunteer recorded at {space_separated} that Tessa Jowell (Labour Party) won the ballot in Member of Parliament for Dulwich and West Norwood, quoting the source 'Seen on the BBC news'.</summary>
     <post_id>65808</post_id>
     <winner_person_id>4322</winner_person_id>
     <winner_person_name>Tessa Jowell</winner_person_name>
@@ -133,7 +133,7 @@ class TestResultsFeed(TestUserMixin, WebTest):
       <name>john</name>
     </author>
     <id>http://example.com/#{item_id}</id>
-    <summary type="html">A example.com volunteer recorded at {space_separated} that Tessa Jowell (Labour Party) won the ballot in Member of Parliament for Dulwich and West Norwood, quoting the source 'Seen on the BBC news').</summary>
+    <summary type="html">A example.com volunteer recorded at {space_separated} that Tessa Jowell (Labour Party) won the ballot in Member of Parliament for Dulwich and West Norwood, quoting the source 'Seen on the BBC news'.</summary>
   </entry>
 </feed>
 '''.format(

--- a/results/tests.py
+++ b/results/tests.py
@@ -74,7 +74,7 @@ class TestResultsFeed(TestUserMixin, UK2015ExamplesMixin, WebTest):
   <id>http://example.com/</id>
   <updated>{updated}</updated>
   <entry>
-    <title>Tessa Jowell (Labour Party) won in Member of Parliament for Dulwich and West Norwood</title>
+    <title>Tessa Jowell (Labour Party) won in Dulwich and West Norwood</title>
     <link href="http://example.com/#{item_id}" rel="alternate"/>
     <published>{updated}</published>
     <updated>{updated}</updated>
@@ -82,14 +82,14 @@ class TestResultsFeed(TestUserMixin, UK2015ExamplesMixin, WebTest):
       <name>john</name>
     </author>
     <id>http://example.com/#{item_id}</id>
-    <summary type="html">A example.com volunteer recorded at {space_separated} that Tessa Jowell (Labour Party) won the ballot in Member of Parliament for Dulwich and West Norwood, quoting the source 'Seen on the BBC news'.</summary>
+    <summary type="html">A example.com volunteer recorded at {space_separated} that Tessa Jowell (Labour Party) won the ballot in Dulwich and West Norwood, quoting the source 'Seen on the BBC news'.</summary>
     <post_id>65808</post_id>
     <winner_person_id>4322</winner_person_id>
     <winner_person_name>Tessa Jowell</winner_person_name>
     <winner_party_id>party:53</winner_party_id>
     <winner_party_name>Labour Party</winner_party_name>
     <user_id>{user_id}</user_id>
-    <post_name>Member of Parliament for Dulwich and West Norwood</post_name>
+    <post_name>Dulwich and West Norwood</post_name>
     <information_source>Seen on the BBC news</information_source>
     <parlparse_id>uk.org.publicwhip/person/123456</parlparse_id>
   </entry>
@@ -115,7 +115,7 @@ class TestResultsFeed(TestUserMixin, UK2015ExamplesMixin, WebTest):
   <id>http://example.com/</id>
   <updated>{updated}</updated>
   <entry>
-    <title>Tessa Jowell (Labour Party) won in Member of Parliament for Dulwich and West Norwood</title>
+    <title>Tessa Jowell (Labour Party) won in Dulwich and West Norwood</title>
     <link href="http://example.com/#{item_id}" rel="alternate"/>
     <published>{updated}</published>
     <updated>{updated}</updated>
@@ -123,7 +123,7 @@ class TestResultsFeed(TestUserMixin, UK2015ExamplesMixin, WebTest):
       <name>john</name>
     </author>
     <id>http://example.com/#{item_id}</id>
-    <summary type="html">A example.com volunteer recorded at {space_separated} that Tessa Jowell (Labour Party) won the ballot in Member of Parliament for Dulwich and West Norwood, quoting the source 'Seen on the BBC news'.</summary>
+    <summary type="html">A example.com volunteer recorded at {space_separated} that Tessa Jowell (Labour Party) won the ballot in Dulwich and West Norwood, quoting the source 'Seen on the BBC news'.</summary>
   </entry>
 </feed>
 '''.format(

--- a/run-tests
+++ b/run-tests
@@ -34,7 +34,7 @@ for TEST_SETTINGS_MODULE in "${TEST_SETTINGS_MODULES[@]}"
 do
     if [ "$1" = "--coverage" ]
     then
-        COMMAND="coverage run -a --source=alerts,auth_helpers,bulk_adding,cached_counts,candidates,compat,elections,moderation_queue,official_documents,tasks,uk_results --branch manage.py test --nologcapture --noinput --settings=$TEST_SETTINGS_MODULE"
+        COMMAND="coverage run -a --source=alerts,auth_helpers,bulk_adding,cached_counts,candidates,compat,elections,moderation_queue,official_documents,results,tasks,uk_results --branch manage.py test --nologcapture --noinput --settings=$TEST_SETTINGS_MODULE"
     else
         COMMAND="./manage.py test --nologcapture --noinput --settings=$TEST_SETTINGS_MODULE"
     fi

--- a/uk_results/forms.py
+++ b/uk_results/forms.py
@@ -102,7 +102,7 @@ class ReviewVotesForm(forms.ModelForm):
         for candidate_result in instance.candidate_results.all():
             membership = candidate_result.membership
             post_election = instance.post_election_result.post_election
-            election = membership.extra.election
+            election = post_election.election
 
             source = instance.review_source
             if not source:

--- a/uk_results/forms.py
+++ b/uk_results/forms.py
@@ -95,14 +95,13 @@ def mark_candidates_as_winner(request, instance):
             membership.extra.elected = True
             membership.extra.save()
 
-
             ResultEvent.objects.create(
                 election=election,
                 winner=membership.person,
-                winner_person_name=membership.person.name,
-                post_id=post_election.postextra.slug,
-                post_name=post_election.postextra.base.label,
-                winner_party_id=membership.on_behalf_of.extra.slug,
+                post=post_election.postextra.base,
+                old_post_id=post_election.postextra.slug,
+                old_post_name=post_election.postextra.base.label,
+                winner_party=membership.on_behalf_of,
                 source=source,
                 user=instance.reviewed_by,
             )

--- a/uk_results/tests.py
+++ b/uk_results/tests.py
@@ -1,3 +1,98 @@
+from __future__ import print_function, unicode_literals
+
+from mock import patch
+
 from django.test import TestCase
 
-# Create your tests here.
+from nose.plugins.attrib import attr
+
+from candidates.tests.auth import TestUserMixin
+from candidates.tests.factories import (
+    CandidacyExtraFactory, PersonExtraFactory)
+from candidates.tests.uk_examples import UK2015ExamplesMixin
+
+from results.models import ResultEvent
+
+from .models import CandidateResult, PostElectionResult, ResultSet
+from .forms import mark_candidates_as_winner
+
+
+@attr(country='uk')
+class TestUKResults(TestUserMixin, UK2015ExamplesMixin, TestCase):
+
+    def setUp(self):
+        super(TestUKResults, self).setUp()
+        # Create a PostElectionResult, initially not confirmed.
+        pee = self.local_post.postextraelection_set.get()
+        per = PostElectionResult.objects.create(
+            post_election=pee,
+            confirmed=False,
+        )
+        # Now create a ResultSet
+        self.result_set = ResultSet.objects.create(
+            post_election_result=per,
+            num_turnout_reported=10000,
+            num_spoilt_ballots=30,
+            user=self.user,
+            ip_address='127.0.0.1',
+            source='Example ResultSet for testing',
+            reviewed_by=self.user_who_can_record_results,
+        )
+        # Create three people:
+        self.persons_extra = [
+            PersonExtraFactory.create(base__id='13', base__name='Alice'),
+            PersonExtraFactory.create(base__id='14', base__name='Bob'),
+            PersonExtraFactory.create(base__id='15', base__name='Carol'),
+        ]
+        parties_extra = [
+            self.labour_party_extra,
+            self.conservative_party_extra,
+            self.ld_party_extra
+        ]
+        # Create their candidacies:
+        candidacies = [
+            CandidacyExtraFactory.create(
+                election=self.local_election,
+                base__person=person_extra.base,
+                base__post=self.local_post.base,
+                base__on_behalf_of=party_extra.base,
+            ).base
+            for person_extra, party_extra
+            in zip(self.persons_extra, parties_extra)
+        ]
+        # Create their CandidateResult objects:
+        votes = [2000, 5000, 3000]
+        winner = [False, True, False]
+        self.candidate_results = [
+            CandidateResult.objects.create(
+                result_set=self.result_set,
+                membership=c,
+                num_ballots_reported=v,
+                is_winner=w)
+            for c, v, w in zip(candidacies, votes, winner)
+        ]
+        # Now make that the confirmed ResultSet for that
+        # PostElectionResult.
+        per.confirmed = True
+        per.confirmed_resultset = self.result_set
+        per.save()
+
+    @patch('uk_results.forms.get_change_metadata')
+    def test_mark_candidates_as_winner(self, mock_get_change_metadata):
+        # 'instance' here is an instance of ResultSet. request is only
+        # needed to calculate change_metadata, so patch
+        # get_change_metadata instead.
+        mock_get_change_metadata.return_value = {
+            'information_source': 'Example source for tests',
+            'version_id': '277bb23c148bea2c',
+            'timestamp': '2017-06-05T14:01:14.394447'
+        }
+        mark_candidates_as_winner(None, self.result_set)
+        self.assertEqual(1, ResultEvent.objects.count())
+        result_event = ResultEvent.objects.get()
+        self.assertEqual(result_event.election, self.local_election)
+        self.assertEqual(result_event.winner, self.persons_extra[1].base)
+        self.assertEqual(result_event.post, self.local_post.base)
+        self.assertEqual(result_event.winner_party, self.conservative_party_extra.base)
+        self.assertEqual(result_event.source, 'Example ResultSet for testing')
+        self.assertEqual(result_event.user, self.user_who_can_record_results)


### PR DESCRIPTION
The `/results/all.atom` and `/results/all-basic.atom` feeds dated from before the migration to django-popolo, and only one of the fields had been migrated to those models. This pull request migrates the other fields which were just text-based to foreign keys where appropriate.

The only image URL which was included was a template for forming URLs for an image proxy that resized on-the-fly; this is no longer supported, so this pull request adds a new `<image_url>` element to the additional data.

This pull request also adds elements with data about the election to the extended feed.

This also adds some more useful help for these feeds:

![new-atom-feed](https://cloud.githubusercontent.com/assets/7907/26679418/d41d3e10-46cc-11e7-9d39-e2370f3b0d70.png)
