### PR TITLE
Allow a trailing slash on update links

### DIFF
--- a/candidates/urls.py
+++ b/candidates/urls.py
@@ -128,7 +128,7 @@ patterns_to_format = [
         'name': 'person-create-select-election'
     },
     {
-        'pattern': r'^person/(?P<person_id>\d+)/update$',
+        'pattern': r'^person/(?P<person_id>\d+)/update/?$',
         'view': views.UpdatePersonView.as_view(),
         'name': 'person-update'
     },
@@ -173,7 +173,7 @@ patterns_to_format = [
         'name': 'person-other-name-delete',
     },
     {
-        'pattern': r'^person/(?P<person_id>\d+)/other-name/(?P<pk>\d+)/update$',
+        'pattern': r'^person/(?P<person_id>\d+)/other-name/(?P<pk>\d+)/update/?$',
         'view': views.PersonOtherNameUpdateView.as_view(),
         'name': 'person-other-name-update',
     },


### PR DESCRIPTION
WhoCanIVoteFor is linking to the update URL but with an extra slash on
the end, which means it's treated as a slug for the person. I don't
think this is intentional, and generally it's bad for the site to be
picky about the presence / absence of trailing slashes on URLs.