### PR TITLE
fix EE import

### DIFF
--- a/ynr/apps/elections/uk/every_election.py
+++ b/ynr/apps/elections/uk/every_election.py
@@ -35,6 +35,11 @@ class EEElection(dict):
     def children(self):
         return self['children']
 
+    @property
+    def is_leaf_node(self):
+        return (not self['children'] and\
+            self['group_type'] in ['organisation', None])
+
     def get_or_create_organisation(self):
         org_name = self['organisation']['official_name']
         classification = self['organisation']['organisation_type']
@@ -204,9 +209,7 @@ class EEElection(dict):
 
 
 def is_mayor_or_pcc_ballot(election):
-    is_leaf_node = (not election['children'] and\
-        election['group_type'] in ['organisation', None])
-    return (is_leaf_node and\
+    return (election.is_leaf_node and\
         election['election_type']['election_type'] in ['mayor', 'pcc'])
 
 

--- a/ynr/apps/elections/uk/every_election.py
+++ b/ynr/apps/elections/uk/every_election.py
@@ -204,8 +204,9 @@ class EEElection(dict):
 
 
 def is_mayor_or_pcc_ballot(election):
-    return (election['group_type'] == 'organisation' and\
-        not election['children'] and\
+    is_leaf_node = (not election['children'] and\
+        election['group_type'] in ['organisation', None])
+    return (is_leaf_node and\
         election['election_type']['election_type'] in ['mayor', 'pcc'])
 
 

--- a/ynr/apps/elections/uk/tests/ee_import_results.py
+++ b/ynr/apps/elections/uk/tests/ee_import_results.py
@@ -11196,7 +11196,7 @@ each_type_of_election_on_one_day = json.loads("""
         "election_name": "Greater Manchester"
       },
       "group": "mayor.2019-01-17",
-      "group_type": "organisation",
+      "group_type": null,
       "children": [],
       "elected_role": "Mayor",
       "division": null,


### PR DESCRIPTION
This stops the EE import from throwing `TypeError: 'NoneType' object has no attribute '__getitem__'` on `mayor.watford.2018-05-03` and get us syncing elections into YNR again. Turned out to be less painful than I suspected :)