### PR TITLE
Remove the check for paired models

### DIFF
--- a/ynr/apps/candidates/models/popolo_extra.py
+++ b/ynr/apps/candidates/models/popolo_extra.py
@@ -197,7 +197,6 @@ def paired_object_safe_to_delete(base_object):
         return True
     if len(collected[1]) != 1:
         return False
-    assert collected[1][0] == base_object.extra
     return True
 
 


### PR DESCRIPTION
This check is still useful for a short time until we remove them all,
however it's preventing edits being reverted, so it's better for it to
go now.