### PR TITLE
Add retractions of previous results to the results feeds

### DIFF
--- a/candidates/models/popolo_extra.py
+++ b/candidates/models/popolo_extra.py
@@ -391,6 +391,13 @@ class PersonExtra(HasImageMixin, models.Model):
             return path
         return request.build_absolute_uri(path)
 
+    def get_identifier(self, scheme):
+        identifier_object = self.base.identifiers.filter(
+            scheme='uk.org.publicwhip').first()
+        if identifier_object:
+            return identifier_object.identifier
+        return ''
+
     @property
     def current_candidacies(self):
         result = self.base.memberships.filter(

--- a/candidates/templates/candidates/results.html
+++ b/candidates/templates/candidates/results.html
@@ -46,6 +46,7 @@ result:</p>
     &lt;/author&gt;
     &lt;id&gt;https://candidates.democracyclub.org.uk/#32346&lt;/id&gt;
     &lt;summary type="html"&gt;A Democracy Club Candidates volunteer recorded at 2017-06-09 10:36:38 that David Cameron (Conservative and Unionist Party) won the ballot in Witney, quoting the source 'BBC news'.&lt;/summary&gt;
+    &lt;retraction&gt;0&lt;/retraction&gt;
     &lt;election_slug&gt;parl.2017-06-08&lt;/election_slug&gt;
     &lt;election_name&gt;2017 General Election&lt;/election_name&gt;
     &lt;election_date&gt;2017-06-08&lt;/election_date&gt;
@@ -88,11 +89,29 @@ result:</p>
 </pre>
 
 <p>
+
   If you're using this feed, please be aware that it's possible
-  that a volunteer will record the wrong winner in error. At the
-  moment retractions of results aren't recorded in these results
-  feeds, but we're adding that very soon.
+  that a volunteer will record the wrong winner in error. In
+  that case, there will be an entry in the feed to indicate that
+  that statement about the winner has been retracted. If you're
+  using the extended feed, that will have
+  a <tt>&lt;retracted&gt;1&lt;/retracted&gt;</tt> element. If
+  you're using the basic feed, then the entry will look like:
 </p>
+
+<pre class="feed-example">
+&lt;entry&gt;
+  &lt;title&gt;Correction: retracting the statement that Tessa Jowell (Labour Party) won in Dulwich and West Norwood&lt;/title&gt;
+  &lt;link href="http://example.com/#32" rel="alternate"/&gt;
+  &lt;published&gt;2017-06-09T11:25:00.110335+00:00&lt;/published&gt;
+  &lt;updated&gt;2017-06-09T11:25:00.110335+00:00&lt;/updated&gt;
+  &lt;author&gt;
+    &lt;name&gt;john&lt;/name&gt;
+  &lt;/author&gt;
+  &lt;id&gt;http://example.com/#32&lt;/id&gt;
+  &lt;summary type="html"&gt;At 2017-06-09 11:25:00, a example.com volunteer retracted the previous assertion that Tessa Jowell (Labour Party) won the ballot in Dulwich and West Norwood, quoting the source 'Result recorded in error, retracting'.&lt;/summary&gt;
+&lt;/entry&gt;
+</pre>
 
 <p>
   This feed contains results from any election, so if you just

--- a/candidates/tests/test_record_winner.py
+++ b/candidates/tests/test_record_winner.py
@@ -150,6 +150,7 @@ class TestRecordWinner(TestUserMixin, UK2015ExamplesMixin, WebTest):
         self.assertEqual(resultevent.source, 'BBC website')
         self.assertEqual(resultevent.user, self.user_who_can_record_results)
         self.assertEqual(resultevent.parlparse_id, '')
+        self.assertEqual(resultevent.retraction, False)
 
     def test_cannot_record_multiple_winners(self):
         base_record_url = reverse(
@@ -188,6 +189,7 @@ class TestRecordWinner(TestUserMixin, UK2015ExamplesMixin, WebTest):
             submission_response = form.submit()
             self.assertEqual('There were already 1 winners' in context.exception)
         self.assertEqual(1, ResultEvent.objects.count())
+        self.assertFalse(ResultEvent.objects.get().retraction)
 
     def test_record_multiple_winners(self):
         self.election.people_elected_per_post = 2
@@ -235,6 +237,7 @@ class TestRecordWinner(TestUserMixin, UK2015ExamplesMixin, WebTest):
         person = Person.objects.get(id=2009)
         self.assertTrue(person.extra.get_elected(self.election))
         self.assertEqual(2, ResultEvent.objects.count())
+        self.assertEqual(2, ResultEvent.objects.filter(retraction=False).count())
 
     def test_record_multiple_winners_per_post_setting(self):
         post_election = PostExtraElection.objects.get(
@@ -286,6 +289,8 @@ class TestRecordWinner(TestUserMixin, UK2015ExamplesMixin, WebTest):
         person = Person.objects.get(id=2009)
         self.assertTrue(person.extra.get_elected(self.election))
         self.assertEqual(2, ResultEvent.objects.count())
+        self.assertEqual(2, ResultEvent.objects.filter(retraction=False).count())
+
 
 class TestRetractWinner(TestUserMixin, UK2015ExamplesMixin, WebTest):
 
@@ -306,21 +311,21 @@ class TestRetractWinner(TestUserMixin, UK2015ExamplesMixin, WebTest):
             organization=self.labour_party_extra.base
         )
 
-        winner = PersonExtraFactory.create(
+        self.winner = PersonExtraFactory.create(
             base__id='4322',
             base__name='Helen Hayes'
         )
 
         CandidacyExtraFactory.create(
             election=self.election,
-            base__person=winner.base,
+            base__person=self.winner.base,
             base__post=self.dulwich_post_extra.base,
             base__on_behalf_of=self.labour_party_extra.base,
             elected=True
             )
 
         MembershipFactory.create(
-            person=winner.base,
+            person=self.winner.base,
             organization=self.labour_party_extra.base
         )
 
@@ -384,6 +389,7 @@ class TestRetractWinner(TestUserMixin, UK2015ExamplesMixin, WebTest):
             expect_errors=True,
         )
         self.assertEqual(post_response.status_code, 403)
+        self.assertEqual(0, ResultEvent.objects.count())
 
     def test_retract_winner_privileged(self):
         self.app.get(
@@ -414,3 +420,16 @@ class TestRetractWinner(TestUserMixin, UK2015ExamplesMixin, WebTest):
 
         person = Person.objects.get(id=4322)
         self.assertFalse(person.extra.get_elected(self.election))
+
+        self.assertEqual(1, ResultEvent.objects.count())
+        resultevent = ResultEvent.objects.get()
+        self.assertEqual(resultevent.election, self.election)
+        self.assertEqual(resultevent.winner, self.winner.base)
+        self.assertEqual(resultevent.old_post_id, '65808')
+        self.assertEqual(resultevent.old_post_name, 'Member of Parliament for Dulwich and West Norwood')
+        self.assertEqual(resultevent.post, self.dulwich_post_extra.base)
+        self.assertEqual(resultevent.winner_party, self.labour_party_extra.base)
+        self.assertEqual(resultevent.source, 'Result recorded in error, retracting')
+        self.assertEqual(resultevent.user, self.user_who_can_record_results)
+        self.assertEqual(resultevent.parlparse_id, '')
+        self.assertEqual(resultevent.retraction, True)

--- a/candidates/views/constituencies.py
+++ b/candidates/views/constituencies.py
@@ -521,15 +521,31 @@ class ConstituencyRetractWinnerView(ElectionMixin, GroupRequiredMixin, View):
                 role=self.election_data.candidate_membership_role,
                 extra__election=self.election_data,
             )
+            source = _('Result recorded in error, retracting')
             for candidacy in all_candidacies.all():
+                if candidacy.extra.elected:
+                    # If elected is True then a ResultEvent will have
+                    # been created and been included in the feed, so
+                    # we need to create a corresponding retraction
+                    # ResultEvent.
+                    ResultEvent.objects.create(
+                        election=self.election_data,
+                        winner=candidacy.person,
+                        old_post_id=candidacy.post.extra.slug,
+                        old_post_name=candidacy.post.label,
+                        post=candidacy.post,
+                        winner_party=candidacy.on_behalf_of,
+                        source=source,
+                        user=self.request.user,
+                        parlparse_id=candidacy.person.extra.get_identifier(
+                            'uk.org.publicwhip'),
+                        retraction=True,
+                    )
                 if candidacy.extra.elected is not None:
                     candidacy.extra.elected = None
                     candidacy.extra.save()
                     candidate = candidacy.person
-                    change_metadata = get_change_metadata(
-                        self.request,
-                        _('Result recorded in error, retracting')
-                    )
+                    change_metadata = get_change_metadata(self.request, source)
                     candidate.extra.record_version(change_metadata)
                     candidate.save()
 

--- a/candidates/views/constituencies.py
+++ b/candidates/views/constituencies.py
@@ -454,10 +454,6 @@ class ConstituencyRecordWinnerView(ElectionMixin, GroupRequiredMixin, FormView):
             membership_new_winner.extra.elected = True
             membership_new_winner.extra.save()
 
-            parlparse_id = ''
-            parlparse_identifier = self.person.identifiers.filter(scheme='uk.org.publicwhip').first()
-            if parlparse_identifier:
-                parlparse_id = parlparse_identifier.identifier
             ResultEvent.objects.create(
                 election=self.election_data,
                 winner=self.person,
@@ -467,7 +463,8 @@ class ConstituencyRecordWinnerView(ElectionMixin, GroupRequiredMixin, FormView):
                 winner_party=membership_new_winner.on_behalf_of,
                 source=form.cleaned_data['source'],
                 user=self.request.user,
-                parlparse_id=parlparse_id,
+                parlparse_id=self.person.extra.get_identifier(
+                    'uk.org.publicwhip'),
             )
 
             self.person.extra.record_version(change_metadata)

--- a/results/feeds.py
+++ b/results/feeds.py
@@ -2,14 +2,12 @@ from __future__ import unicode_literals
 
 from django.contrib.sites.models import Site
 from django.contrib.syndication.views import Feed
-from django.db.models import Prefetch
 from django.utils.feedgenerator import Atom1Feed
 from django.utils.six.moves.urllib_parse import urlunsplit
 from django.utils.translation import ugettext_lazy as _
 
 from compat import text_type
 
-from candidates.models import ImageExtra
 from .models import ResultEvent
 
 

--- a/results/migrations/0021_resultevent_retraction.py
+++ b/results/migrations/0021_resultevent_retraction.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('results', '0020_remove_resultevent_proxy_image_url_template'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='resultevent',
+            name='retraction',
+            field=models.BooleanField(default=False),
+        ),
+    ]

--- a/results/models.py
+++ b/results/models.py
@@ -22,6 +22,7 @@ class ResultEvent(models.Model):
     source = models.CharField(max_length=512)
     user = models.ForeignKey(User, blank=True, null=True)
     parlparse_id = models.CharField(blank=True, null=True, max_length=256)
+    retraction = models.BooleanField(default=False)
 
     @property
     def short_post_name(self):

--- a/results/tests.py
+++ b/results/tests.py
@@ -21,7 +21,7 @@ from candidates.tests.uk_examples import UK2015ExamplesMixin
 from .models import ResultEvent
 
 
-class TestResultsFeed(TestUserMixin, UK2015ExamplesMixin, WebTest):
+class XMLEqualityMixin(object):
 
     maxDiff = None
 
@@ -45,6 +45,10 @@ class TestResultsFeed(TestUserMixin, UK2015ExamplesMixin, WebTest):
         tree_b.getroottree().write_c14n(c14n_b)
         if c14n_a.getvalue() != c14n_b.getvalue():
             self.assertEqual(xml_a, xml_b)
+
+
+class TestResultsFeed(
+        XMLEqualityMixin, TestUserMixin, UK2015ExamplesMixin, WebTest):
 
     def setUp(self):
         super(TestResultsFeed, self).setUp()

--- a/results/tests.py
+++ b/results/tests.py
@@ -73,7 +73,7 @@ class TestResultsFeed(
                 'user_notes': 'A photo of Tessa Jowell',
             },
         ).base
-        result_event = ResultEvent.objects.create(
+        ResultEvent.objects.create(
             election=self.election,
             winner=person_extra.base,
             post=self.dulwich_post_extra.base,
@@ -105,6 +105,7 @@ class TestResultsFeed(
     </author>
     <id>http://example.com/#{item_id}</id>
     <summary type="html">A example.com volunteer recorded at {space_separated} that Tessa Jowell (Labour Party) won the ballot in Dulwich and West Norwood, quoting the source 'Seen on the BBC news'.</summary>
+    <retraction>0</retraction>
     <election_slug>2015</election_slug>
     <election_name>2015 General Election</election_name>
     <election_date>{election_date}</election_date>
@@ -158,5 +159,205 @@ class TestResultsFeed(
     updated=rfc3339_date(result_event.created),
     space_separated=result_event.created.strftime("%Y-%m-%d %H:%M:%S"),
     item_id=result_event.id,
+)
+        self.compare_xml(expected, xml_pretty)
+
+
+class TestResultsFeedWithRetraction(
+        XMLEqualityMixin, TestUserMixin, UK2015ExamplesMixin, WebTest):
+
+    def setUp(self):
+        super(TestResultsFeedWithRetraction, self).setUp()
+        accidental_winner = factories.PersonExtraFactory.create(
+            base__id='4322',
+            base__name='Tessa Jowell',
+        )
+        real_winner = factories.PersonExtraFactory.create(
+            base__id='4493',
+            base__name='James Barber',
+        )
+        ResultEvent.objects.create(
+            election=self.election,
+            winner=accidental_winner.base,
+            post=self.dulwich_post_extra.base,
+            winner_party=self.labour_party_extra.base,
+            source='Seen on the BBC news',
+            user=self.user,
+            parlparse_id='uk.org.publicwhip/person/123456',
+        )
+        ResultEvent.objects.create(
+            election=self.election,
+            winner=accidental_winner.base,
+            post=self.dulwich_post_extra.base,
+            winner_party=self.labour_party_extra.base,
+            source='Result recorded in error, retracting',
+            user=self.user,
+            parlparse_id='uk.org.publicwhip/person/123456',
+            retraction=True,
+        )
+        ResultEvent.objects.create(
+            election=self.election,
+            winner=real_winner.base,
+            post=self.dulwich_post_extra.base,
+            winner_party=self.ld_party_extra.base,
+            source='Seen on Sky News',
+            user=self.user,
+        )
+        # This is ordered by default:
+        self.events = ResultEvent.objects.all()
+
+    def test_all_feed_with_a_correction(self):
+        response = self.app.get('/results/all.atom')
+        root = etree.XML(response.content)
+        xml_pretty = etree.tounicode(root, pretty_print=True)
+
+        expected = '''<feed xmlns="http://www.w3.org/2005/Atom" xml:lang="en-gb">
+  <title>Election results from example.com (with extra data)</title>
+  <link href="http://example.com/" rel="alternate"/>
+  <link href="http://example.com/results/all.atom" rel="self"/>
+  <id>http://example.com/</id>
+  <updated>{updated[0]}</updated>
+  <entry>
+    <title>Tessa Jowell (Labour Party) won in Dulwich and West Norwood</title>
+    <link href="http://example.com/#{item_id[0]}" rel="alternate"/>
+    <published>{updated[0]}</published>
+    <updated>{updated[0]}</updated>
+    <author>
+      <name>john</name>
+    </author>
+    <id>http://example.com/#{item_id[0]}</id>
+    <summary type="html">A example.com volunteer recorded at {space_separated[0]} that Tessa Jowell (Labour Party) won the ballot in Dulwich and West Norwood, quoting the source 'Seen on the BBC news'.</summary>
+    <retraction>0</retraction>
+    <election_slug>2015</election_slug>
+    <election_name>2015 General Election</election_name>
+    <election_date>{election_date}</election_date>
+    <post_id>65808</post_id>
+    <winner_person_id>4322</winner_person_id>
+    <winner_person_name>Tessa Jowell</winner_person_name>
+    <winner_party_id>party:53</winner_party_id>
+    <winner_party_name>Labour Party</winner_party_name>
+    <user_id>{user_id}</user_id>
+    <post_name>Dulwich and West Norwood</post_name>
+    <information_source>Seen on the BBC news</information_source>
+    <parlparse_id>uk.org.publicwhip/person/123456</parlparse_id>
+  </entry>
+  <entry>
+    <title>Correction: retracting the statement that Tessa Jowell (Labour Party) won in Dulwich and West Norwood</title>
+    <link href="http://example.com/#{item_id[1]}" rel="alternate"/>
+    <published>{updated[1]}</published>
+    <updated>{updated[1]}</updated>
+    <author>
+      <name>john</name>
+    </author>
+    <id>http://example.com/#{item_id[1]}</id>
+    <summary type="html">At {space_separated[1]}, a example.com volunteer retracted the previous assertion that Tessa Jowell (Labour Party) won the ballot in Dulwich and West Norwood, quoting the source 'Result recorded in error, retracting'.</summary>
+    <retraction>1</retraction>
+    <election_slug>2015</election_slug>
+    <election_name>2015 General Election</election_name>
+    <election_date>{election_date}</election_date>
+    <post_id>65808</post_id>
+    <winner_person_id>4322</winner_person_id>
+    <winner_person_name>Tessa Jowell</winner_person_name>
+    <winner_party_id>party:53</winner_party_id>
+    <winner_party_name>Labour Party</winner_party_name>
+    <user_id>{user_id}</user_id>
+    <post_name>Dulwich and West Norwood</post_name>
+    <information_source>Result recorded in error, retracting</information_source>
+    <parlparse_id>uk.org.publicwhip/person/123456</parlparse_id>
+  </entry>
+  <entry>
+    <title>James Barber (Liberal Democrats) won in Dulwich and West Norwood</title>
+    <link href="http://example.com/#{item_id[2]}" rel="alternate"/>
+    <published>{updated[2]}</published>
+    <updated>{updated[2]}</updated>
+    <author>
+      <name>john</name>
+    </author>
+    <id>http://example.com/#{item_id[2]}</id>
+    <summary type="html">A example.com volunteer recorded at {space_separated[2]} that James Barber (Liberal Democrats) won the ballot in Dulwich and West Norwood, quoting the source 'Seen on Sky News'.</summary>
+    <retraction>0</retraction>
+    <election_slug>2015</election_slug>
+    <election_name>2015 General Election</election_name>
+    <election_date>{election_date}</election_date>
+    <post_id>65808</post_id>
+    <winner_person_id>4493</winner_person_id>
+    <winner_person_name>James Barber</winner_person_name>
+    <winner_party_id>party:90</winner_party_id>
+    <winner_party_name>Liberal Democrats</winner_party_name>
+    <user_id>{user_id}</user_id>
+    <post_name>Dulwich and West Norwood</post_name>
+    <information_source>Seen on Sky News</information_source>
+  </entry>
+</feed>
+'''.format(
+    updated=[
+        rfc3339_date(result_event.created) for result_event in
+        self.events
+    ],
+    space_separated=[
+        result_event.created.strftime("%Y-%m-%d %H:%M:%S") for result_event in
+        self.events
+    ],
+    item_id=[result_event.id for result_event in self.events],
+    user_id=self.user.id,
+    election_date=self.election.election_date,
+)
+        self.compare_xml(expected, xml_pretty)
+
+    def test_all_basic_feed_with_a_correction(self):
+        response = self.app.get('/results/all-basic.atom')
+        root = etree.XML(response.content)
+        xml_pretty = etree.tounicode(root, pretty_print=True)
+
+        expected = '''<feed xmlns="http://www.w3.org/2005/Atom" xml:lang="en-gb">
+  <title>Election results from example.com</title>
+  <link href="http://example.com/" rel="alternate"/>
+  <link href="http://example.com/results/all-basic.atom" rel="self"/>
+  <id>http://example.com/</id>
+  <updated>{updated[0]}</updated>
+  <entry>
+    <title>Tessa Jowell (Labour Party) won in Dulwich and West Norwood</title>
+    <link href="http://example.com/#{item_id[0]}" rel="alternate"/>
+    <published>{updated[0]}</published>
+    <updated>{updated[0]}</updated>
+    <author>
+      <name>john</name>
+    </author>
+    <id>http://example.com/#{item_id[0]}</id>
+    <summary type="html">A example.com volunteer recorded at {space_separated[0]} that Tessa Jowell (Labour Party) won the ballot in Dulwich and West Norwood, quoting the source 'Seen on the BBC news'.</summary>
+  </entry>
+  <entry>
+    <title>Correction: retracting the statement that Tessa Jowell (Labour Party) won in Dulwich and West Norwood</title>
+    <link href="http://example.com/#{item_id[1]}" rel="alternate"/>
+    <published>{updated[1]}</published>
+    <updated>{updated[1]}</updated>
+    <author>
+      <name>john</name>
+    </author>
+    <id>http://example.com/#{item_id[1]}</id>
+    <summary type="html">At {space_separated[1]}, a example.com volunteer retracted the previous assertion that Tessa Jowell (Labour Party) won the ballot in Dulwich and West Norwood, quoting the source 'Result recorded in error, retracting'.</summary>
+  </entry>
+  <entry>
+    <title>James Barber (Liberal Democrats) won in Dulwich and West Norwood</title>
+    <link href="http://example.com/#{item_id[2]}" rel="alternate"/>
+    <published>{updated[2]}</published>
+    <updated>{updated[2]}</updated>
+    <author>
+      <name>john</name>
+    </author>
+    <id>http://example.com/#{item_id[2]}</id>
+    <summary type="html">A example.com volunteer recorded at {space_separated[2]} that James Barber (Liberal Democrats) won the ballot in Dulwich and West Norwood, quoting the source 'Seen on Sky News'.</summary>
+  </entry>
+</feed>
+'''.format(
+    updated=[
+        rfc3339_date(result_event.created) for result_event in
+        self.events
+    ],
+    space_separated=[
+        result_event.created.strftime("%Y-%m-%d %H:%M:%S") for result_event in
+        self.events
+    ],
+    item_id=[result_event.id for result_event in self.events],
 )
         self.compare_xml(expected, xml_pretty)

--- a/results/tests.py
+++ b/results/tests.py
@@ -82,7 +82,6 @@ class TestResultsFeed(
             user=self.user,
             parlparse_id='uk.org.publicwhip/person/123456',
         )
-        result_event.created = datetime(2015, 12, 1, 15, 59)
 
     def test_all_feed_with_one_item(self):
         response = self.app.get('/results/all.atom')


### PR DESCRIPTION
The results feeds had no good way of showing that we'd made a mistake in recording that a candidate was the winner of an election; this pull request adds elements to those feeds indicating when this has happened and adds documentation of how this is done.