### PR TITLE
External elastic search

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,15 +18,9 @@ cache:
     - $HOME/.pip-cache/
     - $HOME/.tox/
     - .tox
-env:
-  - ES_VERSION=2.3.1 ES_DOWNLOAD_URL=https://download.elastic.co/elasticsearch/release/org/elasticsearch/distribution/tar/elasticsearch/${ES_VERSION}/elasticsearch-${ES_VERSION}.tar.gz
 
 install:
   - pip install tox coveralls tox-travis
-  # Install ES
-  - wget -nc ${ES_DOWNLOAD_URL}
-  - tar -xzf elasticsearch-${ES_VERSION}.tar.gz
-  - ./elasticsearch-${ES_VERSION}/bin/elasticsearch &
   # Make sure pip is at the latest version:
   - pip install -U pip
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -86,4 +86,5 @@ urllib3==1.13
 waitress==0.8.9
 WebOb==1.4
 WebTest==2.0.15
+Whoosh==2.7.4
 yanc==0.2.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,7 @@ django-debug-toolbar-template-timings
 django-debug-toolbar==1.9.1
 django-extensions==1.6.1
 django-filter==0.13
-django-haystack==2.5.1
+django-haystack==2.6.0
 django-markdown-deux==1.0.5
 django-model-utils==2.3.1
 django-notifications-hq==1.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -30,7 +30,7 @@ Django>=1.9,<1.10
 djangorestframework-jsonp==1.0.2
 djangorestframework==3.3.3
 docutils==0.10
-elasticsearch==0.4.5
+elasticsearch==2.4.1
 factory-boy==2.6.0
 fake-factory==0.5.3
 futures==3.0.3

--- a/ynr/apps/candidates/search_indexes.py
+++ b/ynr/apps/candidates/search_indexes.py
@@ -12,6 +12,7 @@ class PersonIndex(CelerySearchIndex, indexes.Indexable):
     family_name = indexes.CharField(model_attr='family_name')
     given_name = indexes.CharField(model_attr='given_name')
     additional_name = indexes.CharField(model_attr='additional_name')
+    last_updated = indexes.DateTimeField(model_attr='updated_at')
 
     def get_updated_field(self):
         return 'updated_at'

--- a/ynr/settings/base.py
+++ b/ynr/settings/base.py
@@ -381,9 +381,8 @@ HAYSTACK_SIGNAL_PROCESSOR = 'haystack.signals.RealtimeSignalProcessor'
 
 HAYSTACK_CONNECTIONS = {
     'default': {
-        'ENGINE': 'haystack.backends.elasticsearch_backend.ElasticsearchSearchEngine',  # noqa
-        'URL': 'http://127.0.0.1:9200/',
-        'INDEX_NAME': 'ynr',
+        'ENGINE': 'haystack.backends.whoosh_backend.WhooshEngine',
+        'PATH': '.haystack',
     },
 }
 

--- a/ynr/settings/testing.py
+++ b/ynr/settings/testing.py
@@ -17,6 +17,13 @@ PASSWORD_HASHERS = [
 
 RUNNING_TESTS = True
 
+HAYSTACK_CONNECTIONS = {
+    'default': {
+        'ENGINE': 'haystack.backends.whoosh_backend.WhooshEngine',
+        'STORAGE': 'ram',
+    },
+}
+
 SECRET_KEY = "just here for testing"
 
 if os.environ.get('TRAVIS'):


### PR DESCRIPTION
Doing this to try to lighten the load on the server a little more, and also make it easier to move to `n` servers if we wanted to in future.

Moving to Whoosh in non-prod should make installing and dev work easier too.