### PR TITLE
Catch not standing conflicts when merging

### DIFF
--- a/ynr/apps/candidates/templates/candidates/generic-merge-error.html
+++ b/ynr/apps/candidates/templates/candidates/generic-merge-error.html
@@ -1,0 +1,20 @@
+{% extends "base.html" %}
+{% block content %}
+  {% if error_message %}
+  <h1><a href="{{ person.get_absolute_url }}">{{ person.name }}</a></h1>
+  <h2>Error Merging</h2>
+  <p>Sorry, something when wrong when merging. The error message was:</p>
+  <p><code>{{ error_message }}</code></p>
+  {% endif %}
+
+  <form class="person__actions__action person__actions__merge" id="person-merge" action="{% url 'person-merge' person_id=person.id %}" method="post">
+    {% csrf_token %}
+    <h2>Is this a duplicate person?</h2>
+    <p>
+      <label for="other">Merge another person into this one:</label>
+      <input id="other" name="other" placeholder="Other person ID" type="text" value="{{ other_person_id }}">
+    </p>
+    <input type="submit" class="button alert" value="Merge people">
+  </form>
+
+{% endblock %}

--- a/ynr/apps/candidates/urls.py
+++ b/ynr/apps/candidates/urls.py
@@ -72,6 +72,11 @@ patterns_to_format = [
         "name": "person-revert",
     },
     {
+        "pattern": r"^person/(?P<person_id>\d+)/merge_correct_not_standing/(?P<other_person_id>\d+)$",
+        "view": views.CorrectNotStandingMergeView.as_view(),
+        "name": "person-merge-correct-not-standing",
+    },
+    {
         "pattern": r"^person/(?P<person_id>\d+)/merge$",
         "view": views.MergePeopleView.as_view(),
         "name": "person-merge",

--- a/ynr/apps/candidates/urls.py
+++ b/ynr/apps/candidates/urls.py
@@ -72,7 +72,7 @@ patterns_to_format = [
         "name": "person-revert",
     },
     {
-        "pattern": r"^person/(?P<person_id>\d+)/merge_correct_not_standing/(?P<other_person_id>\d+)$",
+        "pattern": r"^person/(?P<person_id>\d+)/merge_conflict/(?P<other_person_id>\d+)/not_standing/$",
         "view": views.CorrectNotStandingMergeView.as_view(),
         "name": "person-merge-correct-not-standing",
     },

--- a/ynr/apps/candidates/views/people.py
+++ b/ynr/apps/candidates/views/people.py
@@ -18,7 +18,6 @@ from django.utils.decorators import method_decorator
 from django.utils.http import urlquote
 from django.views.decorators.cache import cache_control
 from django.views.generic import FormView, TemplateView, View
-from slugify import slugify
 
 from auth_helpers.views import GroupRequiredMixin, user_in_group
 from candidates.forms import SingleElectionForm
@@ -30,6 +29,7 @@ from people.forms import (
     UpdatePersonForm,
 )
 from people.models import Person
+from popolo.models import NotStandingValidationError
 from ynr.apps.people.merging import PersonMerger
 
 from ..diffs import get_version_diffs
@@ -42,7 +42,6 @@ from .helpers import (
     get_person_form_fields,
 )
 from .version_data import get_change_metadata, get_client_ip
-from popolo.models import NotStandingValidationError
 
 
 def get_call_to_action_flash_message(person, new_person=False):
@@ -213,7 +212,7 @@ class MergePeopleView(GroupRequiredMixin, View, MergePeopleMixin):
         # Check that the person IDs are well-formed:
         primary_person_id = self.kwargs["person_id"]
         secondary_person_id = self.request.POST["other"]
-        if not re.search("^\d+$", secondary_person_id):
+        if not re.search(r"^\d+$", secondary_person_id):
             message = "Malformed person ID '{0}'"
             raise ValueError(message.format(secondary_person_id))
         if primary_person_id == secondary_person_id:
@@ -258,7 +257,7 @@ class CorrectNotStandingMergeView(
         for version in versions_json:
             try:
                 membership = version["data"]["standing_in"][election.slug]
-                if membership == None:
+                if membership is None:
                     return version
             except KeyError:
                 continue

--- a/ynr/apps/candidates/views/people.py
+++ b/ynr/apps/candidates/views/people.py
@@ -30,7 +30,7 @@ from people.forms import (
 )
 from people.models import Person
 from popolo.models import NotStandingValidationError
-from ynr.apps.people.merging import PersonMerger
+from ynr.apps.people.merging import PersonMerger, InvalidMergeError
 
 from ..diffs import get_version_diffs
 from ..models import TRUSTED_TO_MERGE_GROUP_NAME, LoggedAction, PersonRedirect
@@ -212,10 +212,10 @@ class MergePeopleView(GroupRequiredMixin, TemplateView, MergePeopleMixin):
     def validate(self, context):
         if not re.search(r"^\d+$", context["other_person_id"]):
             message = "Malformed person ID '{0}'"
-            raise ValueError(message.format(context["other_person_id"]))
+            raise InvalidMergeError(message.format(context["other_person_id"]))
         if context["person"].pk == int(context["other_person_id"]):
             message = "You can't merge a person ({0}) with themself ({1})"
-            raise ValueError(
+            raise InvalidMergeError(
                 message.format(context["person"].pk, context["other_person_id"])
             )
 
@@ -232,7 +232,7 @@ class MergePeopleView(GroupRequiredMixin, TemplateView, MergePeopleMixin):
         # Check that the person IDs are well-formed:
         try:
             self.validate(context)
-        except ValueError as e:
+        except InvalidMergeError as e:
             context["error_message"] = e
             return self.render_to_response(context)
 

--- a/ynr/apps/candidates/views/people.py
+++ b/ynr/apps/candidates/views/people.py
@@ -266,17 +266,17 @@ class CorrectNotStandingMergeView(
     def populate_not_standing_list(self, person, person_not_standing):
         for membership in person.memberships.all():
             if (
-                membership.post_election.election
+                membership.ballot.election
                 in person_not_standing.not_standing.all()
             ):
                 self.not_standing_elections.append(
                     {
-                        "election": membership.post_election.election,
+                        "election": membership.ballot.election,
                         "person_standing": person,
-                        "person_standing_ballot": membership.post_election,
+                        "person_standing_ballot": membership.ballot,
                         "person_not_standing": person_not_standing,
                         "version": self.extract_not_standing_edit(
-                            membership.post_election.election,
+                            membership.ballot.election,
                             person_not_standing.versions,
                         ),
                     }

--- a/ynr/apps/people/merging.py
+++ b/ynr/apps/people/merging.py
@@ -321,3 +321,4 @@ class PersonMerger:
             if delete:
                 # Delete the old person
                 self.safe_delete(self.source_person)
+        return self.dest_person

--- a/ynr/apps/people/templates/people/correct_not_standing_in_merge.html
+++ b/ynr/apps/people/templates/people/correct_not_standing_in_merge.html
@@ -1,0 +1,58 @@
+{% extends "base.html" %}
+{% block content %}
+
+  <h2>Not standing mix up</h2>
+  <p>Merging these profiles would cause the resulting profile to be
+    added to an election that someone has asserted the person isn't standing in.</p>
+  <p>This can sometimes happen when a duplicate profile has been created, but it could be
+  some other problem that needs investigating.</p>
+  <p>Please check that this merge is correct, and if you think everything looks ok you
+  can remove the "not standing" assertion and continue with the merge.</p>
+  <style>td {vertical-align: top;}</style>
+  <table>
+  <thead>
+    <tr>
+      <th>Election</th>
+      <th>Person Standing</th>
+      <th>Person not standing</th>
+      <th>Source</th>
+    </tr>
+  </thead>
+  <tbody>
+    {% for not_standing_election in not_standing_elections %}
+      <tr>
+        <td>
+          <a href="{{ not_standing_election.election.get_absolute_url }}">
+            {{ not_standing_election.election.name }} {{ not_standing_election.election.election_date }}
+          </a>
+        </td>
+        <td>
+          <a href="{{ not_standing_election.person_standing.get_absolute_url }}">
+            {{ not_standing_election.person_standing.name }} ({{ not_standing_election.person_standing.pk }})
+          </a>
+          <ul>
+            <li><a href="{{ not_standing_election.person_standing_ballot.get_absolute_url }}">Ballot</a></li>
+            <li><a href="{{ not_standing_election.person_standing_ballot.sopn.get_absolute_url }}">SOPN</a></li>
+          </ul>
+        </td>
+        <td>
+          <a href="{{ not_standing_election.person_not_standing.get_absolute_url }}">
+            {{ not_standing_election.person_not_standing.name }} ({{ not_standing_election.person_not_standing.pk }})
+          </a>
+        </td>
+        <td><strong>{{ not_standing_election.version.username }}</strong> asserted this person wasn't standing in an edit with the source:
+          <blockquote>{{ not_standing_election.version.information_source|urlize }}</blockquote></td>
+      </tr>
+    {% endfor %}
+
+  </tbody>
+  </table>
+
+  <form method="post">
+  {% csrf_token %}
+  <button type="submit">Remove the "not standing" flag and merge</button>
+  <a href="{{ person_a.get_absolute_url }}" class="button secondary">
+    Stop merge and return to {{ person_a.name }} ({{ person_a.pk }})</a>
+  </form>
+
+{% endblock %}

--- a/ynr/apps/people/templates/people/correct_not_standing_in_merge.html
+++ b/ynr/apps/people/templates/people/correct_not_standing_in_merge.html
@@ -6,8 +6,8 @@
     added to an election that someone has asserted the person isn't standing in.</p>
   <p>This can sometimes happen when a duplicate profile has been created, but it could be
   some other problem that needs investigating.</p>
-  <p>Please check that this merge is correct, and if you think everything looks ok you
-  can remove the "not standing" assertion and continue with the merge.</p>
+  <p>Please check that this merge is correct, and if you think everything looks ok choose
+    "confirm" to remove the "not standing" assertion and continue with the merge.</p>
   <style>table {width: 100%;} td {vertical-align: top;}</style>
   <table>
   <thead>

--- a/ynr/apps/people/templates/people/correct_not_standing_in_merge.html
+++ b/ynr/apps/people/templates/people/correct_not_standing_in_merge.html
@@ -1,21 +1,22 @@
 {% extends "base.html" %}
 {% block content %}
 
-  <h2>Not standing mix up</h2>
+  <h2>'Not standing' mix up</h2>
   <p>Merging these profiles would cause the resulting profile to be
     added to an election that someone has asserted the person isn't standing in.</p>
   <p>This can sometimes happen when a duplicate profile has been created, but it could be
   some other problem that needs investigating.</p>
   <p>Please check that this merge is correct, and if you think everything looks ok you
   can remove the "not standing" assertion and continue with the merge.</p>
-  <style>td {vertical-align: top;}</style>
+  <style>table {width: 100%;} td {vertical-align: top;}</style>
   <table>
   <thead>
     <tr>
       <th>Election</th>
       <th>Person Standing</th>
       <th>Person not standing</th>
-      <th>Source</th>
+      <th>Ballot</th>
+      <th>SOPN</th>
     </tr>
   </thead>
   <tbody>
@@ -30,18 +31,22 @@
           <a href="{{ not_standing_election.person_standing.get_absolute_url }}">
             {{ not_standing_election.person_standing.name }} ({{ not_standing_election.person_standing.pk }})
           </a>
-          <ul>
-            <li><a href="{{ not_standing_election.person_standing_ballot.get_absolute_url }}">Ballot</a></li>
-            <li><a href="{{ not_standing_election.person_standing_ballot.sopn.get_absolute_url }}">SOPN</a></li>
-          </ul>
         </td>
         <td>
           <a href="{{ not_standing_election.person_not_standing.get_absolute_url }}">
             {{ not_standing_election.person_not_standing.name }} ({{ not_standing_election.person_not_standing.pk }})
           </a>
         </td>
-        <td><strong>{{ not_standing_election.version.username }}</strong> asserted this person wasn't standing in an edit with the source:
-          <blockquote>{{ not_standing_election.version.information_source|urlize }}</blockquote></td>
+        <td>
+          <a href="{{ not_standing_election.person_standing_ballot.get_absolute_url }}">Ballot</a>
+        </td>
+        <td>
+          {% if not_standing_election.person_standing_ballot.sopn %}
+            <a href="{{ not_standing_election.person_standing_ballot.sopn.get_absolute_url }}" target="_blank">
+            SOPN
+          </a>
+          {% endif %}
+        </td>
       </tr>
     {% endfor %}
 
@@ -50,7 +55,10 @@
 
   <form method="post">
   {% csrf_token %}
-  <button type="submit">Remove the "not standing" flag and merge</button>
+  <button type="submit">
+    I confirm this person is standing in {{ not_standing_elections|pluralize:"this,these" }}
+    election{{ not_standing_elections|pluralize }}
+  </button>
   <a href="{{ person_a.get_absolute_url }}" class="button secondary">
     Stop merge and return to {{ person_a.name }} ({{ person_a.pk }})</a>
   </form>

--- a/ynr/apps/people/tests/test_merge_view.py
+++ b/ynr/apps/people/tests/test_merge_view.py
@@ -648,7 +648,7 @@ class TestMergePeopleView(TestUserMixin, UK2015ExamplesMixin, WebTest):
         response = merge_form.submit()
         self.assertEqual(response.status_code, 302)
         self.assertEqual(
-            response.location, "/person/1/merge_correct_not_standing/2009"
+            response.location, "/person/1/merge_conflict/2009/not_standing/"
         )
         response = response.follow()
         form = response.forms[1]

--- a/ynr/apps/people/tests/test_merge_view.py
+++ b/ynr/apps/people/tests/test_merge_view.py
@@ -629,14 +629,14 @@ class TestMergePeopleView(TestUserMixin, UK2015ExamplesMixin, WebTest):
                     "version_id": "274e50504df330e4"
                   }]""",
         )
-        person_a.not_standing.add(self.dulwich_post_pee.election)
+        person_a.not_standing.add(self.dulwich_post_ballot.election)
 
         person_b = Person.objects.get(pk=2009)
         factories.MembershipFactory.create(
             person=person_b,
             post=self.dulwich_post,
             party=self.labour_party,
-            post_election=self.dulwich_post_pee,
+            ballot=self.dulwich_post_ballot,
         )
 
         response = self.app.get(

--- a/ynr/apps/people/tests/test_merge_view.py
+++ b/ynr/apps/people/tests/test_merge_view.py
@@ -655,3 +655,25 @@ class TestMergePeopleView(TestUserMixin, UK2015ExamplesMixin, WebTest):
         response = form.submit()
         response.follow()
         self.assertEqual(response.location, "/person/1/tessa-jowell")
+
+    def test_merge_same_person_shows_error(self):
+        response = self.app.get(
+            "/person/{}/update".format(2009), user=self.user_who_can_merge
+        )
+        merge_form = response.forms["person-merge"]
+        merge_form["other"] = 2009
+        response = merge_form.submit()
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(
+            response, "You can&#39;t merge a person (2009) with themself (2009)"
+        )
+
+    def test_merge_malformed_other(self):
+        response = self.app.get(
+            "/person/{}/update".format(2009), user=self.user_who_can_merge
+        )
+        merge_form = response.forms["person-merge"]
+        merge_form["other"] = "foobar"
+        response = merge_form.submit()
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "Malformed person ID &#39;foobar&#39;")

--- a/ynr/apps/people/tests/test_merge_view.py
+++ b/ynr/apps/people/tests/test_merge_view.py
@@ -295,7 +295,7 @@ class TestMergePeopleView(TestUserMixin, UK2015ExamplesMixin, WebTest):
         response = merge_form.submit()
 
         self.assertEqual(response.status_code, 302)
-        self.assertEqual(response.location, "/person/2009/tessa-jowell")
+        self.assertEqual(response.location, "/person/2007/tessa-jowell")
 
         # Check that the redirect object has been made:
         self.assertEqual(

--- a/ynr/apps/people/tests/test_merge_view.py
+++ b/ynr/apps/people/tests/test_merge_view.py
@@ -602,7 +602,7 @@ class TestMergePeopleView(TestUserMixin, UK2015ExamplesMixin, WebTest):
                       "homepage_url": "",
                       "honorific_prefix": "Mr",
                       "honorific_suffix": "",
-                      "id": "2007",
+                      "id": "1",
                       "identifiers": [],
                       "image": null,
                       "linkedin_url": "",

--- a/ynr/apps/popolo/models.py
+++ b/ynr/apps/popolo/models.py
@@ -35,6 +35,10 @@ class VersionNotFound(Exception):
     pass
 
 
+class NotStandingValidationError(ValueError):
+    pass
+
+
 class Organization(Dateframeable, Timestampable, models.Model):
     """
     A group with a common purpose or reason for existence that goes beyond the
@@ -314,7 +318,7 @@ class Membership(Dateframeable, Timestampable, models.Model):
                     '"{election}", but that\'s in {person} '
                     "({person_id})'s not_standing list."
                 )
-                raise Exception(
+                raise NotStandingValidationError(
                     msg.format(
                         election=self.ballot.election,
                         person=self.person.name,


### PR DESCRIPTION
This PR adds a view that is shown after a merge has been started, that catches a not standing conflict.

Rather than a 500, the following is shown:

![Screenshot 2019-04-28 17 42 32](https://user-images.githubusercontent.com/242329/56867430-0c814c80-69dd-11e9-87ef-35d92cd46d93.png)


This deals with a class of 500 error described in #936.

The regression test comment explains it:

```
The following is an invalid sort of merge:

Person A: Standing in local.foo.2019-0-01
Person B: local.foo.2019-0-01 in their "not_standing" list

This is because a human has asserted that Person B is known not to
be standing in the election that person A is standing in.

It's best not to make any assumptions here, as this might indicate
an invalid merge.

However, in reality we commonly see this when a two people have been
created in the same election. Because most users can't merge, the only
option they have to de-duplicate is to mark one of the people as
not standing.

Someone else can then come along and merge the two people, and see the
above condition.

We now offer them a route out, by removing the not standing assertion,
or abandoning everything and…doing something else?
```