### PR TITLE
tighten up when locking is allowed

### DIFF
--- a/ynr/apps/elections/uk/templates/candidates/_candidates_for_post.html
+++ b/ynr/apps/elections/uk/templates/candidates/_candidates_for_post.html
@@ -71,13 +71,17 @@
           Someone else will double check it soon.
         </p>
       {% else %}
-        <button type="submit" class="button small">
           {% if candidates_locked %}
-            {% trans "Unlock candidate list" %}
+            <button type="submit" class="button small">
+              {% trans "Unlock candidate list" %}
+            </button>
           {% else %}
-            {% trans "Lock candidate list" %}
+            {% if has_lock_suggestion and some_official_documents %}
+              <button type="submit" class="button small">
+                {% trans "Lock candidate list" %}
+              </button>
+            {% endif %}
           {% endif %}
-        </button>
       {% endif %}
       <p>
       {% if candidates_locked %}

--- a/ynr/apps/elections/uk/tests/test_post_view.py
+++ b/ynr/apps/elections/uk/tests/test_post_view.py
@@ -203,3 +203,56 @@ class TestConstituencyDetailView(TestUserMixin, UK2015ExamplesMixin, WebTest):
             response,
             "Lock candidate list"
         )
+
+    def test_no_lock_button_if_no_sopn(self):
+        group = Group.objects.get(name=TRUSTED_TO_LOCK_GROUP_NAME)
+        self.user.groups.add(group)
+        self.user.save()
+
+        pee = PostExtraElection.objects.get(
+            election__slug='2015',
+            postextra__slug='14419',
+        )
+
+        SuggestedPostLock.objects.create(
+            postextraelection=pee,
+            user=self.users_to_delete[-1],
+            justification='I liked totally reviewed the SOPN',
+        )
+
+        response = self.app.get(
+            '/election/2015/post/14419/edinburgh-east',
+            user=self.user,
+        )
+        self.assertNotContains(
+            response,
+            "Lock candidate list"
+        )
+
+    def test_no_lock_button_if_no_lock_suggestion(self):
+        group = Group.objects.get(name=TRUSTED_TO_LOCK_GROUP_NAME)
+        self.user.groups.add(group)
+        self.user.save()
+
+        OfficialDocument.objects.create(
+            election=self.election,
+            post=self.edinburgh_east_post_extra.base,
+            source_url='http://example.com',
+            document_type=OfficialDocument.NOMINATION_PAPER,
+            post_election=self.edinburgh_east_post_extra_pee,
+            uploaded_file="sopn.pdf"
+        )
+
+        pee = PostExtraElection.objects.get(
+            election__slug='2015',
+            postextra__slug='14419',
+        )
+
+        response = self.app.get(
+            '/election/2015/post/14419/edinburgh-east',
+            user=self.user,
+        )
+        self.assertNotContains(
+            response,
+            "Lock candidate list"
+        )


### PR DESCRIPTION
* require a lock suggestion before PEE may be locked
* only allow locking if we have one or more `OfficialDocument` objects attached to this PEE

Closes #524