### PR TITLE
Log in after confirming email address

### DIFF
--- a/ynr/settings/base.py
+++ b/ynr/settings/base.py
@@ -178,7 +178,7 @@ ACCOUNT_FORMS = {
     "login": "ynr.forms.CustomLoginForm",
     "signup": "ynr.forms.CustomSignupForm",
 }
-
+ACCOUNT_LOGIN_ON_EMAIL_CONFIRMATION = True
 ACCOUNT_USERNAME_REQUIRED = True
 ACCOUNT_USERNAME_VALIDATORS = "ynr.helpers.allauth_validators"
 SOCIALACCOUNT_AUTO_SIGNUP = True


### PR DESCRIPTION
Fixes #793

From [the docs](https://django-allauth.readthedocs.io/en/latest/configuration.html):

> ACCOUNT_LOGIN_ON_EMAIL_CONFIRMATION (=False)
> 
> The default behaviour is not log users in and to redirect them to ACCOUNT_EMAIL_CONFIRMATION_ANONYMOUS_REDIRECT_URL.
>
> By changing this setting to True, users will automatically be logged in once they confirm their email address. Note however that this only works when confirming the email address immediately after signing up, assuming users didn’t close their browser or used some sort of private browsing mode.
