### PR TITLE
Add option to disable editing elections in Django's admin interface

### DIFF
--- a/elections/admin.py
+++ b/elections/admin.py
@@ -1,12 +1,32 @@
 from __future__ import unicode_literals
 
+from django.conf import settings
 from django.contrib import admin
+
 from .models import AreaType, Election
+
+CAN_EDIT_ELECTIONS = getattr(settings, 'CAN_EDIT_ELECTIONS', True)
+
 
 class ElectionAdmin(admin.ModelAdmin):
     list_display = ('name', 'election_date', 'description', 'current')
     search_fields = ('name', 'slug')
     ordering = ('-election_date', 'name')
+
+    def has_add_permission(self, request, obj=None):
+        return CAN_EDIT_ELECTIONS
+
+    def has_delete_permission(self, request, obj=None):
+        return CAN_EDIT_ELECTIONS
+
+    def get_readonly_fields(self, request, obj=None):
+        if CAN_EDIT_ELECTIONS:
+            return list(self.readonly_fields)
+        else:
+            return list(self.readonly_fields) + \
+                [field.name for field in obj._meta.fields] + \
+                [field.name for field in obj._meta.many_to_many]
+
 
 class AreaTypeAdmin(admin.ModelAdmin):
     list_display = ('name', 'source')

--- a/mysite/settings/conf.py
+++ b/mysite/settings/conf.py
@@ -553,6 +553,7 @@ def get_settings(conf_file_leafname, election_app=None, tests=False):
     add_election_specific_settings(result, election_app_fully_qualified)
 
     result['RESULTS_FEATURE_ACTIVE'] = True
+    result['CAN_EDIT_ELECTIONS'] = conf.get('CAN_EDIT_ELECTIONS', True)
 
     result['DATE_FORMAT'] = conf.get('DATE_FORMAT', "jS E Y")
 


### PR DESCRIPTION
In the UK the source of elections is a different service that should
be thought of as the canonical source of truth for elections.

Having the possibility that someone might edit an election in YNR (
for example to mark an election as no longer current) might cause
confusion especially if these settings get overwritten by a script.

This change makes it possible to disable the admin interface for the
Election model.