### PR TITLE
Upgrade numpy

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -47,7 +47,7 @@ lxml==3.4.1
 mock==1.0.1
 mysociety-django-images==0.0.5
 ndg-httpsclient==0.4.0
-numpy==1.9.1
+numpy==1.14.2
 oauthlib==0.7.2
 path.py==8.1.1
 pexpect==3.3


### PR DESCRIPTION
This fixes the problem where openCV doesn't work on Ubuntu 16.04 becuase
of a version mismatch