### PR TITLE
Output a CSV per election date

### DIFF
--- a/ynr/apps/candidates/tests/test_csv_export.py
+++ b/ynr/apps/candidates/tests/test_csv_export.py
@@ -177,6 +177,8 @@ class CSVTests(TmpMediaRootMixin, TestUserMixin, UK2015ExamplesMixin, TestCase):
                     "candidates-all.csv",
                     "candidates-elected-all.csv",
                     "candidates-local.maidstone.2016-05-05.csv",
+                    "candidates-2015-05-07.csv",
+                    "candidates-2010-05-06.csv",
                 ]
             ),
         )
@@ -196,6 +198,7 @@ class CSVTests(TmpMediaRootMixin, TestUserMixin, UK2015ExamplesMixin, TestCase):
                     "candidates-parl.2010-05-06.csv",
                     "candidates-parl.2015-05-07.csv",
                     "candidates-local.maidstone.2016-05-05.csv",
+                    "candidates-2015-05-07.csv",
                 ]
             ),
         )
@@ -233,10 +236,11 @@ class CSVTests(TmpMediaRootMixin, TestUserMixin, UK2015ExamplesMixin, TestCase):
                     "candidates-all.csv",
                     "candidates-elected-all.csv",
                     "candidates-local.maidstone.2016-05-05.csv",
+                    "candidates-2015-05-07.csv",
+                    "candidates-2010-05-06.csv",
                 ]
             ),
         )
-
         empty_file = self.storage.open("candidates-2018.csv").read()
         self.assertEqual(len(empty_file.splitlines()), 1)
         self.assertEqual(


### PR DESCRIPTION
This outputs a CSV file with all memberships standing per election date.

Closes #759 

I've not linked to these anywhere, as that involves thinking about the page with 5,000 links to 5,000 CSV files (and, well, adding more links to CSV files).

At the moment I'll leave it unlinked and hope that soon we can sort that page out and link to them.