### PR TITLE
Fix typo on results table

### DIFF
--- a/ynr/apps/uk_results/templates/uk_results/includes/vote_results_table.html
+++ b/ynr/apps/uk_results/templates/uk_results/includes/vote_results_table.html
@@ -22,7 +22,7 @@
       </a>
     </td>
     <td>
-      {{ result.membership.on_behalf_of.name }}
+      {{ result.membership.party.name }}
     </td>
     <td>
         {% if result.is_winner %}

--- a/ynr/apps/uk_results/tests/test_uk_results.py
+++ b/ynr/apps/uk_results/tests/test_uk_results.py
@@ -100,3 +100,18 @@ class TestUKResults(TestUserMixin, UK2015ExamplesMixin, TestCase):
         self.result_set.num_turnout_reported = 300
         self.result_set.save()
         self.result_set.record_version()
+
+    def test_table_on_ballot_page(self):
+        resp = self.client.get(
+            self.local_post.ballot_set.get().get_absolute_url()
+        )
+        self.assertContains(resp, "<h3>Results</h3>")
+        expected_row = """
+            <tr>
+                <td><a href="/person/14">Bob</a></td>
+                <td>Conservative Party</td>
+                <td><strong>5000</strong></td>
+                <td><strong>Yes</strong></td>
+            </tr>
+        """
+        self.assertInHTML(expected_row, resp.content.decode("utf8"))


### PR DESCRIPTION
This used the old "on_behalf_of" attribute rather than party.

Fixes #986