### PR TITLE
Redirect Election API URLs

### DIFF
--- a/ynr/apps/api/tests/test_api_v09.py
+++ b/ynr/apps/api/tests/test_api_v09.py
@@ -520,3 +520,13 @@ class TestAPI(TestUserMixin, TmpMediaRootMixin, UK2015ExamplesMixin, WebTest):
             self.assertFalse(
                 self.storage.exists(join("cached-api", dir_name, ".keep"))
             )
+
+    def test_legacy_redirects(self):
+        req = self.app.get("/api/v0.9/elections/2010/")
+        self.assertEqual(req.status_code, 301)
+        self.assertEqual(req.location, "/api/v0.9/elections/parl.2010-05-06/")
+        req = self.app.get("/api/v0.9/elections/2010.json")
+        self.assertEqual(req.status_code, 301)
+        self.assertEqual(
+            req.location, "/api/v0.9/elections/parl.2010-05-06.json"
+        )

--- a/ynr/apps/api/v09/views.py
+++ b/ynr/apps/api/v09/views.py
@@ -320,7 +320,7 @@ class ElectionViewSet(viewsets.ModelViewSet):
                     kwargs={"version": "v0.9", "slug": new_slug},
                 )
                 if self.kwargs.get("format"):
-                    url = "{}.{}".format(url.strip("/"), self.kwargs["format"])
+                    url = "{}.{}".format(url.rstrip("/"), self.kwargs["format"])
                 return HttpResponsePermanentRedirect(url)
         return super().dispatch(request, *args, **kwargs)
 


### PR DESCRIPTION
This is a nice easy one :)

Note that I'm only applying this to `v0.9` as `next` a) isn't really public yet and b) isn't meant to be stable yet.

This follows on from the migration to move legacy slugs to new EE ones.