### PR TITLE
Fix Person images not showing on post pages

### DIFF
--- a/ynr/apps/candidates/templates/candidates/_person_in_list.html
+++ b/ynr/apps/candidates/templates/candidates/_person_in_list.html
@@ -4,9 +4,9 @@
 {% if position_in_list %}
   <span class="person-position">{{ position_in_list }}</span>
 {% endif %}
-{% if c.extra.primary_image %}
+{% if c.primary_image %}
   <a href="{% url 'person-view' c.id c.name|slugify %}">
-    {% thumbnail c.extra.primary_image "x64" as im %}
+    {% thumbnail c.primary_image "x64" as im %}
       <img class="person-avatar" src="{{ im.url }}"/>
     {% endthumbnail %}
   </a>


### PR DESCRIPTION
This was a call to `.extra` that was missed when merging Person and
PersonExtra models.

Include a regression test to make sure the image is actually shown on
the page.

Fixes #626