### PR TITLE
Allow deleting PersonIdentifiers by removing the value

### DIFF
--- a/ynr/apps/people/forms.py
+++ b/ynr/apps/people/forms.py
@@ -81,17 +81,24 @@ class PersonIdentifierForm(forms.ModelForm):
 
         This method is undocumented in Django, but it seems to be the only way.
         """
+        if self.instance:
+            return True
         if self.changed_data == ["value_type"] and not self["value"].data:
             return False
         else:
             return super().has_changed(*args, **kwargs)
+
+    def clean(self):
+        if not self.cleaned_data.get("value"):
+            self.cleaned_data["DELETE"] = True
+        return self.cleaned_data
 
 
 PersonIdentifierFormsetFactory = forms.inlineformset_factory(
     Person,
     PersonIdentifier,
     form=PersonIdentifierForm,
-    can_delete=False,
+    can_delete=True,
     widgets={
         "value_type": forms.Select(
             choices=PersonIdentifier.objects.select_choices()

--- a/ynr/apps/people/tests/test_person_form_identifier_crud.py
+++ b/ynr/apps/people/tests/test_person_form_identifier_crud.py
@@ -64,6 +64,22 @@ class PersonFormsIdentifierCRUDTestCase(TestUserMixin, WebTest):
 
         self.assertEqual(PersonIdentifier.objects.get().value, "@democracyclub")
 
+    def test_form_can_delete_pi(self):
+        """
+        Test that the PersonIdentifier can be deleted by removing the value
+        """
+        resp = self.app.get(
+            reverse("person-update", kwargs={"person_id": self.person.pk}),
+            user=self.user,
+        )
+
+        form = resp.forms[1]
+        form["source"] = "They deleted their account"
+        form["tmp_person_identifiers-0-value"] = ""
+        form.submit()
+
+        self.assertFalse(PersonIdentifier.objects.exists())
+
     def test_form_valid_when_extra_value_type_selected(self):
         """
         If someone selects a value type but doesn't enter a value, it's still valid


### PR DESCRIPTION
This will remove the whole PersonIdentifier model for this form,
including the internal_identifier. As there is no way for the user to
add an internal ID then this is the right thing to do.

If the user can't delete the PI model then things like TwitterBot might
re-create the user-deleted values at a later date.