### PR TITLE
Fix Wikidata ID output in CSVs

### DIFF
--- a/ynr/apps/candidates/tests/test_csv_export.py
+++ b/ynr/apps/candidates/tests/test_csv_export.py
@@ -140,7 +140,7 @@ class CSVTests(TmpMediaRootMixin, TestUserMixin, UK2015ExamplesMixin, TestCase):
         PersonRedirect.objects.create(old_person_id=56, new_person_id=1953)
         self.maxDiff = None
         example_output = (
-            "id,name,honorific_prefix,honorific_suffix,gender,birth_date,election,party_id,party_name,post_id,post_label,mapit_url,elected,email,twitter_username,facebook_page_url,party_ppc_page_url,facebook_personal_url,homepage_url,wikipedia_url,linkedin_url,image_url,proxy_image_url_template,image_copyright,image_uploading_user,image_uploading_user_notes,twitter_user_id,election_date,election_current,party_lists_in_use,party_list_position,old_person_ids,gss_code,parlparse_id,theyworkforyou_url,party_ec_id,favourite_biscuits,cancelled_poll,wikidata_url\r\n"
+            "id,name,honorific_prefix,honorific_suffix,gender,birth_date,election,party_id,party_name,post_id,post_label,mapit_url,elected,email,twitter_username,facebook_page_url,party_ppc_page_url,facebook_personal_url,homepage_url,wikipedia_url,linkedin_url,image_url,proxy_image_url_template,image_copyright,image_uploading_user,image_uploading_user_notes,twitter_user_id,election_date,election_current,party_lists_in_use,party_list_position,old_person_ids,gss_code,parlparse_id,theyworkforyou_url,party_ec_id,favourite_biscuits,cancelled_poll,wikidata_id\r\n"
             + "1953,Daith\xed McKay,,,male,,parl.2010-05-06,party:39,Sinn F\xe9in,66135,North Antrim,,,,,,,,,,,,,,,,,{earlier_election_date},False,False,,12;56,,,,PP39,,False,\r\n".format(
                 **d
             )

--- a/ynr/apps/elections/tests/test_ballot_view.py
+++ b/ynr/apps/elections/tests/test_ballot_view.py
@@ -161,7 +161,7 @@ class TestConstituencyDetailView(TestUserMixin, UK2015ExamplesMixin, WebTest):
                 "twitter_username": "",
                 "twitter_user_id": "",
                 "wikipedia_url": "",
-                "wikidata_url": "",
+                "wikidata_id": "",
             },
         )
 

--- a/ynr/apps/people/models.py
+++ b/ynr/apps/people/models.py
@@ -92,7 +92,7 @@ class PersonIdentifier(TimeStampedModel):
         help_text="A label for the type of value e.g. 'Twitter', 'Person blog'",
     )
     extra_data = JSONField(
-        help_text="""For storing any additional data against this field. 
+        help_text="""For storing any additional data against this field.
                      Used by bots, not humans.""",
         null=True,
     )
@@ -643,7 +643,7 @@ class Person(Timestampable, models.Model):
             ),
             "homepage_url": self.get_single_identifier_value("homepage_url"),
             "wikipedia_url": self.get_single_identifier_value("wikipedia_url"),
-            "wikidata_url": self.get_single_identifier_value("wikidata_url"),
+            "wikidata_id": self.get_single_identifier_value("wikidata_id"),
             "theyworkforyou_url": theyworkforyou_url,
             "parlparse_id": parlparse_id,
             "image_url": primary_image_url,

--- a/ynr/settings/constants/csv_fields.py
+++ b/ynr/settings/constants/csv_fields.py
@@ -37,5 +37,5 @@ CSV_ROW_FIELDS = [
     "party_ec_id",
     "favourite_biscuits",
     "cancelled_poll",
-    "wikidata_url",
+    "wikidata_id",
 ]


### PR DESCRIPTION
This fixes the changes made in #935 to reflect that the field is `wikidata_id` not `wikidata_url`.

Closes #942.