### PR TITLE
Use next API for cached API files

### DIFF
--- a/ynr/apps/api/tests/test_api_v09.py
+++ b/ynr/apps/api/tests/test_api_v09.py
@@ -404,7 +404,7 @@ class TestAPI(TestUserMixin, TmpMediaRootMixin, UK2015ExamplesMixin, WebTest):
         self.assertEqual(first_person["name"], "Sheila Gilmore")
         self.assertEqual(
             first_person["url"],
-            "https://candidates.democracyclub.org.uk/api/v0.9/persons/818/?format=json",
+            "https://candidates.democracyclub.org.uk/api/next/persons/818/?format=json",
         )
         # Similarly, check that the URL of the first post is as expected:
         first_post = posts_1_data["results"][0]
@@ -414,7 +414,7 @@ class TestAPI(TestUserMixin, TmpMediaRootMixin, UK2015ExamplesMixin, WebTest):
         )
         self.assertEqual(
             first_post["url"],
-            "https://candidates.democracyclub.org.uk/api/v0.9/posts/14419/?format=json",
+            "https://candidates.democracyclub.org.uk/api/next/posts/14419/?format=json",
         )
 
     def _setup_cached_api_directory(self, dir_list):

--- a/ynr/apps/candidates/management/commands/candidates_cache_api_to_directory.py
+++ b/ynr/apps/candidates/management/commands/candidates_cache_api_to_directory.py
@@ -133,7 +133,7 @@ class Command(BaseCommand):
         data["previous"] = self.rewrite_link(endpoint, data["previous"])
 
     def get_api_results_to_directory(self, endpoint, json_directory, page_size):
-        url = "/api/v0.9/{endpoint}/?page_size={page_size}&format=json".format(
+        url = "/api/next/{endpoint}/?page_size={page_size}&format=json".format(
             page_size=page_size, endpoint=endpoint
         )
 


### PR DESCRIPTION
WCIVF is the only user of this, so it doesn't have any implications for
other users. WCIVF is already ready to accept these changes (in a PR)