### PR TITLE
Don't set the no-op account adaptor by default

### DIFF
--- a/ynr/settings/base.py
+++ b/ynr/settings/base.py
@@ -404,12 +404,6 @@ MARKDOWN_DEUX_STYLES = {
 ELECTION_APP = 'uk'
 ELECTION_APP_FULLY_QUALIFIED = 'elections.uk'
 
-# If this is set to false, then no new accounts may be created - you
-# might want this past a certain point in the election to reduce
-# opportunities for "drive-by" malicious edits.
-NEW_ACCOUNTS_ALLOWED = True
-
-ACCOUNT_ADAPTER = 'ynr.account_adapter.NoNewUsersAccountAdapter'
 CANDIDATES_REQUIRED_FOR_WEIGHTED_PARTY_LIST = 20
 HOIST_ELECTED_CANDIDATES = True
 

--- a/ynr/settings/local.py.example
+++ b/ynr/settings/local.py.example
@@ -38,3 +38,6 @@ ADMINS = ()
 # RAVEN_CONFIG = {
 #     'dsn': ''
 # }
+
+# To disable new accounts
+# ACCOUNT_ADAPTER = 'ynr.account_adapter.NoNewUsersAccountAdapter'


### PR DESCRIPTION
This code comes with the ability to prevent new account creation,
however by default we want new accounts to be made.

This moves the no-op account adaptor to the example local settings for
anyone who might want to disable account, but ensures they're enabled by
default.

Thanks to @rosewhiffen for reporting.