### PR TITLE
Fix candidates_for_postcode in next API

### DIFF
--- a/ynr/apps/api/next/views.py
+++ b/ynr/apps/api/next/views.py
@@ -141,7 +141,7 @@ class CandidatesAndElectionsForPostcodeViewSet(ViewSet):
                     ),
                     Prefetch(
                         "person__images",
-                        Image.objects.select_related("extra__uploading_user"),
+                        PersonImage.objects.select_related("uploading_user"),
                     ),
                     "person__other_names",
                     "person__contact_details",


### PR DESCRIPTION
This was an untested view that caused a 500 in production due to a missing call to `Image`.