### PR TITLE
Typo correction: replaces 'know yet' with 'known yet'

### DIFF
--- a/ynr/apps/bulk_adding/templates/bulk_add/parties/add_form.html
+++ b/ynr/apps/bulk_adding/templates/bulk_add/parties/add_form.html
@@ -20,7 +20,7 @@
       {% endfor %}
       </ul>
       {% else %}
-      <p>No {{ party.name }} candidates know yet.</p>
+      <p>No {{ party.name }} candidates known yet.</p>
       {% endif %}
       {{ post_info.formset }}
     </div>

--- a/ynr/apps/bulk_adding/tests/test_bulk_add_by_party.py
+++ b/ynr/apps/bulk_adding/tests/test_bulk_add_by_party.py
@@ -49,7 +49,7 @@ class TestBulkAddingByParty(TestUserMixin, UK2015ExamplesMixin, WebTest):
         self.assertContains(response, "1 seat contested.")
 
         self.assertContains(
-            response, "No Conservative Party candidates know yet."
+            response, "No Conservative Party candidates known yet."
         )
 
     def test_submit_name_for_area_without_source(self):


### PR DESCRIPTION
Not sure if I've identified the right tree/branch/thingy to change. 

The same typo appears here: https://github.com/DemocracyClub/yournextrepresentative/blob/af178e790c8b7248ecd5e75b984cb646eb516500/ynr/apps/bulk_adding/tests/test_bulk_add_by_party.py