### PR TITLE
Validate identifiers

### DIFF
--- a/ynr/apps/candidates/tests/test_validators.py
+++ b/ynr/apps/candidates/tests/test_validators.py
@@ -16,46 +16,6 @@ class TestValidators(UK2015ExamplesMixin, TestCase):
         self.person = PersonFactory.create(name="John Doe")
 
     @skip("PersonIdentifiers are on Person Form")
-    def test_twitter_bad_url(self):
-        form = BasePersonForm(
-            {"name": "John Doe", "twitter_username": "http://example.org/blah"}
-        )
-        self.assertFalse(form.is_valid())
-        self.assertEqual(
-            form.errors,
-            {
-                "twitter_username": [
-                    "The Twitter username must only consist of alphanumeric characters or underscore"
-                ]
-            },
-        )
-
-    @skip("PersonIdentifiers are on Person Form")
-    def test_twitter_fine(self):
-        form = BasePersonForm(
-            {"name": "John Doe", "twitter_username": "madeuptwitteraccount"}
-        )
-        self.assertTrue(form.is_valid())
-        self.assertEqual(form.errors, {})
-        self.assertEqual(
-            form.cleaned_data["twitter_username"], "madeuptwitteraccount"
-        )
-
-    @skip("PersonIdentifiers are on Person Form")
-    def test_twitter_full_url(self):
-        form = BasePersonForm(
-            {
-                "name": "John Doe",
-                "twitter_username": "https://twitter.com/madeuptwitteraccount",
-            }
-        )
-        self.assertTrue(form.is_valid())
-        self.assertEqual(form.errors, {})
-        self.assertEqual(
-            form.cleaned_data["twitter_username"], "madeuptwitteraccount"
-        )
-
-    @skip("PersonIdentifiers are on Person Form")
     def test_malformed_email(self):
         form = BasePersonForm(
             {"name": "John Bercow", "email": "foo bar!"},

--- a/ynr/apps/parties/constants.py
+++ b/ynr/apps/parties/constants.py
@@ -35,7 +35,7 @@ DEFAULT_EMBLEMS = {
     # Christian Party
     "PP2893": 1292,
     # Democratic Unionist Party D.U.P
-    "PP70": 78
+    "PP70": 78,
 }
 
 JOINT_DESCRIPTION_REGEX = "^(.*?) \(joint descriptions? with\s?(.*)\)"

--- a/ynr/apps/people/templates/people/forms/person_identifier_inline_formset.html
+++ b/ynr/apps/people/templates/people/forms/person_identifier_inline_formset.html
@@ -2,18 +2,19 @@
 {% for form in identifiers_formset %}
   {{ form.id }}
   <div class="large-12 columns">
-      <div class="row collapse">
-        <div class="small-9 columns">
-          {{ form.value }}
-          {{ form.value.errors }}
-        </div>
-        <div class="small-3 columns">
-          <span class="postfix">
-            {{ form.value_type }}
-          </span>
-          {{ form.value_type.errors }}
-        </div>
+    {% if form.non_field_errors %}
+      {{ form.non_field_errors }}
+    {% endif %}
+    <div class="row collapse">
+      <div class="small-9 columns">
+        {{ form.value }}
+      </div>
+      <div class="small-3 columns">
+        <span class="postfix">
+          {{ form.value_type }}
+        </span>
       </div>
     </div>
+  </div>
 
 {% endfor %}

--- a/ynr/apps/people/tests/test_merging.py
+++ b/ynr/apps/people/tests/test_merging.py
@@ -168,7 +168,11 @@ class TestMerging(TestUserMixin, UK2015ExamplesMixin, WebTest):
         merger.merge()
         self.assertEqual(self.dest_person.other_names.count(), 2)
         self.assertListEqual(
-            list(self.dest_person.other_names.values_list("name", flat=True)),
+            list(
+                self.dest_person.other_names.order_by("name").values_list(
+                    "name", flat=True
+                )
+            ),
             ["Ema Nymnot", "nom de plume"],
         )
 

--- a/ynr/apps/people/tests/test_person_form_identifier_crud.py
+++ b/ynr/apps/people/tests/test_person_form_identifier_crud.py
@@ -1,6 +1,7 @@
 from django_webtest import WebTest
 
 from django.core.urlresolvers import reverse
+from django.test import override_settings
 
 from candidates.tests.auth import TestUserMixin
 from people.models import PersonIdentifier
@@ -8,12 +9,13 @@ from people.tests.factories import PersonFactory
 from candidates.tests.factories import faker_factory
 
 
+@override_settings(TWITTER_APP_ONLY_BEARER_TOKEN=None)
 class PersonFormsIdentifierCRUDTestCase(TestUserMixin, WebTest):
     def setUp(self):
         # super().setUp()
         self.person = PersonFactory(name=faker_factory.name())
         self.pi = PersonIdentifier.objects.create(
-            person=self.person, value="@democlub", value_type="twitter_username"
+            person=self.person, value="democlub", value_type="twitter_username"
         )
 
     def test_person_identifier_on_form(self):
@@ -27,7 +29,7 @@ class PersonFormsIdentifierCRUDTestCase(TestUserMixin, WebTest):
 
         pi_form = resp.context["identifiers_formset"].initial_forms[0]
 
-        self.assertEqual(pi_form["value"].value(), "@democlub")
+        self.assertEqual(pi_form["value"].value(), "democlub")
         self.assertEqual(pi_form["value_type"].value(), "twitter_username")
 
     def test_form_can_add_new_pi(self):
@@ -45,7 +47,7 @@ class PersonFormsIdentifierCRUDTestCase(TestUserMixin, WebTest):
         self.assertEqual(PersonIdentifier.objects.all().count(), 2)
         self.assertEqual(
             list(PersonIdentifier.objects.values_list("value", flat=True)),
-            ["https://democracyclub.org.uk", "@democlub"],
+            ["https://democracyclub.org.uk", "democlub"],
         )
 
     def test_form_can_update_pi(self):
@@ -62,7 +64,9 @@ class PersonFormsIdentifierCRUDTestCase(TestUserMixin, WebTest):
         form["tmp_person_identifiers-0-value"] = "@democracyclub"
         form.submit()
 
-        self.assertEqual(PersonIdentifier.objects.get().value, "@democracyclub")
+        pi = PersonIdentifier.objects.get()
+        self.assertEqual(pi.value, "democracyclub")
+        self.assertEqual(pi.value_type, "twitter_username")
 
     def test_form_can_delete_pi(self):
         """
@@ -99,7 +103,7 @@ class PersonFormsIdentifierCRUDTestCase(TestUserMixin, WebTest):
             reverse("person-view", kwargs={"person_id": self.person.pk}),
         )
 
-        self.assertEqual(PersonIdentifier.objects.get().value, "@democlub")
+        self.assertEqual(PersonIdentifier.objects.get().value, "democlub")
 
     def test_change_value_type(self):
         """
@@ -125,4 +129,44 @@ class PersonFormsIdentifierCRUDTestCase(TestUserMixin, WebTest):
 
         self.assertEqual(
             PersonIdentifier.objects.get().value_type, "homepage_url"
+        )
+
+    def _submit_values(self, value, value_type="twitter_username"):
+        resp = self.app.get(
+            reverse("person-update", kwargs={"person_id": self.person.pk}),
+            user=self.user,
+        )
+
+        form = resp.forms[1]
+        form["source"] = "They changed their username"
+        form["tmp_person_identifiers-0-value_type"] = value_type
+        form["tmp_person_identifiers-0-value"] = value
+        form.submit()
+        return form.submit()
+
+    def test_twitter_bad_url(self):
+        resp = self._submit_values("http://example.com/blah")
+        form = resp.context["identifiers_formset"]
+        self.assertFalse(form.is_valid())
+        self.assertEqual(
+            form[0].non_field_errors(),
+            [
+                "The Twitter username must only consist of alphanumeric characters or underscore"
+            ],
+        )
+
+    def test_twitter_full_url(self):
+        resp = self._submit_values("https://twitter.com/madeuptwitteraccount")
+        self.assertEqual(resp.status_code, 302)
+
+        self.assertEqual(
+            PersonIdentifier.objects.get().value, "madeuptwitteraccount"
+        )
+
+    def test_bad_email_address(self):
+        resp = self._submit_values("whoops", "email")
+        form = resp.context["identifiers_formset"]
+        self.assertFalse(form.is_valid())
+        self.assertEqual(
+            form[0].non_field_errors(), ["Enter a valid email address."]
         )


### PR DESCRIPTION
This was something I never got to when changing the identifiers fields, but there is a chunk of bad data in the fields now because of this.

To save having to manually clean this up, I'd like to get this deployed, even though it only validates two fields – I think they are the most important ones, in that we use Twitter to get photos and we use email for other things / it's a commonly requested field.

The twitter username code comes from the old method of validating the field, so should at least be consistent.

I'll run that function over all data in the database once this is deployed and manually clean up any remaining data that it can't fix.