### PR TITLE
Fix dependency conflicts

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,7 +19,7 @@ django-debug-toolbar-template-timings
 django-debug-toolbar==1.9.1
 django-extensions==2.1.2
 django-filter==1.1.0
-django-haystack==2.8.1
+django-haystack==2.7.0
 django-markdown-deux==1.0.5
 django-model-utils==3.1.2
 django-notifications-hq==1.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ cffi>=1.7
 coverage>=3.6
 cryptography==2.3.1
 decorator==4.3.0
-django-allauth==0.36.0
+django-allauth==0.34.0
 django-appconf==1.0.2
 django-braces==1.13.0
 django-cors-headers==2.4.0

--- a/tox.ini
+++ b/tox.ini
@@ -13,6 +13,7 @@ setenv =
     RUN_ENV=test
 
 commands =
+  - pip check
   - python manage.py check
   - python manage.py makemigrations --dry-run
     # pytest --flake


### PR DESCRIPTION
Our dependency tree currently contains 2 problems:

1. django-allauth: version 0.35.0 drops support for django 1.10 see:
    * https://github.com/pennersr/django-allauth/blob/master/ChangeLog.rst#0350-2018-02-02
    * https://github.com/pennersr/django-allauth/blob/cc8e4e6424157e215bb26294de3d8d154c5f5256/setup.py#L130

side note: Have you installed 0.36 on prod yet? Trying to run this version on django 1.10 was throwing `is_safe_url() got an unexpected keyword argument 'allowed_hosts'` in dev for me.

2. django-haystack: version 2.8.0 drops support for django 1.10 see:
    * https://github.com/django-haystack/django-haystack/blob/master/docs/changelog.rst#v280-2018-03-09
    * https://github.com/django-haystack/django-haystack/blob/6c4a854ce12ba031a3172e567aa19e761fcfd9af/setup.py#L15

Proposed solution:

* Downgrade the relevant packages to compatible versions
* Run `pip check` at the start of the CI build. This should cause the build to error when a PR like https://github.com/DemocracyClub/yournextrepresentative/pull/628 is opened which will introduce conflicting requirements.
* Rebase all our dependabot PRs after merging this
