### PR TITLE
Basic prevention of self-locking

### DIFF
--- a/ynr/apps/candidates/views/constituencies.py
+++ b/ynr/apps/candidates/views/constituencies.py
@@ -121,7 +121,13 @@ class ConstituencyDetailView(ElectionMixin, TemplateView):
                 election=self.election_data)
 
             context['has_lock_suggestion'] = \
-                SuggestedPostLock.objects.filter(postextraelection=pee).exists()
+                SuggestedPostLock.objects.filter(
+                    postextraelection=pee).exists()
+
+            if self.request.user.is_authenticated():
+                context['current_user_suggested_lock'] = \
+                    SuggestedPostLock.objects.filter(
+                        user=self.request.user).exists()
 
             context['suggest_lock_form'] = SuggestedPostLockForm(
                 initial={'postextraelection': pee},

--- a/ynr/apps/elections/uk/templates/candidates/_candidates_for_post.html
+++ b/ynr/apps/elections/uk/templates/candidates/_candidates_for_post.html
@@ -68,7 +68,7 @@
       {% if current_user_suggested_lock %}
         <p>
           Locking disabled because you suggested locking this post.
-          Please ask someone else to review it as a double check.
+          Someone else will double check it soon.
         </p>
       {% else %}
         <button type="submit" class="button small">

--- a/ynr/apps/elections/uk/templates/candidates/_candidates_for_post.html
+++ b/ynr/apps/elections/uk/templates/candidates/_candidates_for_post.html
@@ -61,17 +61,31 @@
   {# Use the post label here, since multiple posts may be used on a page #}
   {% url 'constituency' election=election post_id=post_data.id ignored_slug=post_data.label|slugify as post_url %}
   {% url 'constituencies' election=election_data.slug as election_posts_url %}
-
   {% if user_can_lock %}
     <form method="post" action="{% url 'constituency-lock' election=election %}">
       {% csrf_token %}
       {% for field in lock_form %}{{ field }}{% endfor %}
-      <input type="submit" class="button small" value="{% if candidates_locked %}{% trans "Unlock candidate list" %}{% else %}{% trans "Lock candidate list" %}{% endif %}">
+      {% if current_user_suggested_lock %}
+        <p>
+          Locking disabled because you suggested locking this post.
+          Please ask someone else to review it as a double check.
+        </p>
+      {% else %}
+        <button type="submit" class="button small">
+          {% if candidates_locked %}
+            {% trans "Unlock candidate list" %}
+          {% else %}
+            {% trans "Lock candidate list" %}
+          {% endif %}"
+        </button>
+      {% endif %}
+      <p>
       {% if candidates_locked %}
         {% trans "(This list of candidates is currently <strong>locked</strong>.)" %}
       {% else %}
         {% trans "(This list of candidates is currently <strong>unlocked</strong>.)" %}
       {% endif %}
+      </p>
     </form>
   {% else %}
     {% if candidates_locked %}

--- a/ynr/apps/elections/uk/tests/test_post_view.py
+++ b/ynr/apps/elections/uk/tests/test_post_view.py
@@ -114,3 +114,36 @@ class TestConstituencyDetailView(TestUserMixin, UK2015ExamplesMixin, WebTest):
             response,
             "Locking disabled because you suggested locking this post"
         )
+
+    def test_post_lock_offered_when_suggested_lock_exists(self):
+        group = Group.objects.get(name=TRUSTED_TO_LOCK_GROUP_NAME)
+        self.user.groups.add(group)
+        self.user.save()
+
+        OfficialDocument.objects.create(
+            election=self.election,
+            post=self.edinburgh_east_post_extra.base,
+            source_url='http://example.com',
+            document_type=OfficialDocument.NOMINATION_PAPER,
+            uploaded_file="sopn.pdf"
+        )
+
+        pee = PostExtraElection.objects.get(
+            election__slug='2015',
+            postextra__slug='14419',
+        )
+
+        SuggestedPostLock.objects.create(
+            postextraelection=pee,
+            user=self.users_to_delete[-1],
+            justification='I liked totally reviewed the SOPN',
+        )
+
+        response = self.app.get(
+            '/election/2015/post/14419/edinburgh-east',
+            user=self.user,
+        )
+        self.assertContains(
+            response,
+            "Lock candidate list"
+        )


### PR DESCRIPTION
Of course there are other ways to prevent this that are out of scope of
this PR.

For example, this doesn't cover the case where a user with locking
permission has added all the candidates themselves but hasn't suggested
locking. This case is harder to detect.

For the time being, this should catch the most obvious cases of
self-locking.

Closes #312