### PR TITLE
Don't show SOPN tracker if no SOPNs are ready to add

### DIFF
--- a/ynr/apps/elections/uk/templates/candidates/homepage_sopn_progress.html
+++ b/ynr/apps/elections/uk/templates/candidates/homepage_sopn_progress.html
@@ -1,5 +1,5 @@
 {% load humanize %}
-{% if SHOW_SOPN_TRACKER %}
+{% if SHOW_SOPN_TRACKER and sopn_progress%}
 
 {# <div class="radius progress success large-12" role="progressbar" #}
 {#     aria-valuenow="{{ sopn_progress.sopns_imported }}" #}


### PR DESCRIPTION
Simple bug fix for missing template vars, and generally unhelpful CTA if we have no SOPNs