### PR TITLE
fix needs_review feed

### DIFF
--- a/ynr/settings/base.py
+++ b/ynr/settings/base.py
@@ -426,6 +426,11 @@ IMAGE_PROXY_URL = ''
 
 RESULTS_FEATURE_ACTIVE = False
 
+
+# import application constants
+from .constants.needs_review import * # noqa
+
+
 # .local.py overrides all the common settings.
 try:
     from .local import *  # noqa

--- a/ynr/settings/constants/needs_review.py
+++ b/ynr/settings/constants/needs_review.py
@@ -1,10 +1,5 @@
 from __future__ import unicode_literals
 
-# INSTALLED_APPS = [
-#     'bulk_adding',
-#     'uk_results',
-# ]
-#
 
 PEOPLE_LIABLE_TO_VANDALISM = {
     2811, # Theresa May


### PR DESCRIPTION
1. I've moved this to a `/settings/constants` dir. There is probably some further 'refactoring' we can do to separate app constants from stuff like DB credentials, context processors etc.

2. This is probably out of date. We could look at automatically generating it. We also need to ensure we keep people we have manually added to this list for various reasons (e.g: previous vandalism incidents). It might also be worth looking at https://github.com/mysociety/yournextrepresentative/pull/997 where @mhl has done some work on moving this to the DB where it may be easier to maintian than a config file?

Closes #412