### PR TITLE
Merge bugs

### DIFF
--- a/ynr/apps/candidates/models/versions.py
+++ b/ynr/apps/candidates/models/versions.py
@@ -103,6 +103,8 @@ def get_person_as_version_data(person, new_person=False):
             }
         for not_standing_in_election in person.not_standing.all():
             standing_in[not_standing_in_election.slug] = None
+            # Delete party memberships if not standing in this election
+            party_memberships.pop(not_standing_in_election.slug, None)
 
     # Add `favourite_biscuits` to an `extra_fields` key
     # to re-produce the previous ExtraField model.

--- a/ynr/apps/people/merging.py
+++ b/ynr/apps/people/merging.py
@@ -241,7 +241,12 @@ class PersonMerger:
 
     def merge_not_standing(self):
         for election in self.source_person.not_standing.all():
-            self.dest_person.not_standing.add(election)
+            if not self.dest_person.memberships.filter(
+                post_election__election=election
+            ):
+                # If this election is in the dest person's memberships, we
+                # shouldn't add to their "not standing" list.
+                self.dest_person.not_standing.add(election)
             self.source_person.not_standing.remove(election)
 
     def setup_redirect(self):

--- a/ynr/apps/people/models.py
+++ b/ynr/apps/people/models.py
@@ -297,8 +297,19 @@ class Person(Timestampable, models.Model):
         new_version["data"] = get_person_as_version_data(
             self, new_person=new_person
         )
-        if not versions or new_version["data"] != versions[0]["data"]:
+        should_insert = True
+
+        if versions and new_version["data"] == versions[0]["data"]:
+            # Don't create empty versions
+            should_insert = False
+
+        if new_version["information_source"].startswith("After merging person"):
+            # Always create a version if this is a merge
+            should_insert = True
+
+        if should_insert:
             versions.insert(0, new_version)
+
         self.versions = json.dumps(versions)
 
     def get_slug(self):


### PR DESCRIPTION
Fixes for a couple of merge bugs reported:

## #811 
See the test comment – this was a bug and changes the way we deal with conflicting assertions about membership of an election (keeps memberships by default)

## #860 

Wasn't the bug it looked like, but was a bug in the way we saved merge versions. 