### PR TITLE
Fix for the elections API when an election has no Organization

### DIFF
--- a/ynr/apps/candidates/serializers.py
+++ b/ynr/apps/candidates/serializers.py
@@ -207,7 +207,8 @@ class ElectionSerializer(MinimalElectionSerializer):
         )
 
 
-    organization = MinimalOrganizationExtraSerializer(source='organization.extra')
+    organization = MinimalOrganizationExtraSerializer(
+        read_only=True, source='organization.extra')
 
 
 class MinimalPostExtraSerializer(serializers.HyperlinkedModelSerializer):

--- a/ynr/apps/candidates/tests/test_api.py
+++ b/ynr/apps/candidates/tests/test_api.py
@@ -184,6 +184,14 @@ class TestAPI(TmpMediaRootMixin, UK2015ExamplesMixin, WebTest):
         self.assertEqual(elections["count"], len(elections["results"]))
         self.assertEqual(elections["count"], 3)
 
+    def test_api_elections_without_orgs(self):
+        # Regression test that we can serve elections without an organzation
+        self.election.organization = None
+        self.election.save()
+        elections_resp = self.app.get(
+            "/api/v0.9/elections/", expect_errors=True)
+        self.assertEqual(elections_resp.status_code, 200)
+
     def test_api_election(self):
         elections_resp = self.app.get("/api/v0.9/elections/")
         elections = elections_resp.json


### PR DESCRIPTION
I expect the fact an election doesn't have an organization is another
bug in itself, but there is no database level constraint, so the code
should work.