### PR TITLE
candidates_unset_elected: check if the election is in the past

### DIFF
--- a/candidates/management/commands/candidates_unset_elected.py
+++ b/candidates/management/commands/candidates_unset_elected.py
@@ -1,6 +1,8 @@
 from __future__ import print_function, unicode_literals
 
-from django.core.management.base import BaseCommand
+from datetime import date
+
+from django.core.management.base import BaseCommand, CommandError
 
 from candidates.models import MembershipExtra
 from elections.models import Election
@@ -13,9 +15,18 @@ class Command(BaseCommand):
             'ELECTION-ID',
             help='The ID of the election for which to reset all candidacy elected statuses'
         )
+        parser.add_argument(
+            '-f', '--force',
+            action='store_true',
+            help='Unset the candidacy elected status even if the election is in the past'
+        )
 
     def handle(self, **options):
         election_slug = options['ELECTION-ID']
         election = Election.objects.get(slug=election_slug)
+        if election.election_date <= date.today() and not options['force']:
+            msg = "The election {0.name} ({0.slug}) is in the past: run with " \
+                  "-f if you really want to do this"
+            raise CommandError(msg.format(election))
         MembershipExtra.objects.filter(election=election) \
             .update(elected=None)


### PR DESCRIPTION
It would be bad to accidentally remove the elected status of all
candidates in an election that we have real results for, since the
candidates_unset_elected command is really just here for cleanup after a
bug. As suggested by Sym, this commit changes the command to make it
refuse to run if the election date is in the past, unless you pass
-f / --force as well.