### PR TITLE
fix SOCIALACCOUNT_ADAPTER name

### DIFF
--- a/ynr/settings/base.py
+++ b/ynr/settings/base.py
@@ -168,7 +168,7 @@ SOCIALACCOUNT_PROVIDERS = {
 
 LOGIN_REDIRECT_URL = "/"
 ACCOUNT_AUTHENTICATION_METHOD = "username_email"
-SOCIALACCOUNT_ADAPTER = "ynr.account_adapter.SentryLoggingSocialAccountAdapter"
+SOCIALACCOUNT_ADAPTER = "ynr.account_adapter.LoggingSocialAccountAdapter"
 ACCOUNT_EMAIL_VERIFICATION = "mandatory"
 ACCOUNT_EMAIL_REQUIRED = True
 ACCOUNT_FORMS = {


### PR DESCRIPTION
This should fix
`AttributeError: module 'ynr.account_adapter' has no attribute 'SentryLoggingSocialAccountAdapter'`
on social login

https://github.com/DemocracyClub/yournextrepresentative/blob/862545a5f8f94fe815b54b4d66e3db87c4ce8a35/ynr/account_adapter.py#L22