### PR TITLE
Comment out links to uk_results from post pages and the header

### DIFF
--- a/elections/uk/templates/base.html
+++ b/elections/uk/templates/base.html
@@ -33,7 +33,7 @@
   <li class="nav-links__item"><a href="{% url 'posts' %}">{% trans "Elections" %}</a></li>
   <li class="nav-links__item"><a href="{% url 'reports_home' %}">{% trans "Numbers" %}</a></li>
   <li class="nav-links__item"><a href="{% url 'help-api' %}">{% trans "Get the data" %}</a></li>
-  <li class="nav-links__item"><a href="{% url 'results-home' %}" style="color:#FFFF8E">{% trans "New! 4 May local election results" %}</a></li>
+  {# <li class="nav-links__item"><a href="{% url 'results-home' %}" style="color:#FFFF8E">{% trans "New! 4 May local election results" %}</a></li> #}
 {% endblock %}
 
 

--- a/elections/uk/templates/uk/constituency.html
+++ b/elections/uk/templates/uk/constituency.html
@@ -25,11 +25,13 @@
             </section>
           {% endif %}
 
-          {% if not post_election.postelectionresult_set.confirmed %}
-            <a href="{% url "report-post-votes-view" post_election.id %}" class="button">
-            Report results for {{post_data.label}}
-            </a>
-          {% endif %}
+          {% comment %}
+            {% if not post_election.postelectionresult_set.confirmed %}
+              <a href="{% url "report-post-votes-view" post_election.id %}" class="button">
+              Report results for {{post_data.label}}
+              </a>
+            {% endif %}
+          {% endcomment %}
         {% endif %}
 
         {% if not candidates_locked %}


### PR DESCRIPTION
This so that enthusiastic people don't just click through and start
adding election results in the uk_results app for the 2017 General
Election; the ways this could interact with the older results recording
mechanism are complex and might well cause unexpected behaviour. To be
careful, we're removing these links until the results are in and we
have more time to test this and update the code (e.g. to stop duplicate
ResultEvent objects from being created, and handle corrections to
previously declared results.)