### PR TITLE
Redirect to PEE page from ballot_paper_id

### DIFF
--- a/ynr/apps/candidates/urls.py
+++ b/ynr/apps/candidates/urls.py
@@ -56,6 +56,11 @@ patterns_to_format = [
         'name': 'posts',
     },
     {
+        'pattern': r'^election/{election}/$',
+        'view': views.BallotPaperIDRedirectView.as_view(),
+        'name': 'ballot_paper_id_redirect'
+    },
+    {
         'pattern': r'^election/{election}/constituencies$',
         'view': views.ConstituencyListView.as_view(),
         'name': 'constituencies'

--- a/ynr/apps/candidates/views/constituencies.py
+++ b/ynr/apps/candidates/views/constituencies.py
@@ -12,7 +12,7 @@ from django.http import (
 from django.utils.decorators import method_decorator
 from django.utils.http import urlquote
 from django.utils.translation import ugettext as _
-from django.views.generic import TemplateView, FormView, View
+from django.views.generic import TemplateView, FormView, View, RedirectView
 from django.shortcuts import get_object_or_404
 from django.db import transaction
 from django.db.models import Prefetch
@@ -300,6 +300,13 @@ class ConstituencyDetailCSVView(ElectionMixin, View):
         response.write(list_to_csv(all_people))
         return response
 
+class BallotPaperIDRedirectView(RedirectView):
+    def get_redirect_url(self, *args, **kwargs):
+        pee = get_object_or_404(
+            PostExtraElection,
+            ballot_paper_id=kwargs['election']
+        )
+        return pee.get_absolute_url()
 
 class ConstituencyListView(ElectionMixin, TemplateView):
     template_name = 'candidates/constituencies.html'


### PR DESCRIPTION
Closes #471

Note that this is a hidden feature for our use at this election cycle.
In future all URLs will use the ballot_paper_id if they can, and other
redirects will be in place to manage the old style URLs.