### PR TITLE
Fix live site importer

### DIFF
--- a/ynr/apps/candidates/management/commands/candidates_import_from_live_site.py
+++ b/ynr/apps/candidates/management/commands/candidates_import_from_live_site.py
@@ -338,9 +338,14 @@ class Command(BaseCommand):
                     k: m_data[k]
                     for k in ("label", "role", "start_date", "end_date")
                 }
-                kwargs["person"] = people.models.Person.objects.get(
-                    pk=m_data["person"]["id"]
-                )
+                try:
+                    kwargs["person"] = people.models.Person.objects.get(
+                        pk=m_data["person"]["id"]
+                    )
+                except people.models.Person.DoesNotExist:
+                    # Chances are this person was created since the last
+                    # cached person run was updated. It's ok to ignore this
+                    continue
                 if m_data.get("party"):
                     kwargs["party"] = Party.objects.get(
                         ec_id=m_data["party"]["ec_id"]

--- a/ynr/apps/candidates/management/commands/candidates_import_from_live_site.py
+++ b/ynr/apps/candidates/management/commands/candidates_import_from_live_site.py
@@ -294,9 +294,7 @@ class Command(BaseCommand):
                         post=post,
                         election=election,
                         candidates_locked=election_data["candidates_locked"],
-                        ballot_paper_id="tmp_{}.{}".format(
-                            election.slug, post.slug
-                        ),
+                        ballot_paper_id=election_data["ballot_paper_id"],
                     )
         person_to_image_data = {}
         for person_data in self.get_api_results("persons"):

--- a/ynr/apps/candidates/management/commands/candidates_import_from_live_site.py
+++ b/ynr/apps/candidates/management/commands/candidates_import_from_live_site.py
@@ -92,7 +92,7 @@ class Command(BaseCommand):
             models.PartySet,
             models.LoggedAction,
             models.PersonRedirect,
-            emodels.Election,  # , models.ExtraField,
+            emodels.Election,
         ):
             if model_class.objects.exists():
                 non_empty_models.append(model_class)
@@ -161,10 +161,6 @@ class Command(BaseCommand):
         return filename
 
     def mirror_from_api(self, ignore_images):
-        for extra_field in self.get_api_results("extra_fields"):
-            with show_data_on_error("extra_field", extra_field):
-                del extra_field["url"]
-                models.ExtraField.objects.update_or_create(**extra_field)
         party_sets_by_slug = {}
         for party_set_data in self.get_api_results("party_sets"):
             with show_data_on_error("party_set_data", party_set_data):
@@ -302,7 +298,6 @@ class Command(BaseCommand):
                             election.slug, post.slug
                         ),
                     )
-        extra_fields = {ef.key: ef for ef in models.ExtraField.objects.all()}
         person_to_image_data = {}
         for person_data in self.get_api_results("persons"):
             with show_data_on_error("person_data", person_data):
@@ -336,13 +331,6 @@ class Command(BaseCommand):
                     person, pmodels.OtherName, person_data["other_names"]
                 )
                 self.add_related(person, pmodels.Link, person_data["links"])
-
-                # Look for any data in ExtraFields
-                for extra_field_data in person_data["extra_fields"]:
-                    person.extra_field_values.create(
-                        field=extra_fields[extra_field_data["key"]],
-                        value=extra_field_data["value"],
-                    )
 
         for m_data in self.get_api_results("memberships", "next"):
             with show_data_on_error("m_data", m_data):
@@ -418,7 +406,6 @@ class Command(BaseCommand):
                 models.PartySet,
                 emodels.Election,
                 PersonImage,
-                models.ExtraField,
                 people.models.Person,
             ],
         )


### PR DESCRIPTION
This removes `ExtraField` but also makes the importer slightly more robust, trying to make sure that a long running import doesn't fail towards the end if people have been added since the last cached API run.