### PR TITLE
Add legacy slug to embedded Party on memberships

### DIFF
--- a/ynr/apps/parties/serializers.py
+++ b/ynr/apps/parties/serializers.py
@@ -47,4 +47,4 @@ class PartySerializer(serializers.HyperlinkedModelSerializer):
 class MinimalPartySerializer(PartySerializer):
     class Meta:
         model = Party
-        fields = ("ec_id", "name")
+        fields = ("ec_id", "name", "legacy_slug")


### PR DESCRIPTION
In contrast to recent PRs…

This is needed because WCIVF is using the `legacy_slug` for party IDs, and it uses this slug when adding memberships.

I expect we'll move away from using this in WCIVF one day, but for now it's easier to have it in the output here.