### PR TITLE
Cached-API default storage

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,8 @@
 [tox]
-envlist = py{27,35,36}-django19
+envlist = py{35,36}-django19
 skipsdist = True
 
 [tox:travis]
-2.7 = py27
 3.5 = py35
 3.6 = py36
 

--- a/ynr/apps/candidates/management/commands/candidates_cache_api_to_directory.py
+++ b/ynr/apps/candidates/management/commands/candidates_cache_api_to_directory.py
@@ -6,129 +6,157 @@ import re
 from shutil import rmtree
 
 from django.core.management.base import BaseCommand
+from django.core.files.storage import DefaultStorage
+from django.core.files.base import ContentFile
 from django.test import Client
 from django.utils.six.moves.urllib_parse import urlsplit, parse_qs
-
-from ynr.helpers import mkdir_p
-
-
-def hostname_and_secure(url):
-    split_url = urlsplit(url)
-    return (split_url.netloc, split_url.scheme == 'https')
 
 
 def path_and_query(url):
     split_url = urlsplit(url)
-    return split_url.path + '?' + split_url.query
+    return split_url.path + "?" + split_url.query
 
 
 def page_from_url(url):
-    page_values = parse_qs(urlsplit(url).query).get('page')
+    page_values = parse_qs(urlsplit(url).query).get("page")
     if page_values:
         return int(page_values[0])
     return 1
 
 
 def page_filename(endpoint, page_number):
-    return '{}-{:06d}.json'.format(endpoint, page_number)
-
-
-def update_latest_symlink(output_directory, subdirectory):
-    tmp_symlink_location = join(output_directory, 'new')
-    symlink_location = join(output_directory, 'latest')
-    if exists(tmp_symlink_location):
-        os.remove(symlink_location)
-    os.symlink(subdirectory, tmp_symlink_location)
-    os.rename(tmp_symlink_location, symlink_location)
+    return "{}-{:06d}.json".format(endpoint, page_number)
 
 
 def is_timestamped_dir(directory):
-    dir_basename = basename(directory)
-    return isdir(directory) and \
-        re.search(r'^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}$', dir_basename)
-
-
-def prune(output_directory):
-    timestamped_directories_to_remove = set(sorted(
-        e for e in os.listdir(output_directory)
-        if is_timestamped_dir(join(output_directory, e))
-    )[:-4]) # Make sure we always leave at least the last 4 directories
-    latest_symlink = join(output_directory, 'latest')
-    if exists(latest_symlink):
-        current_timestamped_directory = os.readlink(latest_symlink)
-        timestamped_directories_to_remove.discard(
-            current_timestamped_directory)
-    # Don't remove any directory dated in the last 12 hours:
-    remove_before = datetime.now() - timedelta(hours=12)
-    too_recent = {
-        e for e in timestamped_directories_to_remove
-        if datetime.strptime(e, '%Y-%m-%dT%H:%M:%S') >= remove_before}
-    for e in too_recent:
-        timestamped_directories_to_remove.remove(e)
-    # Now remove any of those directories that are left:
-    for e in sorted(timestamped_directories_to_remove):
-        rmtree(join(output_directory, e))
+    return re.search(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}$", directory)
 
 
 class Command(BaseCommand):
 
     help = "Cache the output of the persons and posts endpoints to a directory"
 
-    endpoints = ('persons', 'posts')
+    endpoints = ("persons", "posts")
 
     def add_arguments(self, parser):
         parser.add_argument(
-            'OUTPUT-DIRECTORY',
-            help='The directory to write output to')
+            "--hostname",
+            action="store",
+            default="candidates.democracyclub.org.uk",
+            help="Optional hostname if files are stored at a relative path",
+        )
         parser.add_argument(
-            'DIRECTORY-URL',
-            help='The URL which that directory will be served at')
+            "--base-url", help="Optional url_prefix for next and previous links"
+        )
         parser.add_argument(
-            '--page-size',
+            "--http",
+            help="Force URLs to use HTTP. Defaults to HTTPS",
+            action="store_true",
+        )
+        parser.add_argument(
+            "--page-size",
             type=int,
-            help='How many results should be output per file (max 200)'
+            help="How many results should be output per file (max 200)",
         )
         parser.add_argument(
-            '--prune',
-            action='store_true',
-            help=('Prune older timestamped directories (those over 12 hours '
-                  'old, never deleting the latest successfully generated one '
-                  'or any of the 4 most recent)')
+            "--prune",
+            action="store_true",
+            help=(
+                "Prune older timestamped directories (those over 12 hours "
+                "old, never deleting the latest successfully generated one "
+                "or any of the 4 most recent)"
+            ),
         )
+
+    def update_latest_page(self, output_directory, endpoint):
+        latest_page_location = join(output_directory, "latest")
+        file_name = join(latest_page_location, page_filename(endpoint, 1))
+        self.storage.save(file_name, ContentFile(self.first_page_json))
+
+    def prune(self):
+        all_dirs = []
+        for directory in self.storage.listdir(self.directory_path)[0]:
+            if is_timestamped_dir(directory):
+                all_dirs.append(directory)
+
+        # Make sure we always leave at least the last 4 directories
+        timestamped_directories_to_remove = sorted(all_dirs)[:-4]
+
+        for path in sorted(timestamped_directories_to_remove):
+            dir_path = join(self.directory_path, path)
+            for filename in self.storage.listdir(dir_path)[1]:
+                self.storage.delete(join(dir_path, filename))
+
+    def get_url_prefix(self, url_prefix=None):
+        """
+        Use the hostname passed if there is one, otherwise try to guess it from
+        the DefaultStorage class.
+
+        Raise a ValueError if the hostname isn't an absolute URL
+
+        """
+
+        if not url_prefix:
+            url_prefix = self.storage.base_url
+
+        if self.secure:
+            match = "https://"
+        else:
+            match = "http://"
+
+        if not url_prefix.startswith(match):
+            raise ValueError(
+                "URL prefix must start with {}. Try using --url_prefix.".format(
+                    match
+                )
+            )
+        return url_prefix
 
     def rewrite_link(self, endpoint, url):
         if not url:
             return None
         page = page_from_url(url)
         filename = page_filename(endpoint, page)
-        return '{}{}/{}'.format(self.directory_url, self.timestamp, filename)
+        return "{}{}/{}".format(self.url_prefix, self.timestamp, filename)
 
     def get(self, url):
-        kwargs = {'SERVER_NAME': self.hostname}
+        kwargs = {"SERVER_NAME": self.hostname}
         if self.secure:
-            kwargs['wsgi.url_scheme'] = 'https'
-            kwargs['secure'] = True
+            kwargs["wsgi.url_scheme"] = "https"
+            kwargs["secure"] = True
         return self.client.get(url, **kwargs)
 
     def rewrite_next_and_previous_links(self, endpoint, data):
-        data['next'] = self.rewrite_link(endpoint, data['next'])
-        data['previous'] = self.rewrite_link(endpoint, data['previous'])
+        data["next"] = self.rewrite_link(endpoint, data["next"])
+        data["previous"] = self.rewrite_link(endpoint, data["previous"])
 
     def get_api_results_to_directory(self, endpoint, json_directory, page_size):
-        url = '/api/v0.9/{endpoint}/?page_size={page_size}&format=json'.format(
-            page_size=page_size, endpoint=endpoint)
+        url = "/api/v0.9/{endpoint}/?page_size={page_size}&format=json".format(
+            page_size=page_size, endpoint=endpoint
+        )
+
         while url:
             page = page_from_url(url)
-            output_filename = join(json_directory, page_filename(endpoint, page))
+            output_filename = join(
+                json_directory, page_filename(endpoint, page)
+            )
             response = self.get(url)
             if response.status_code != 200:
                 msg = "Unexpected response {0} from {1}"
                 raise Exception(msg.format(response.status_code, url))
-            data = json.loads(response.content.decode('utf-8'))
-            original_next_url = data['next']
+            data = json.loads(response.content.decode("utf-8"))
+            original_next_url = data["next"]
             self.rewrite_next_and_previous_links(endpoint, data)
-            with open(output_filename, 'w') as f:
-                json.dump(data, f, indent=4, sort_keys=True)
+
+            json_page = json.dumps(data, indent=4, sort_keys=True).encode(
+                "utf8"
+            )
+
+            if page == 1:
+                self.first_page_json = json_page
+
+            self.storage.save(output_filename, ContentFile(json_page))
+
             # Now make sure the next URL works with the test client:
             if original_next_url:
                 url = path_and_query(original_next_url)
@@ -137,19 +165,22 @@ class Command(BaseCommand):
 
     def handle(self, *args, **options):
         self.client = Client()
-        self.directory_url = options['DIRECTORY-URL']
-        if not self.directory_url.endswith('/'):
-            self.directory_url = self.directory_url + '/'
-        self.hostname, self.secure = hostname_and_secure(self.directory_url)
-        mkdir_p(options['OUTPUT-DIRECTORY'])
-        self.timestamp = datetime.now().strftime('%Y-%m-%dT%H:%M:%S')
-        json_directory = join(options['OUTPUT-DIRECTORY'], self.timestamp)
-        mkdir_p(json_directory)
-        page_size = options['page_size']
+        self.directory_path = "cached-api"
+        self.storage = DefaultStorage()
+        self.secure = not options.get("http", False)
+        self.hostname = options["hostname"]
+        self.url_prefix = self.get_url_prefix(options["url_prefix"])
+
+        self.timestamp = datetime.now().strftime("%Y-%m-%dT%H:%M:%S")
+        json_directory = join(self.directory_path, self.timestamp)
+
+        page_size = options["page_size"]
         if not page_size:
             page_size = 200
         for endpoint in self.endpoints:
-            self.get_api_results_to_directory(endpoint, json_directory, page_size)
-        update_latest_symlink(options['OUTPUT-DIRECTORY'], self.timestamp)
-        if options['prune']:
-            prune(options['OUTPUT-DIRECTORY'])
+            self.get_api_results_to_directory(
+                endpoint, json_directory, page_size
+            )
+            self.update_latest_page(self.directory_path, endpoint)
+        if options["prune"]:
+            self.prune()

--- a/ynr/apps/candidates/tests/test_api.py
+++ b/ynr/apps/candidates/tests/test_api.py
@@ -7,43 +7,37 @@ from shutil import rmtree
 from tempfile import mkdtemp
 
 from django.core.management import call_command
+from django.conf import settings
+from django.core.files.storage import DefaultStorage
+from django.core.files.base import ContentFile
 
 from django_webtest import WebTest
 
-from .factories import (
-    MembershipFactory, PersonExtraFactory,
-)
+from .factories import MembershipFactory, PersonExtraFactory
 from .uk_examples import UK2015ExamplesMixin
 
-from candidates.management.commands.candidates_cache_api_to_directory \
-    import prune
 from candidates.models import LoggedAction, PersonRedirect
+from candidates.tests.helpers import TmpMediaRootMixin
 
 
-class TestAPI(UK2015ExamplesMixin, WebTest):
-
+class TestAPI(TmpMediaRootMixin, UK2015ExamplesMixin, WebTest):
     def setUp(self):
         super().setUp()
 
         person_extra = PersonExtraFactory.create(
-            base__id='2009',
-            base__name='Tessa Jowell'
+            base__id="2009", base__name="Tessa Jowell"
         )
         dulwich_not_stand = PersonExtraFactory.create(
-            base__id='4322',
-            base__name='Helen Hayes'
+            base__id="4322", base__name="Helen Hayes"
         )
         edinburgh_candidate = PersonExtraFactory.create(
-            base__id='818',
-            base__name='Sheila Gilmore'
+            base__id="818", base__name="Sheila Gilmore"
         )
         edinburgh_winner = PersonExtraFactory.create(
-            base__id='5795',
-            base__name='Tommy Sheppard'
+            base__id="5795", base__name="Tommy Sheppard"
         )
         edinburgh_may_stand = PersonExtraFactory.create(
-            base__id='5163',
-            base__name='Peter McColl'
+            base__id="5163", base__name="Peter McColl"
         )
         MembershipFactory.create(
             person=person_extra.base,
@@ -54,14 +48,14 @@ class TestAPI(UK2015ExamplesMixin, WebTest):
         MembershipFactory.create(
             person=person_extra.base,
             organization=self.labour_party_extra.base,
-            post_election = self.edinburgh_east_post_extra_pee,
+            post_election=self.edinburgh_east_post_extra_pee,
         )
 
         MembershipFactory.create(
             person=dulwich_not_stand.base,
             post=self.dulwich_post_extra.base,
             on_behalf_of=self.labour_party_extra.base,
-            post_election=self.dulwich_post_extra_pee_earlier
+            post_election=self.dulwich_post_extra_pee_earlier,
         )
         dulwich_not_stand.not_standing.add(self.election)
 
@@ -87,164 +81,142 @@ class TestAPI(UK2015ExamplesMixin, WebTest):
             post_election=self.edinburgh_east_post_extra_pee_earlier,
         )
 
+        self.storage = DefaultStorage()
+
     def test_api_basic_response(self):
-        response = self.app.get(
-            '/api/v0.9/'
-        )
+        response = self.app.get("/api/v0.9/")
         self.assertEqual(response.status_code, 200)
         json = response.json
 
         self.assertEqual(
-            json['persons'],
-            'http://localhost:80/api/v0.9/persons/'
+            json["persons"], "http://localhost:80/api/v0.9/persons/"
         )
         self.assertEqual(
-            json['organizations'],
-            'http://localhost:80/api/v0.9/organizations/'
+            json["organizations"], "http://localhost:80/api/v0.9/organizations/"
         )
         self.assertEqual(
-            json['elections'],
-            'http://localhost:80/api/v0.9/elections/'
+            json["elections"], "http://localhost:80/api/v0.9/elections/"
         )
-        self.assertEqual(json['posts'], 'http://localhost:80/api/v0.9/posts/')
+        self.assertEqual(json["posts"], "http://localhost:80/api/v0.9/posts/")
 
-        persons_resp = self.app.get('/api/v0.9/persons/')
+        persons_resp = self.app.get("/api/v0.9/persons/")
         self.assertEqual(persons_resp.status_code, 200)
 
-        organizations_resp = self.app.get('/api/v0.9/organizations/')
+        organizations_resp = self.app.get("/api/v0.9/organizations/")
         self.assertEqual(organizations_resp.status_code, 200)
 
-        elections_resp = self.app.get('/api/v0.9/elections/')
+        elections_resp = self.app.get("/api/v0.9/elections/")
         self.assertEqual(elections_resp.status_code, 200)
 
-        posts_resp = self.app.get('/api/v0.9/posts/')
+        posts_resp = self.app.get("/api/v0.9/posts/")
         self.assertEqual(posts_resp.status_code, 200)
 
     def test_api_errors(self):
-        response = self.app.get(
-            '/api/',
-            expect_errors=True
-        )
+        response = self.app.get("/api/", expect_errors=True)
         self.assertEqual(response.status_code, 404)
 
-        response = self.app.get(
-            '/api/v0.8',
-            expect_errors=True
-        )
+        response = self.app.get("/api/v0.8", expect_errors=True)
         self.assertEqual(response.status_code, 404)
 
-        response = self.app.get(
-            '/api/v0.9/person/',
-            expect_errors=True
-        )
+        response = self.app.get("/api/v0.9/person/", expect_errors=True)
         self.assertEqual(response.status_code, 404)
 
-        response = self.app.get(
-            '/api/v0.9/persons/4000/',
-            expect_errors=True
-        )
+        response = self.app.get("/api/v0.9/persons/4000/", expect_errors=True)
         self.assertEqual(response.status_code, 404)
 
-        response = self.app.post(
-            '/api/v0.9/persons/',
-            {},
-            expect_errors=True
-        )
+        response = self.app.post("/api/v0.9/persons/", {}, expect_errors=True)
         self.assertEqual(response.status_code, 403)
 
     def test_api_persons(self):
-        persons_resp = self.app.get('/api/v0.9/persons/')
+        persons_resp = self.app.get("/api/v0.9/persons/")
 
         persons = persons_resp.json
 
-        self.assertEqual(persons['count'], len(persons['results']))
-        self.assertEqual(persons['count'], 5)
+        self.assertEqual(persons["count"], len(persons["results"]))
+        self.assertEqual(persons["count"], 5)
 
     def test_api_person(self):
-        person_resp = self.app.get('/api/v0.9/persons/2009/')
+        person_resp = self.app.get("/api/v0.9/persons/2009/")
 
         self.assertEqual(person_resp.status_code, 200)
 
         person = person_resp.json
-        self.assertEqual(person['id'], 2009)
-        self.assertEqual(person['name'], 'Tessa Jowell')
+        self.assertEqual(person["id"], 2009)
+        self.assertEqual(person["name"], "Tessa Jowell")
 
-        memberships = sorted(
-            person['memberships'],
-            key=lambda m: m['role']
-        )
+        memberships = sorted(person["memberships"], key=lambda m: m["role"])
 
         self.assertEqual(len(memberships), 2)
-        self.assertEqual(memberships[1]['role'], 'Candidate')
+        self.assertEqual(memberships[1]["role"], "Candidate")
 
-        self.assertEqual(len(person['versions']), 0)
+        self.assertEqual(len(person["versions"]), 0)
 
     def test_api_organizations(self):
-        organizations_resp = self.app.get('/api/v0.9/organizations/')
+        organizations_resp = self.app.get("/api/v0.9/organizations/")
 
         organizations = organizations_resp.json
 
-        self.assertEqual(organizations['count'], len(organizations['results']))
-        self.assertEqual(organizations['count'], 7)
+        self.assertEqual(organizations["count"], len(organizations["results"]))
+        self.assertEqual(organizations["count"], 7)
 
     def test_api_organization(self):
-        organizations_resp = self.app.get('/api/v0.9/organizations/')
+        organizations_resp = self.app.get("/api/v0.9/organizations/")
         organizations = organizations_resp.json
 
         organization_url = None
-        for organization in organizations['results']:
-            if organization['id'] == 'party:53':
-                organization_url = organization['url']
+        for organization in organizations["results"]:
+            if organization["id"] == "party:53":
+                organization_url = organization["url"]
                 break
 
         organization_resp = self.app.get(organization_url)
         self.assertEqual(organization_resp.status_code, 200)
 
         organization = organization_resp.json
-        self.assertEqual(organization['id'], 'party:53')
-        self.assertEqual(organization['name'], 'Labour Party')
+        self.assertEqual(organization["id"], "party:53")
+        self.assertEqual(organization["name"], "Labour Party")
 
     def test_api_elections(self):
-        elections_resp = self.app.get('/api/v0.9/elections/')
+        elections_resp = self.app.get("/api/v0.9/elections/")
 
         elections = elections_resp.json
 
-        self.assertEqual(elections['count'], len(elections['results']))
-        self.assertEqual(elections['count'], 3)
+        self.assertEqual(elections["count"], len(elections["results"]))
+        self.assertEqual(elections["count"], 3)
 
     def test_api_election(self):
-        elections_resp = self.app.get('/api/v0.9/elections/')
+        elections_resp = self.app.get("/api/v0.9/elections/")
         elections = elections_resp.json
 
         election_url = None
-        for election in elections['results']:
-            if election['id'] == '2015':
-                election_url = election['url']
+        for election in elections["results"]:
+            if election["id"] == "2015":
+                election_url = election["url"]
                 break
 
         election_resp = self.app.get(election_url)
         self.assertEqual(election_resp.status_code, 200)
 
         election = election_resp.json
-        self.assertEqual(election['id'], '2015')
-        self.assertEqual(election['name'], '2015 General Election')
+        self.assertEqual(election["id"], "2015")
+        self.assertEqual(election["name"], "2015 General Election")
 
     def test_api_posts(self):
-        posts_resp = self.app.get('/api/v0.9/posts/')
+        posts_resp = self.app.get("/api/v0.9/posts/")
 
         posts = posts_resp.json
 
-        self.assertEqual(posts['count'], len(posts['results']))
-        self.assertEqual(posts['count'], 5)
+        self.assertEqual(posts["count"], len(posts["results"]))
+        self.assertEqual(posts["count"], 5)
 
     def test_api_post(self):
-        posts_resp = self.app.get('/api/v0.9/posts/')
+        posts_resp = self.app.get("/api/v0.9/posts/")
         posts = posts_resp.json
 
         post_url = None
-        for post in posts['results']:
-            if post['id'] == '65808':
-                post_url = post['url']
+        for post in posts["results"]:
+            if post["id"] == "65808":
+                post_url = post["url"]
                 break
 
         self.assertTrue(post_url)
@@ -253,249 +225,258 @@ class TestAPI(UK2015ExamplesMixin, WebTest):
 
         post = post_resp.json
 
-        self.assertEqual(post['id'], '65808')
+        self.assertEqual(post["id"], "65808")
         self.assertEqual(
-            post['label'],
-            'Member of Parliament for Dulwich and West Norwood'
+            post["label"], "Member of Parliament for Dulwich and West Norwood"
         )
 
     def test_api_person_redirects(self):
-        PersonRedirect.objects.create(old_person_id='1234', new_person_id='42')
-        PersonRedirect.objects.create(old_person_id='5678', new_person_id='12')
-        person_redirects_resp = self.app.get('/api/v0.9/person_redirects/')
+        PersonRedirect.objects.create(old_person_id="1234", new_person_id="42")
+        PersonRedirect.objects.create(old_person_id="5678", new_person_id="12")
+        person_redirects_resp = self.app.get("/api/v0.9/person_redirects/")
         person_redirects = person_redirects_resp.json
-        self.assertEqual(
-            person_redirects['results'][0]['old_person_id'], 1234)
-        self.assertEqual(
-            person_redirects['results'][0]['new_person_id'], 42)
-        self.assertEqual(
-            person_redirects['results'][1]['old_person_id'], 5678)
-        self.assertEqual(
-            person_redirects['results'][1]['new_person_id'], 12)
+        self.assertEqual(person_redirects["results"][0]["old_person_id"], 1234)
+        self.assertEqual(person_redirects["results"][0]["new_person_id"], 42)
+        self.assertEqual(person_redirects["results"][1]["old_person_id"], 5678)
+        self.assertEqual(person_redirects["results"][1]["new_person_id"], 12)
 
     def test_api_person_redirect(self):
-        PersonRedirect.objects.create(old_person_id='1234', new_person_id='42')
-        url = '/api/v0.9/person_redirects/1234/'
+        PersonRedirect.objects.create(old_person_id="1234", new_person_id="42")
+        url = "/api/v0.9/person_redirects/1234/"
         person_redirect_resp = self.app.get(url)
         person_redirect = person_redirect_resp.json
-        self.assertEqual(person_redirect['old_person_id'], 1234)
-        self.assertEqual(person_redirect['new_person_id'], 42)
+        self.assertEqual(person_redirect["old_person_id"], 1234)
+        self.assertEqual(person_redirect["new_person_id"], 42)
 
     def test_api_version_info(self):
-        version_resp = self.app.get('/version.json')
+        version_resp = self.app.get("/version.json")
         self.assertEqual(version_resp.status_code, 200)
 
         info = version_resp.json
-        self.assertEqual(info['users_who_have_edited'], 0)
-        self.assertEqual(info['interesting_user_actions'], 0)
+        self.assertEqual(info["users_who_have_edited"], 0)
+        self.assertEqual(info["interesting_user_actions"], 0)
 
-        LoggedAction.objects.create(
-            action_type='set-candidate-not-elected'
-        )
+        LoggedAction.objects.create(action_type="set-candidate-not-elected")
 
-        LoggedAction.objects.create(
-            action_type='edit-candidate'
-        )
+        LoggedAction.objects.create(action_type="edit-candidate")
 
-        version_resp = self.app.get('/version.json')
+        version_resp = self.app.get("/version.json")
         info = version_resp.json
-        self.assertEqual(info['interesting_user_actions'], 1)
+        self.assertEqual(info["interesting_user_actions"], 1)
 
     def test_api_cors_headers(self):
-        resp = self.app.get('/api/v0.9/', headers={
-            'Origin': b'http://example.com'}
+        resp = self.app.get(
+            "/api/v0.9/", headers={"Origin": b"http://example.com"}
         )
-        self.assertTrue('Access-Control-Allow-Origin' in resp.headers)
-        self.assertEqual(resp.headers['Access-Control-Allow-Origin'], '*')
+        self.assertTrue("Access-Control-Allow-Origin" in resp.headers)
+        self.assertEqual(resp.headers["Access-Control-Allow-Origin"], "*")
 
-        resp = self.app.get('/', headers={
-            'Origin': b'http://example.com'}
-        )
-        self.assertFalse('Access-Control-Allow-Origin' in resp.headers)
+        resp = self.app.get("/", headers={"Origin": b"http://example.com"})
+        self.assertFalse("Access-Control-Allow-Origin" in resp.headers)
 
     def test_api_jsonp_response(self):
-        response = self.app.get(
-            '/api/v0.9/?format=jsonp&callback=test'
-        )
+        response = self.app.get("/api/v0.9/?format=jsonp&callback=test")
         self.assertEqual(response.status_code, 200)
-        self.assertTrue(response.text.startswith('test('))
+        self.assertTrue(response.text.startswith("test("))
 
-    @patch('candidates.management.commands.candidates_cache_api_to_directory.datetime')
+    @patch(
+        "candidates.management.commands.candidates_cache_api_to_directory.datetime"
+    )
     def test_persons_api_to_directory(self, mock_datetime):
         # current
         # timestamped
         # timestamped
         mock_datetime.now.return_value = datetime(2017, 5, 14, 12, 33, 5, 0)
-        target_directory = mkdtemp()
-        try:
-            call_command(
-                'candidates_cache_api_to_directory',
-                target_directory,
-                'https://example.com/media/api-cache-for-wcivf',
-                page_size='3',
+        target_directory = settings.MEDIA_ROOT
+        call_command(
+            "candidates_cache_api_to_directory",
+            page_size="3",
+            url_prefix="https://example.com/media/api-cache-for-wcivf/",
+        )
+        expected_leafname = "2017-05-14T12:33:05"
+        expected_timestamped_directory = join(
+            settings.MEDIA_ROOT, "cached-api", expected_leafname
+        )
+        expected_symlink = join(settings.MEDIA_ROOT, "cached-api", "latest")
+        self.assertTrue(exists(expected_timestamped_directory))
+        self.assertTrue(exists(expected_symlink))
+        # Check that the files in that directory are as expected:
+        entries = os.listdir(expected_timestamped_directory)
+        persons_1_leafname = "persons-000001.json"
+        persons_2_leafname = "persons-000002.json"
+        posts_1_leafname = "posts-000001.json"
+        posts_2_leafname = "posts-000002.json"
+        self.assertEqual(
+            set(entries),
+            {
+                persons_1_leafname,
+                persons_2_leafname,
+                posts_1_leafname,
+                posts_2_leafname,
+            },
+        )
+        # Get the data from those pages:
+        with open(
+            join(expected_timestamped_directory, persons_1_leafname)
+        ) as f:
+            persons_1_data = json.load(f)
+        with open(
+            join(expected_timestamped_directory, persons_2_leafname)
+        ) as f:
+            persons_2_data = json.load(f)
+        with open(join(expected_timestamped_directory, posts_1_leafname)) as f:
+            posts_1_data = json.load(f)
+        with open(join(expected_timestamped_directory, posts_2_leafname)) as f:
+            posts_2_data = json.load(f)
+        # Check the previous and next links are as we expect:
+        self.assertEqual(
+            persons_1_data["next"],
+            "https://example.com/media/api-cache-for-wcivf/{}/{}".format(
+                expected_leafname, persons_2_leafname
+            ),
+        )
+        self.assertEqual(persons_1_data["previous"], None)
+        self.assertEqual(persons_2_data["next"], None)
+        self.assertEqual(
+            persons_2_data["previous"],
+            "https://example.com/media/api-cache-for-wcivf/{}/{}".format(
+                expected_leafname, persons_1_leafname
+            ),
+        )
+        self.assertEqual(
+            posts_1_data["next"],
+            "https://example.com/media/api-cache-for-wcivf/{}/{}".format(
+                expected_leafname, posts_2_leafname
+            ),
+        )
+        self.assertEqual(posts_1_data["previous"], None)
+        self.assertEqual(posts_2_data["next"], None)
+        self.assertEqual(
+            posts_2_data["previous"],
+            "https://example.com/media/api-cache-for-wcivf/{}/{}".format(
+                expected_leafname, posts_1_leafname
+            ),
+        )
+        # Check that the URL of the first person is as expected,
+        # as well as it being the right person:
+        first_person = persons_1_data["results"][0]
+        self.assertEqual(first_person["id"], 818)
+        self.assertEqual(first_person["name"], "Sheila Gilmore")
+        self.assertEqual(
+            first_person["url"],
+            "https://candidates.democracyclub.org.uk/api/v0.9/persons/818/?format=json",
+        )
+        # Similarly, check that the URL of the first post is as expected:
+        first_post = posts_1_data["results"][0]
+        self.assertEqual(first_post["id"], self.edinburgh_east_post_extra.slug)
+        self.assertEqual(
+            first_post["label"], "Member of Parliament for Edinburgh East"
+        )
+        self.assertEqual(
+            first_post["url"],
+            "https://candidates.democracyclub.org.uk/api/v0.9/posts/14419/?format=json",
+        )
+
+    def _setup_cached_api_directory(self, dir_list):
+        """
+        Saves a tmp file in settings.MEDIA_ROOT, called `.keep` in each
+        directory in dir_list.
+
+        """
+        for d in dir_list:
+            self.storage.save(join("cached-api", d, ".keep"), ContentFile("."))
+
+    @patch(
+        "candidates.management.commands.candidates_cache_api_to_directory.datetime"
+    )
+    def test_cache_api_to_directory_prune(self, mock_datetime):
+        # Need to make sure datetime.strptime still works:
+        mock_datetime.strptime.side_effect = datetime.strptime
+        mock_datetime.now.return_value = datetime(2017, 5, 14, 12, 33, 5, 0)
+
+        expected_to_prune = [
+            "2017-05-12T08:00:00",
+            "2017-05-12T10:00:00",
+            "2017-05-12T12:00:00",
+        ]
+        expected_to_keep = [
+            "2017-05-14T08:00:00",
+            "2017-05-14T10:00:00",
+            "2017-05-14T12:00:00",
+            "2017-05-14T12:33:05",
+        ]
+
+        self._setup_cached_api_directory(expected_to_keep + expected_to_prune)
+
+        self.assertTrue(
+            self.storage.exists(
+                join("cached-api", "2017-05-12T08:00:00", ".keep")
             )
-            expected_leafname = '2017-05-14T12:33:05'
-            expected_timestamped_directory = \
-                join(target_directory, expected_leafname)
-            expected_symlink = join(target_directory, 'latest')
-            self.assertTrue(exists(expected_timestamped_directory))
-            self.assertTrue(exists(expected_symlink))
-            # Check that the symlink points to to the timestamped directory:
-            self.assertEqual(os.readlink(expected_symlink), expected_leafname)
-            # Check that the files in that directory are as expected:
-            entries = os.listdir(expected_timestamped_directory)
-            persons_1_leafname = 'persons-000001.json'
-            persons_2_leafname = 'persons-000002.json'
-            posts_1_leafname = 'posts-000001.json'
-            posts_2_leafname = 'posts-000002.json'
-            self.assertEqual(set(entries), {
-                persons_1_leafname, persons_2_leafname,
-                posts_1_leafname, posts_2_leafname,
-            })
-            # Get the data from those pages:
-            with open(join(expected_timestamped_directory, persons_1_leafname)) as f:
-                persons_1_data = json.load(f)
-            with open(join(expected_timestamped_directory, persons_2_leafname)) as f:
-                persons_2_data = json.load(f)
-            with open(join(expected_timestamped_directory, posts_1_leafname)) as f:
-                posts_1_data = json.load(f)
-            with open(join(expected_timestamped_directory, posts_2_leafname)) as f:
-                posts_2_data = json.load(f)
-            # Check the previous and next links are as we expect:
-            self.assertEqual(
-                persons_1_data['next'],
-                'https://example.com/media/api-cache-for-wcivf/{}/{}'.format(
-                    expected_leafname, persons_2_leafname))
-            self.assertEqual(persons_1_data['previous'], None)
-            self.assertEqual(persons_2_data['next'], None)
-            self.assertEqual(
-                persons_2_data['previous'],
-                'https://example.com/media/api-cache-for-wcivf/{}/{}'.format(
-                    expected_leafname, persons_1_leafname))
-            self.assertEqual(
-                posts_1_data['next'],
-                'https://example.com/media/api-cache-for-wcivf/{}/{}'.format(
-                    expected_leafname, posts_2_leafname))
-            self.assertEqual(posts_1_data['previous'], None)
-            self.assertEqual(posts_2_data['next'], None)
-            self.assertEqual(
-                posts_2_data['previous'],
-                'https://example.com/media/api-cache-for-wcivf/{}/{}'.format(
-                    expected_leafname, posts_1_leafname))
-            # Check that the URL of the first person is as expected,
-            # as well as it being the right person:
-            first_person = persons_1_data['results'][0]
-            self.assertEqual(first_person['id'], 818)
-            self.assertEqual(first_person['name'], 'Sheila Gilmore')
-            self.assertEqual(first_person['url'], 'https://example.com/api/v0.9/persons/818/?format=json')
-            # Similarly, check that the URL of the first post is as expected:
-            first_post = posts_1_data['results'][0]
-            self.assertEqual(first_post['id'], self.edinburgh_east_post_extra.slug)
-            self.assertEqual(first_post['label'], 'Member of Parliament for Edinburgh East')
-            self.assertEqual(first_post['url'], 'https://example.com/api/v0.9/posts/14419/?format=json')
-        finally:
-            rmtree(target_directory)
+        )
 
-    @patch('candidates.management.commands.candidates_cache_api_to_directory.rmtree')
-    @patch('candidates.management.commands.candidates_cache_api_to_directory.datetime')
-    def test_cache_api_to_directory_prune(self, mock_datetime, mock_rmtree):
+        call_command(
+            "candidates_cache_api_to_directory",
+            page_size="3",
+            url_prefix="https://example.com/media/api-cache-for-wcivf/",
+            prune=True,
+        )
+
+        for dir_name in expected_to_keep:
+            self.assertTrue(
+                self.storage.exists(join("cached-api", dir_name, ".keep"))
+            )
+
+        for dir_name in expected_to_prune:
+            self.assertFalse(
+                self.storage.exists(join("cached-api", dir_name, ".keep"))
+            )
+
+    @patch(
+        "candidates.management.commands.candidates_cache_api_to_directory.datetime"
+    )
+    def test_cache_api_to_directory_prune_four_old(self, mock_datetime):
         # Need to make sure datetime.strptime still works:
         mock_datetime.strptime.side_effect = datetime.strptime
         mock_datetime.now.return_value = datetime(2017, 5, 14, 12, 33, 5, 0)
-        target_directory = mkdtemp()
-        try:
-            for d in (
-                    '2017-05-12T08:00:00',
-                    '2017-05-12T10:00:00',
-                    '2017-05-12T12:00:00',
-                    '2017-05-14T08:00:00',
-                    '2017-05-14T10:00:00',
-                    '2017-05-14T12:00:00',
-            ):
-                os.makedirs(join(target_directory, d))
-            os.symlink('2017-05-12T08:00:00', join(target_directory, 'latest'))
-            prune(target_directory)
-            # That should have kept the last 4 + the one that latest
-            # points to, so there should only have been one call to rmtree:
-            self.assertEqual(mock_rmtree.call_count, 1)
-            self.assertEqual(
-                mock_rmtree.mock_calls[0],
-                call(join(target_directory, '2017-05-12T10:00:00')))
-        finally:
-            rmtree(target_directory)
 
-    @patch('candidates.management.commands.candidates_cache_api_to_directory.rmtree')
-    @patch('candidates.management.commands.candidates_cache_api_to_directory.datetime')
-    def test_cache_api_to_directory_prune_four_old(self, mock_datetime, mock_rmtree):
-        # Need to make sure datetime.strptime still works:
-        mock_datetime.strptime.side_effect = datetime.strptime
-        mock_datetime.now.return_value = datetime(2017, 5, 14, 12, 33, 5, 0)
-        target_directory = mkdtemp()
-        try:
-            for d in (
-                    '2017-05-12T06:00:00',
-                    '2017-05-12T08:00:00',
-                    '2017-05-12T10:00:00',
-                    '2017-05-12T12:00:00',
-            ):
-                os.makedirs(join(target_directory, d))
-            prune(target_directory)
-            # Even though all of those directories are more than 36
-            # hours old, they should all be kept because they're the
-            # most recent 4:
-            self.assertEqual(mock_rmtree.call_count, 0)
-        finally:
-            rmtree(target_directory)
+        expected_to_prune = ["2017-05-12T06:00:00"]
+        expected_to_keep = [
+            "2017-05-12T08:00:00",
+            "2017-05-12T10:00:00",
+            "2017-05-12T12:00:00",
+            "2017-05-14T12:33:05",
+        ]
 
-    @patch('candidates.management.commands.candidates_cache_api_to_directory.rmtree')
-    @patch('candidates.management.commands.candidates_cache_api_to_directory.datetime')
-    def test_cache_api_to_directory_prune_lots_very_recent(self, mock_datetime, mock_rmtree):
-        # Need to make sure datetime.strptime still works:
-        mock_datetime.strptime.side_effect = datetime.strptime
-        mock_datetime.now.return_value = datetime(2017, 5, 14, 12, 33, 5, 0)
-        target_directory = mkdtemp()
-        try:
-            for d in (
-                    '2017-05-13T22:00:00',
-                    '2017-05-14T00:00:00',
-                    '2017-05-14T02:00:00',
-                    '2017-05-14T04:00:00',
-                    '2017-05-14T06:00:00',
-                    '2017-05-14T08:00:00',
-                    '2017-05-14T10:00:00',
-                    '2017-05-14T12:00:00',
-            ):
-                os.makedirs(join(target_directory, d))
-            prune(target_directory)
-            # All of those are too recent to be removed, so there
-            # should be no calls to rmtree:
-            self.assertEqual(mock_rmtree.call_count, 2)
-        finally:
-            rmtree(target_directory)
+        self._setup_cached_api_directory(expected_to_keep + expected_to_prune)
 
-    @patch('candidates.management.commands.candidates_cache_api_to_directory.rmtree')
-    @patch('candidates.management.commands.candidates_cache_api_to_directory.datetime')
-    def test_cache_api_prune_when_latest_is_in_last_four(self, mock_datetime, mock_rmtree):
-        # Need to make sure datetime.strptime still works:
-        mock_datetime.strptime.side_effect = datetime.strptime
-        mock_datetime.now.return_value = datetime(2017, 5, 14, 12, 33, 5, 0)
-        target_directory = mkdtemp()
-        try:
-            for d in (
-                    '2017-05-13T22:00:00',
-                    '2017-05-14T00:00:00',
-                    '2017-05-14T02:00:00',
-                    '2017-05-14T04:00:00',
-                    '2017-05-14T06:00:00',
-                    '2017-05-14T08:00:00',
-                    '2017-05-14T10:00:00',
-                    '2017-05-14T12:00:00',
-            ):
-                os.makedirs(join(target_directory, d))
-            os.symlink('2017-05-14T12:00:00', join(target_directory, 'latest'))
-            prune(target_directory)
-            # All of those are too recent to be removed, so there
-            # should be no calls to rmtree:
-            self.assertEqual(mock_rmtree.call_count, 2)
-        finally:
-            rmtree(target_directory)
+        self.assertTrue(
+            self.storage.exists(
+                join("cached-api", "2017-05-12T06:00:00", ".keep")
+            )
+        )
+
+        self.assertTrue(
+            self.storage.exists(
+                join("cached-api", "2017-05-12T08:00:00", ".keep")
+            )
+        )
+
+        call_command(
+            "candidates_cache_api_to_directory",
+            page_size="3",
+            url_prefix="https://example.com/media/api-cache-for-wcivf/",
+            prune=True,
+        )
+        # Even though all of those directories are more than 36
+        # hours old, they should all be kept because they're the
+        # most recent 4:
+        for dir_name in expected_to_keep:
+            self.assertTrue(
+                self.storage.exists(join("cached-api", dir_name, ".keep"))
+            )
+
+        for dir_name in expected_to_prune:
+            self.assertFalse(
+                self.storage.exists(join("cached-api", dir_name, ".keep"))
+            )
+

--- a/ynr/apps/candidates/tests/test_api.py
+++ b/ynr/apps/candidates/tests/test_api.py
@@ -297,11 +297,11 @@ class TestAPI(TmpMediaRootMixin, UK2015ExamplesMixin, WebTest):
         expected_timestamped_directory = join(
             settings.MEDIA_ROOT, "cached-api", expected_leafname
         )
-        expected_symlink = join(settings.MEDIA_ROOT, "cached-api", "latest")
-        self.assertTrue(exists(expected_timestamped_directory))
-        self.assertTrue(exists(expected_symlink))
+        expected_path = join("cached-api", "latest")
+        self.assertTrue(self.storage.exists(expected_timestamped_directory))
+        self.assertTrue(self.storage.exists(expected_path))
         # Check that the files in that directory are as expected:
-        entries = os.listdir(expected_timestamped_directory)
+        entries = self.storage.listdir(expected_timestamped_directory)[1]
         persons_1_leafname = "persons-000001.json"
         persons_2_leafname = "persons-000002.json"
         posts_1_leafname = "posts-000001.json"
@@ -316,17 +316,17 @@ class TestAPI(TmpMediaRootMixin, UK2015ExamplesMixin, WebTest):
             },
         )
         # Get the data from those pages:
-        with open(
+        with self.storage.open(
             join(expected_timestamped_directory, persons_1_leafname)
         ) as f:
             persons_1_data = json.load(f)
-        with open(
+        with self.storage.open(
             join(expected_timestamped_directory, persons_2_leafname)
         ) as f:
             persons_2_data = json.load(f)
-        with open(join(expected_timestamped_directory, posts_1_leafname)) as f:
+        with self.storage.open(join(expected_timestamped_directory, posts_1_leafname)) as f:
             posts_1_data = json.load(f)
-        with open(join(expected_timestamped_directory, posts_2_leafname)) as f:
+        with self.storage.open(join(expected_timestamped_directory, posts_2_leafname)) as f:
             posts_2_data = json.load(f)
         # Check the previous and next links are as we expect:
         self.assertEqual(

--- a/ynr/apps/candidates/tests/test_api.py
+++ b/ynr/apps/candidates/tests/test_api.py
@@ -319,15 +319,15 @@ class TestAPI(TmpMediaRootMixin, UK2015ExamplesMixin, WebTest):
         with self.storage.open(
             join(expected_timestamped_directory, persons_1_leafname)
         ) as f:
-            persons_1_data = json.load(f)
+            persons_1_data = json.loads(f.read().decode('utf8'))
         with self.storage.open(
             join(expected_timestamped_directory, persons_2_leafname)
         ) as f:
-            persons_2_data = json.load(f)
+            persons_2_data = json.loads(f.read().decode('utf8'))
         with self.storage.open(join(expected_timestamped_directory, posts_1_leafname)) as f:
-            posts_1_data = json.load(f)
+            posts_1_data = json.loads(f.read().decode('utf8'))
         with self.storage.open(join(expected_timestamped_directory, posts_2_leafname)) as f:
-            posts_2_data = json.load(f)
+            posts_2_data = json.loads(f.read().decode('utf8'))
         # Check the previous and next links are as we expect:
         self.assertEqual(
             persons_1_data["next"],

--- a/ynr/s3_storage.py
+++ b/ynr/s3_storage.py
@@ -20,3 +20,14 @@ class MediaStorage(S3Boto3Storage):
     """
 
     location = settings.MEDIAFILES_LOCATION
+
+    @property
+    def base_url(self):
+        """
+        This is a small hack around the fact that Django Storages dosn't
+        provide the same methods as FileSystemStorage.
+
+        `base_url` is missing from their implementation of the storage class,
+        so we emulate it here by calling URL with an empty key name.
+        """
+        return self.url('')


### PR DESCRIPTION
Previously this command expected to be run on a local file system with a
file system that supported things like symlinks.

This meant that the storage back end couldn't be changed to, for example,
S3.

This set of changes moves to using DefaultStorage.

Note that this means we can't use things like shutil.rmtree. We have to
loop over files and delete them.