### PR TITLE
Move to tox and pytest

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -13,4 +13,3 @@ source =
     results
     tasks
     uk_results
-

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,16 @@
+[run]
+branch = True
+source =
+
+    auth_helpers
+    bulk_adding
+    cached_counts
+    candidates
+    compat
+    elections
+    moderation_queue
+    official_documents
+    results
+    tasks
+    uk_results
+

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ __pycache__
 /mysite/settings/local.py
 /mysite/static/jsi18n
 .DS_Store
+.tox
+.cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,32 +13,29 @@ addons:
 
 cache:
   pip: true
-  ccache: true
   directories:
     - /home/travis/virtualenv
     - $HOME/.pip-cache/
-before_cache:
-    - rm -f .tox/py34-django19/log/*.log
-    - rm -f .tox/py35-django19/log/*.log
-    - rm -f .cache/pip/log/*.log
-
+    - $HOME/.tox/
+    - .tox
 env:
   - ES_VERSION=2.3.1 ES_DOWNLOAD_URL=https://download.elastic.co/elasticsearch/release/org/elasticsearch/distribution/tar/elasticsearch/${ES_VERSION}/elasticsearch-${ES_VERSION}.tar.gz
 
 install:
+  - pip install tox coveralls
   # Install ES
   - wget -nc ${ES_DOWNLOAD_URL}
   - tar -xzf elasticsearch-${ES_VERSION}.tar.gz
   - ./elasticsearch-${ES_VERSION}/bin/elasticsearch &
   # Make sure pip is at the latest version:
   - pip install -U pip
-  # Now install the rest of the required Python packages:
-  - CFLAGS="-O0" pip install -r requirements.txt
-  - pip install python-coveralls
-  - ./manage.py compilemessages
 
 script:
-  - wget -q --waitretry=1 --retry-connrefused -T 10 -O - http://127.0.0.1:9200
-  - ./run-tests --coverage
+  - tox
 after_success:
   - coveralls
+before_cache:
+    - rm -f .tox/py27-django19/log/*.log
+    - rm -f .tox/py34-django19/log/*.log
+    - rm -f .tox/py35-django19/log/*.log
+    - rm -f .cache/pip/log/*.log

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ env:
   - ES_VERSION=2.3.1 ES_DOWNLOAD_URL=https://download.elastic.co/elasticsearch/release/org/elasticsearch/distribution/tar/elasticsearch/${ES_VERSION}/elasticsearch-${ES_VERSION}.tar.gz
 
 install:
-  - pip install tox coveralls
+  - pip install tox coveralls tox-travis
   # Install ES
   - wget -nc ${ES_DOWNLOAD_URL}
   - tar -xzf elasticsearch-${ES_VERSION}.tar.gz

--- a/bulk_adding/tests.py
+++ b/bulk_adding/tests.py
@@ -9,12 +9,10 @@ from candidates.tests.auth import TestUserMixin
 
 from official_documents.models import OfficialDocument
 
-from nose.plugins.attrib import attr
 from candidates.tests import factories
 from candidates.tests.uk_examples import UK2015ExamplesMixin
 
 
-@attr(country='uk')
 class TestBulkAdding(TestUserMixin, UK2015ExamplesMixin, WebTest):
 
     def setUp(self):

--- a/candidates/feeds.py
+++ b/candidates/feeds.py
@@ -8,6 +8,7 @@ from django.contrib.syndication.views import Feed
 from django.core.urlresolvers import reverse
 from django.utils.feedgenerator import Atom1Feed
 from django.utils.translation import ugettext_lazy as _
+from django.conf import settings
 
 from .models import LoggedAction
 
@@ -50,7 +51,7 @@ class ChangesMixin(object):
 
 
 class RecentChangesFeed(ChangesMixin, Feed):
-    site_name = Site.objects.get_current().name
+    site_name = settings.SITE_NAME
     title = _("{site_name} recent changes").format(site_name=site_name)
     description = _("Changes to {site_name} candidates").format(site_name=site_name)
     link = "/feeds/changes.xml"
@@ -88,7 +89,7 @@ class RecentChangesFeed(ChangesMixin, Feed):
 
 
 class NeedsReviewFeed(ChangesMixin, Feed):
-    site_name = Site.objects.get_current().name
+    site_name = settings.SITE_NAME
     title = _('{site_name} changes for review').format(site_name=site_name)
     link = '/feeds/needs-review.xml'
     feed_type = Atom1Feed

--- a/candidates/tests/test_upcoming_elections_api.py
+++ b/candidates/tests/test_upcoming_elections_api.py
@@ -9,7 +9,6 @@ from datetime import date, timedelta
 from django.conf import settings
 from django.utils.six.moves.urllib_parse import urljoin
 
-from nose.plugins.attrib import attr
 from django_webtest import WebTest
 
 from candidates.tests.factories import (
@@ -52,7 +51,6 @@ def fake_requests_for_every_election(url, *args, **kwargs):
     })
 
 
-@attr(country='uk')
 @patch('elections.uk.geo_helpers.requests')
 class TestUpcomingElectionsAPI(UK2015ExamplesMixin, WebTest):
     def setUp(self):

--- a/elections/uk/tests/test_country_specific.py
+++ b/elections/uk/tests/test_country_specific.py
@@ -2,12 +2,9 @@ from mock import patch
 
 from django.test import TestCase
 
-from nose.plugins.attrib import attr
-
 from candidates.election_specific import additional_merge_actions
 from candidates.tests import factories
 
-@attr(country='uk')
 class TestUKSpecificOverride(TestCase):
 
     @patch('elections.uk.lib.additional_merge_actions')

--- a/elections/uk/tests/test_csv.py
+++ b/elections/uk/tests/test_csv.py
@@ -2,14 +2,11 @@ from __future__ import unicode_literals
 
 from django.test import TestCase
 
-from nose.plugins.attrib import attr
-
 from candidates.models import PersonExtra, PersonRedirect
 from candidates.tests import factories
 from candidates.tests.uk_examples import UK2015ExamplesMixin
 
 
-@attr(country='uk')
 class CSVTests(UK2015ExamplesMixin, TestCase):
 
     def setUp(self):

--- a/elections/uk/tests/test_custom_merge.py
+++ b/elections/uk/tests/test_custom_merge.py
@@ -1,5 +1,4 @@
 from django_webtest import WebTest
-from nose.plugins.attrib import attr
 from popolo.models import Person
 
 from candidates.tests import factories
@@ -10,7 +9,6 @@ from candidates.models import PostExtraElection
 from uk_results.models import CandidateResult, PostElectionResult, ResultSet
 
 
-@attr(country='uk')
 class TestUKResultsPreserved(TestUserMixin, UK2015ExamplesMixin, WebTest):
 
     def setUp(self):

--- a/elections/uk/tests/test_person_view.py
+++ b/elections/uk/tests/test_person_view.py
@@ -1,8 +1,5 @@
-from nose.plugins.attrib import attr
-
 from candidates.tests.person_view_shared_tests_mixin import PersonViewSharedTestsMixin
 
 
-@attr(country='uk')
 class TestPersonView(PersonViewSharedTestsMixin):
     pass

--- a/elections/uk/tests/test_post_view.py
+++ b/elections/uk/tests/test_post_view.py
@@ -5,14 +5,11 @@ from django_webtest import WebTest
 from moderation_queue.models import SuggestedPostLock
 from official_documents.models import OfficialDocument
 
-from nose.plugins.attrib import attr
-
 from candidates.models import PostExtraElection
 from candidates.tests.auth import TestUserMixin
 from candidates.tests.uk_examples import UK2015ExamplesMixin
 
 
-@attr(country='uk')
 class TestConstituencyDetailView(TestUserMixin, UK2015ExamplesMixin, WebTest):
 
     def test_suggest_post_lock_offered_with_document_when_unlocked(self):

--- a/moderation_queue/tests/test_queue.py
+++ b/moderation_queue/tests/test_queue.py
@@ -17,7 +17,6 @@ from PIL import Image
 from io import BytesIO
 from django_webtest import WebTest
 from mock import patch
-from nose.plugins.attrib import attr
 
 from popolo.models import Person
 from ..models import QueuedImage, PHOTO_REVIEWERS_GROUP_NAME, SuggestedPostLock
@@ -506,7 +505,6 @@ class SuggestedLockReviewTests(UK2015ExamplesMixin, TestUserMixin, WebTest):
         self.assertContains(response, '<h3>')
 
 
-@attr(country='uk')
 class SOPNReviewRequiredTest(UK2015ExamplesMixin, TestUserMixin, WebTest):
 
     def test_sopn_review_view_no_reviews(self):

--- a/mysite/settings/base.py
+++ b/mysite/settings/base.py
@@ -424,5 +424,12 @@ except ImportError:
         fg="red"
     ))
 
-if len(sys.argv) > 1 and sys.argv[1] in ['test']:
+def _is_running_tests():
+    if len(sys.argv) > 1 and sys.argv[1] in ['test']:
+        return True
+    if os.environ.get('RUN_ENV') == 'test':
+        return True
+    return False
+
+if _is_running_tests():
     from .testing import *  # noqa

--- a/mysite/settings/base.py
+++ b/mysite/settings/base.py
@@ -28,6 +28,7 @@ DEBUG = False
 ALLOWED_HOSTS = []
 
 SITE_ID = 1
+SITE_NAME = "Democracy Club Candidates"
 
 # Google analytics settings:
 GOOGLE_ANALYTICS_ACCOUNT = None

--- a/mysite/settings/base.py
+++ b/mysite/settings/base.py
@@ -313,7 +313,7 @@ EE_CACHE_SECONDS = 86400
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.postgresql_psycopg2',
-        'NAME': 'ynr',
+        'NAME': '',
         # Note that there are various comments on the web
         # suggesting that settings CONN_MAX_AGE != 0 is a bad
         # idea when eventlet or gevent workers are being used.

--- a/mysite/settings/base.py
+++ b/mysite/settings/base.py
@@ -85,7 +85,6 @@ INSTALLED_APPS = (
     'django.contrib.messages',
     'django.contrib.staticfiles',
     'django.contrib.sites',
-    'django_nose',
     'django_extensions',
     'pipeline',
     'statici18n',
@@ -303,8 +302,6 @@ PIPELINE = {
     'YUI_BINARY': '/usr/bin/env yui-compressor',
 }
 
-
-TEST_RUNNER = 'django_nose.NoseTestSuiteRunner'
 
 SOURCE_HINTS = (
     u"Please don't quote third-party candidate sites \u2014 ",

--- a/mysite/settings/local.example.py
+++ b/mysite/settings/local.example.py
@@ -1,0 +1,40 @@
+# Only set this to True in development environments
+DEBUG = True
+
+# Set this to a long random string and keep it secret
+# This is a handy tool:
+# https://www.miniwebtool.com/django-secret-key-generator/
+SECRET_KEY = None
+
+DATABASES = {
+    'default': {
+        'ENGINE': 'django.db.backends.postgresql_psycopg2',
+        'NAME': '',
+        'USER': '',
+        'PASSWORD': '',
+    },
+}
+
+# A tuple of tuples containing (Full name, email address)
+ADMINS = ()
+
+# **** Other settings that might be useful to change locally
+
+# ALLOWED_HOSTS = ['*']
+# INTERNAL_IPS = ['127.0.0.1', 'localhost', ]
+
+# CACHES = {
+#     "default": {
+#         "BACKEND": "django.core.cache.backends.dummy.DummyCache",
+#     }
+# }
+
+
+# **** Settings that might be useful in production
+
+# STATICFILES_STORAGE = 'pipeline.storage.PipelineCachedStorage'
+# SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
+# ACCOUNT_DEFAULT_HTTP_PROTOCOL = 'https'
+# RAVEN_CONFIG = {
+#     'dsn': ''
+# }

--- a/mysite/settings/testing.py
+++ b/mysite/settings/testing.py
@@ -15,16 +15,6 @@ PASSWORD_HASHERS = [
 ]
 
 RUNNING_TESTS = True
-NOSE_ARGS = [
-    '--nocapture',
-    '--with-yanc',
-    # There are problems with OpenCV on Travis, so don't even try to
-    # import moderation_queue/faces.py
-    '--ignore-files=faces',
-    '--ignore-files=mysite/settings/testing.py',
-    '--with-doctest'
-]
-
 
 SECRET_KEY = "just here for testing"
 

--- a/mysite/settings/testing.py
+++ b/mysite/settings/testing.py
@@ -2,6 +2,7 @@ from .base import *  # noqa
 
 
 DATABASES['default']['CONN_MAX_AGE'] = 0
+SITE_NAME = "example.com"
 
 CACHES = {
     'default': {

--- a/mysite/settings/travis.py
+++ b/mysite/settings/travis.py
@@ -1,0 +1,3 @@
+from .testing import *  # noqa
+
+DATABASES['default']['NAME'] = 'postgres'

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,11 @@
+[pytest]
+norecursedirs = .tox /locale /static
+DJANGO_SETTINGS_MODULE = mysite.settings.base
+
+pep8ignore =
+  .tox *
+
+env =
+    RUN_ENV=test
+
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ beautifulsoup4==4.4.1
 bleach==1.4.1
 certifi==2015.04.28
 cffi==1.5.0
-coverage==3.7.1
+coverage>=3.6
 cryptography==1.2.3
 decorator==4.0.4
 Django>=1.9,<1.10

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,7 @@ django-cors-headers==1.1.0
 django-date-extensions==1.1.0
 django-crispy-forms==1.6.0
 django-debug-toolbar==1.9
+django-debug-toolbar-template-timings
 django-extensions==1.6.1
 django-filter==0.13
 django-haystack==2.5.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -56,6 +56,12 @@ pyasn1==0.1.9
 pycparser==2.14
 pygeocoder==1.2.5
 pyOpenSSL==0.15.1
+pytest
+pytest-cov
+pytest-django
+pytest-env
+pytest-flakes
+pytest-pep8
 python-dateutil==2.4.2
 python-magic==0.4.6
 python-memcached==1.54
@@ -69,6 +75,7 @@ simplegeneric==0.8.1
 six==1.10.0
 sorl-thumbnail==12.3
 sqlparse==0.1.15
+tox
 traitlets==4.0.0
 Unidecode==0.4.17
 urllib3==1.13

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,6 @@ django-filter==0.13
 django-haystack==2.5.1
 django-markdown-deux==1.0.5
 django-model-utils==2.3.1
-django-nose==1.4.4
 django-notifications-hq==1.0.0
 django-pipeline==1.6.8
 -e git+https://github.com/mysociety/django-popolo@update-with-better-migrations-redux#egg=mysociety-django-popolo
@@ -46,7 +45,6 @@ lxml==3.4.1
 mock==1.0.1
 mysociety-django-images==0.0.5
 ndg-httpsclient==0.4.0
-nose==1.3.7
 numpy==1.9.1
 oauthlib==0.7.2
 path.py==8.1.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -52,7 +52,7 @@ path.py==8.1.1
 pexpect==3.3
 pickleshare==0.5
 Pillow==3.2.0
-psycopg2==2.5.4
+psycopg2==2.7.1
 pyasn1==0.1.9
 pycparser==2.14
 pygeocoder==1.2.5

--- a/results/feeds.py
+++ b/results/feeds.py
@@ -5,6 +5,7 @@ from django.contrib.syndication.views import Feed
 from django.utils.feedgenerator import Atom1Feed
 from django.utils.six.moves.urllib_parse import urlunsplit
 from django.utils.translation import ugettext_lazy as _
+from django.conf import settings
 
 from compat import text_type
 
@@ -14,7 +15,7 @@ from .models import ResultEvent
 class BasicResultEventsFeed(Feed):
     feed_type = Atom1Feed
     title = _("Election results from {site_name}").format(
-        site_name=Site.objects.get_current().name
+        site_name=settings.SITE_NAME
     )
     link = "/"
     description = _("A basic feed of election results")
@@ -107,7 +108,7 @@ class ResultEventsAtomFeedGenerator(Atom1Feed):
 class ResultEventsFeed(BasicResultEventsFeed):
     feed_type = ResultEventsAtomFeedGenerator
     title = _("Election results from {site_name} (with extra data)").format(
-        site_name=Site.objects.get_current().name
+        site_name=settings.SITE_NAME
     )
     description = _("A feed of results from the UK 2015 General Election (with extra data)")
 

--- a/tox.ini
+++ b/tox.ini
@@ -17,5 +17,5 @@ commands =
   - python manage.py compilemessages
     python manage.py check
     # pytest --flake
-    pytest --cov-report= --cov=auth_helpers,bulk_adding,cached_counts,candidates,compat,elections,moderation_queue,official_documents,results,tasks,uk_results
+    pytest --cov-report= --cov
     # pytest --pep8

--- a/tox.ini
+++ b/tox.ini
@@ -14,8 +14,7 @@ setenv =
     RUN_ENV=test
 
 commands =
-  - python manage.py compilemessages
-    python manage.py check
+  - python manage.py check
     # pytest --flake
     pytest --cov-report= --cov
     # pytest --pep8

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,21 @@
+[tox]
+envlist = py{27,34,35}-django19
+skipsdist = True
+
+[tox:travis]
+2.7 = py27
+3.4 = py34
+3.5 = py35
+
+[testenv]
+passenv = *
+deps = -rrequirements.txt
+setenv =
+    RUN_ENV=test
+
+commands =
+  - python manage.py compilemessages
+    python manage.py check
+    # pytest --flake
+    pytest --cov-report= --cov=auth_helpers,bulk_adding,cached_counts,candidates,compat,elections,moderation_queue,official_documents,results,tasks,uk_results
+    # pytest --pep8

--- a/uk_results/tests.py
+++ b/uk_results/tests.py
@@ -4,8 +4,6 @@ from mock import patch
 
 from django.test import TestCase
 
-from nose.plugins.attrib import attr
-
 from candidates.tests.auth import TestUserMixin
 from candidates.tests.factories import (
     CandidacyExtraFactory, PersonExtraFactory)
@@ -17,7 +15,6 @@ from .models import CandidateResult, PostElectionResult, ResultSet
 from .forms import mark_candidates_as_winner
 
 
-@attr(country='uk')
 class TestUKResults(TestUserMixin, UK2015ExamplesMixin, TestCase):
 
     def setUp(self):


### PR DESCRIPTION
[Merge #325 first]

This PR replaces nose with tox and pytest for running tests.

There are two reasons for this:

1. nose has a hard time of…well, frankly…running tests. It breaks quite a lot when different import styles are used in a single project, in ways that's almost impossible to debug.

2. We use pytest and tox everywhere else