### PR TITLE
Use image.file not image.path

### DIFF
--- a/ynr/apps/popolo/models.py
+++ b/ynr/apps/popolo/models.py
@@ -610,7 +610,7 @@ class Person(Dateframeable, Timestampable, models.Model):
         """
 
         if self.primary_image:
-            return get_thumbnail(self.primary_image.path, "x64").url
+            return get_thumbnail(self.primary_image.file, "x64").url
 
         return static("candidates/img/blank-person.png")
 


### PR DESCRIPTION
This is a fix for a problem when using a non-local file storage like S3
where paths don't work for reading in the same way as local storage.

We should use the file object directly, rather than getting
sorl.thumbnail to work out how to open a file from a path