### PR TITLE
Change default emblem for Animal Welfare Party

### DIFF
--- a/ynr/apps/parties/constants.py
+++ b/ynr/apps/parties/constants.py
@@ -40,6 +40,8 @@ DEFAULT_EMBLEMS = {
     "PP3960": 2380,
     # Liberal party
     "PP54": 54,
+    # Animal Welfare Party
+    "PP616": 3535,
 }
 
 JOINT_DESCRIPTION_REGEX = "^(.*?) \(joint descriptions? with\s?(.*)\)"


### PR DESCRIPTION
Add new constant value for Animal Welfare Party as current default (id362) pulls through emblem including previous party name from 2007 rather than 2014 or 2016 approved logo.
As mentioned in WCIVF Slack Channel - could not see relevant Issue to tie Pull Request to.