### PR TITLE
Add celery

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,8 @@
 aenum==1.4.5
 beautifulsoup4==4.4.1
 bleach==1.4.1
+celery[redis]==4.1.0
+celery-haystack==0.10
 certifi==2015.04.28
 cffi==1.5.0
 coverage>=3.6

--- a/ynr/__init__.py
+++ b/ynr/__init__.py
@@ -1,0 +1,7 @@
+from __future__ import absolute_import, unicode_literals
+
+# This will make sure the app is always imported when
+# Django starts so that shared_task will use this app.
+from .celery import app as celery_app
+
+__all__ = ['celery_app']

--- a/ynr/apps/candidates/search_indexes.py
+++ b/ynr/apps/candidates/search_indexes.py
@@ -1,9 +1,10 @@
 from haystack import indexes
+from celery_haystack.indexes import CelerySearchIndex
 
 from popolo.models import Person
 
 
-class PersonIndex(indexes.SearchIndex, indexes.Indexable):
+class PersonIndex(CelerySearchIndex, indexes.Indexable):
     # FIXME: this doesn't seem to work for partial names despite what
     # docs say
     text = indexes.EdgeNgramField(document=True, use_template=True)

--- a/ynr/apps/candidates/search_indexes.py
+++ b/ynr/apps/candidates/search_indexes.py
@@ -13,5 +13,8 @@ class PersonIndex(CelerySearchIndex, indexes.Indexable):
     given_name = indexes.CharField(model_attr='given_name')
     additional_name = indexes.CharField(model_attr='additional_name')
 
+    def get_updated_field(self):
+        return 'updated_at'
+
     def get_model(self):
         return Person

--- a/ynr/celery.py
+++ b/ynr/celery.py
@@ -1,0 +1,19 @@
+from __future__ import absolute_import, unicode_literals
+import os
+from celery import Celery
+
+# set the default Django settings module for the 'celery' program.
+os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'ynr.settings')
+
+app = Celery('ynr')
+
+# Using a string here means the worker doesn't have to serialize
+# the configuration object to child processes.
+# - namespace='CELERY' means all celery-related configuration keys
+#   should have a `CELERY_` prefix.
+app.config_from_object('django.conf:settings', namespace='CELERY')
+
+print(app.conf['task_always_eager'])
+
+# Load task modules from all registered Django app configs.
+app.autodiscover_tasks()

--- a/ynr/settings/base.py
+++ b/ynr/settings/base.py
@@ -125,6 +125,8 @@ INSTALLED_APPS = (
     'raven.contrib.django.raven_compat',
     'uk_results',
     'bulk_adding',
+    'celery_haystack',
+    'celery',
 )
 
 MIDDLEWARE_CLASSES = (
@@ -373,7 +375,10 @@ REST_FRAMEWORK = {
 # allow attaching extra data to notifications:
 NOTIFICATIONS_USE_JSONFIELD = True
 
-HAYSTACK_SIGNAL_PROCESSOR = 'haystack.signals.RealtimeSignalProcessor'
+HAYSTACK_SIGNAL_PROCESSOR = 'celery_haystack.signals.CelerySignalProcessor'
+
+
+CELERY_BROKER_URL = "redis://localhost:6379/0"
 
 HAYSTACK_CONNECTIONS = {
     'default': {

--- a/ynr/settings/base.py
+++ b/ynr/settings/base.py
@@ -375,10 +375,8 @@ REST_FRAMEWORK = {
 # allow attaching extra data to notifications:
 NOTIFICATIONS_USE_JSONFIELD = True
 
-HAYSTACK_SIGNAL_PROCESSOR = 'celery_haystack.signals.CelerySignalProcessor'
+HAYSTACK_SIGNAL_PROCESSOR = 'haystack.signals.RealtimeSignalProcessor'
 
-
-CELERY_BROKER_URL = "redis://localhost:6379/0"
 
 HAYSTACK_CONNECTIONS = {
     'default': {

--- a/ynr/settings/testing.py
+++ b/ynr/settings/testing.py
@@ -17,6 +17,16 @@ PASSWORD_HASHERS = [
 
 RUNNING_TESTS = True
 
+# Normally we use CelerySignalProcessor, however this makes testing harder,
+# as (rightly), the celery tasks wait until a transation has been committed
+# before indexing. This causes problems with tests, as they all run in a
+# transaction. We could use TransactionTestCase, but that would have to be
+# used almost everywhere, and would cause more problems. This is a simplier
+# method, and ultimatlly the value in testing celery with `CELERY_ALWAYS_EAGER`
+# isn't much, as it's not the same as prod anyway.
+HAYSTACK_SIGNAL_PROCESSOR = 'haystack.signals.RealtimeSignalProcessor'
+
+
 SECRET_KEY = "just here for testing"
 
 if os.environ.get('TRAVIS'):

--- a/ynr/settings/testing.py
+++ b/ynr/settings/testing.py
@@ -17,16 +17,6 @@ PASSWORD_HASHERS = [
 
 RUNNING_TESTS = True
 
-# Normally we use CelerySignalProcessor, however this makes testing harder,
-# as (rightly), the celery tasks wait until a transation has been committed
-# before indexing. This causes problems with tests, as they all run in a
-# transaction. We could use TransactionTestCase, but that would have to be
-# used almost everywhere, and would cause more problems. This is a simplier
-# method, and ultimatlly the value in testing celery with `CELERY_ALWAYS_EAGER`
-# isn't much, as it's not the same as prod anyway.
-HAYSTACK_SIGNAL_PROCESSOR = 'haystack.signals.RealtimeSignalProcessor'
-
-
 SECRET_KEY = "just here for testing"
 
 if os.environ.get('TRAVIS'):


### PR DESCRIPTION
There are a couple of reasons for this:

1. Before this change, updating the search index was a blocking
operation when modifying a Person object. This would be find normally,
but slowed everything down a lot when bulk adding by SOPN or Party. It
makes sense move this work to an async task.

2. There may well be other uses for an async queue in future, so adding
this capability to the project makes sense.

See the note in testing.py about running tests.