### PR TITLE
don't list areas with no lock suggestion in suggested locks view

### DIFF
--- a/ynr/apps/moderation_queue/tests/test_queue.py
+++ b/ynr/apps/moderation_queue/tests/test_queue.py
@@ -503,6 +503,13 @@ class SuggestedLockReviewTests(UK2015ExamplesMixin, TestUserMixin, WebTest):
             user=self.user,
             justification='test data'
         )
+        OfficialDocument.objects.create(
+            election=self.election,
+            document_type=OfficialDocument.NOMINATION_PAPER,
+            post=self.dulwich_post_extra.base,
+            post_election=pee,
+            source_url="http://example.com"
+        )
         url = reverse('suggestions-to-lock-review-list')
         response = self.app.get(url, user=self.user)
         self.assertEqual(response.status_code, 200)

--- a/ynr/apps/moderation_queue/views.py
+++ b/ynr/apps/moderation_queue/views.py
@@ -594,8 +594,7 @@ class SuggestLockReviewListView(LoginRequiredMixin, TemplateView):
             election__current=True,
             candidates_locked=False,
         ).exclude(
-            suggestedpostlock=None,
-            officialdocument=None
+            models.Q(suggestedpostlock=None) | models.Q(officialdocument=None)
         ).select_related(
             'election',
             'postextra',


### PR DESCRIPTION
This should be SQL `OR` instead of `AND`

closes #528