### PR TITLE
downgrade django-notifications-hq

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -21,7 +21,7 @@ django-filter==1.1.0
 django-haystack==2.6.0
 django-markdown-deux==1.0.5
 django-model-utils==3.1.2
-django-notifications-hq==1.5.0
+django-notifications-hq==1.1
 django-pipeline==1.6.14
 django-storages==1.6.6
 django-webtest==1.7.8


### PR DESCRIPTION
This is the highest version that doesn't throw

`Conflicting migrations detected; multiple leaf nodes in the migration graph`