### PR TITLE
Don't look for territory_code on null divisions

### DIFF
--- a/elections/uk/management/commands/uk_create_elections_from_every_election.py
+++ b/elections/uk/management/commands/uk_create_elections_from_every_election.py
@@ -153,7 +153,7 @@ class Command(BaseCommand):
         # The division can have a different code to the organisation
         # for example UK wide orgs like `parl` has divisions in 4 differet
         # territories. We need to use the most specific code here.
-        if area_info['division']['territory_code']:
+        if area_info['division'] and area_info['division']['territory_code']:
             territory_code = area_info['division']['territory_code']
         else:
             territory_code = area_info['organisation']['territory_code']


### PR DESCRIPTION
Elections that are to the organisation directly don't have divisions.

This commit stops us assuming they do when looking for a territory_code.