### PR TITLE
Suggesting a post lock creates a LoggedAction

### DIFF
--- a/ynr/apps/elections/uk/templates/candidates/finder.html
+++ b/ynr/apps/elections/uk/templates/candidates/finder.html
@@ -141,6 +141,9 @@
             {% elif action.action_type == 'sopn-upload' %}
               uploaded <a href="{{ action.post_election.sopn.get_absolute_url }}">a SOPN</a> for
               <a href="{{ action.post_election.get_absolute_url }}">{{ action.post_election.ballot_paper_id }}</a>
+            {% elif action.action_type == 'suggest-ballot-lock' %}
+              Suggested locking ballot
+              <a href="{{ action.post_election.get_absolute_url }}">{{ action.post_election.ballot_paper_id }}</a>
             {% else %}
               {% if action.person %}
                 updated <a href="{% url 'person-view' person_id=action.person.id %}">candidate #{{ action.person.id }}</a>

--- a/ynr/apps/moderation_queue/views.py
+++ b/ynr/apps/moderation_queue/views.py
@@ -544,6 +544,15 @@ class SuggestLockView(LoginRequiredMixin, CreateView):
     def form_valid(self, form):
         user = self.request.user
         form.instance.user = user
+
+        LoggedAction.objects.create(
+            user=self.request.user,
+            action_type="suggest-ballot-lock",
+            post_election=form.cleaned_data["postextraelection"],
+            ip_address=get_client_ip(self.request),
+            source=form.cleaned_data["justification"],
+        )
+
         messages.add_message(
             self.request,
             messages.SUCCESS,


### PR DESCRIPTION
This is handy for knowing what's going on with a post, and will also give more points to people ;)

I'm generally thinking about audit trails, now we clean up post lock suggestion after the ballot is locked.