### PR TITLE
fix coverage reports

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,7 +1,6 @@
 [run]
 branch = True
 source =
-
     auth_helpers
     bulk_adding
     cached_counts
@@ -13,3 +12,10 @@ source =
     results
     tasks
     uk_results
+omit =
+    */tests/*
+    */tests.py
+    */apps.py
+    */migrations/*
+    ynr/wsgi.py
+    ynr/settings/*


### PR DESCRIPTION
Excluding stuff we're not actually trying to test should make the coverage reports easier to digest and much more useful for working out where the gaps in the test suite are.

Closes #330 