### PR TITLE
fix references to MEDIA_URL

### DIFF
--- a/ynr/apps/candidates/templates/candidates/api.html
+++ b/ynr/apps/candidates/templates/candidates/api.html
@@ -61,7 +61,7 @@ explaining how to get election results from this site</a>.
   {% endblocktrans %}</p>
 
   <ul>
-    <li><a href="{{ MEDIA_URL }}candidates-all.csv">{% blocktrans %}Download all the candidates{% endblocktrans %}</a></li>
+    <li><a href="{{ settings.MEDIA_URL }}candidates-all.csv">{% blocktrans %}Download all the candidates{% endblocktrans %}</a></li>
   </ul>
 
   {% for era in grouped_elections %}
@@ -78,7 +78,7 @@ explaining how to get election results from this site</a>.
             <ul>
               {% for election in role_data.elections %}
                 {% with slug=election.election.slug title=election.election.name %}
-                  <li><a href="{{ MEDIA_URL }}candidates-{{ slug }}.csv">{% blocktrans %}Download the {{ title }} candidates{% endblocktrans %}</a></li>
+                  <li><a href="{{ settings.MEDIA_URL }}candidates-{{ slug }}.csv">{% blocktrans %}Download the {{ title }} candidates{% endblocktrans %}</a></li>
                 {% endwith %}
               {% endfor %}
             </ul>

--- a/ynr/apps/candidates/templates/candidates/results.html
+++ b/ynr/apps/candidates/templates/candidates/results.html
@@ -213,7 +213,7 @@ result:</p>
 
   <ul>
     <li>{% if all_results_exists %}
-      <a href="{{ MEDIA_URL }}candidates-elected-all.csv">{% blocktrans %}Download data about all of the candidates{% endblocktrans %}</a>
+      <a href="{{ settings.MEDIA_URL }}candidates-elected-all.csv">{% blocktrans %}Download data about all of the candidates{% endblocktrans %}</a>
       {% else %}
       <em>{% trans "(The file of all elected candidates has not yet been generated.)" %}</em>
       {% endif %}
@@ -233,7 +233,7 @@ result:</p>
           {% for election in role_data.elections %}
             {% with slug=election.election.slug title=election.election.name %}
               <li>{% if election.results_file_exists %}
-                <a href="{{ MEDIA_URL }}candidates-elected-{{ slug }}.csv">{% blocktrans %}Download of the {{ title }} elected candidates {% endblocktrans %}</a>
+                <a href="{{ settings.MEDIA_URL }}candidates-elected-{{ slug }}.csv">{% blocktrans %}Download of the {{ title }} elected candidates {% endblocktrans %}</a>
                 {% else %}
                 <em>{% blocktrans %}
                   (The file of elected candidates in {{ title }} has not yet been generated.)

--- a/ynr/apps/elections/uk/templates/candidates/about.html
+++ b/ynr/apps/elections/uk/templates/candidates/about.html
@@ -10,7 +10,7 @@
 {% endblock %}
 
 {% block content %}
-{% with email=settings.SUPPORT_EMAIL %}
+{% with email=settings.SUPPORT_EMAIL MEDIA_URL=settings.MEDIA_URL %}
 
 <div class="help-about">
 


### PR DESCRIPTION
Closes #426

I don't really understand what changed here. I'm guessing somewhere in a line of code that has now been deleted there was a line setting `MEDIA_URL = settings.MEDIA_URL`. Unfortunately one of the side effects of re-organising everything is that there is basically no history/blame anymore because once a file has been moved its a different file, so its quite difficult to work out what has happened.

Either way, I've been through all of the settings in https://github.com/DemocracyClub/yournextrepresentative/blob/master/ynr/context_processors.py#L25-L37 they are all referenced as `settings.SUPPORT_EMAIL`, `settings.GOOGLE_ANALYTICS_ACCOUNT` and so on in the templates. It seems like moving forward it is best to reference all of these settings using a consistent notation anyway.
