### PR TITLE
add a log configuration for elasticsearch

### DIFF
--- a/ynr/settings/base.py
+++ b/ynr/settings/base.py
@@ -426,6 +426,31 @@ IMAGE_PROXY_URL = ''
 RESULTS_FEATURE_ACTIVE = False
 
 
+LOGGING = {
+    'version': 1,
+    'disable_existing_loggers': False,
+    'filters': {
+        'require_debug_false': {
+            '()': 'django.utils.log.RequireDebugFalse'
+        }
+    },
+    'handlers': {
+        'mail_admins': {
+            'level': 'ERROR',
+            'filters': ['require_debug_false'],
+            'class': 'django.utils.log.AdminEmailHandler'
+        },
+    },
+    'loggers': {
+        'elasticsearch': {
+            'handlers': ['mail_admins'],
+            'level': 'ERROR',
+            'propagate': True,
+        },
+    }
+}
+
+
 # import application constants
 from .constants.needs_review import * # noqa
 


### PR DESCRIPTION
It is slightly hard to tell if this is going to be sensible or not until we deploy it.

If the result of this is that elasticsearch mailbombs us with garbage then I will set it to a `null` logger instead, but giving it some kind of log config will silence the warnings and make the error emails clearer.