### PR TITLE
Upgrade to django 2.2

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,0 +1,11 @@
+update_configs:
+  -
+    directory: /
+    ignored_updates:
+      -
+        match:
+          dependency_name: django
+          version_requirement: 3.x
+    package_manager: python
+    update_schedule: daily
+version: 1

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -47,7 +47,6 @@ jsonpointer==2.0
 libsass==0.18.0
 lxml==4.3.4
 mock==1.0.1
-mysociety-django-images==0.0.6
 ndg-httpsclient==0.5.1
 numpy==1.16.2
 oauthlib==3.1.0

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -20,13 +20,13 @@ django-debug-toolbar-template-timings
 django-debug-toolbar==1.11
 django-extensions==2.1.6
 django-filter==2.1.0
-django-haystack==2.7.0
+django-haystack==2.8.1
 django-markdown-deux==1.0.5
 django-model-utils==3.1.2
 django-pipeline==1.6.14
 django-storages==1.6.6
 django-webtest==1.9.4
-Django>=1.11,<2.0
+Django==2.2.4
 djangorestframework-jsonp==1.0.2
 djangorestframework==3.9.4
 docutils==0.14

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{35,36}-django111
+envlist = py{35,36}-django22
 skipsdist = True
 
 [tox:travis]

--- a/ynr/apps/bulk_adding/models.py
+++ b/ynr/apps/bulk_adding/models.py
@@ -44,7 +44,7 @@ class RawPeople(TimeStampedModel):
     # to edit (edit option always there)
     TRUSTED_SOURCES = (SOURCE_COUNCIL_CSV, SOURCE_BULK_ADD_FORM)
 
-    ballot = models.OneToOneField("candidates.Ballot")
+    ballot = models.OneToOneField("candidates.Ballot", on_delete=models.CASCADE)
     data = JSONField()
     source = models.CharField(max_length=512)
     source_type = models.CharField(

--- a/ynr/apps/bulk_adding/views/parties.py
+++ b/ynr/apps/bulk_adding/views/parties.py
@@ -1,6 +1,6 @@
 from braces.views import LoginRequiredMixin
 from django import forms as django_forms
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.db import transaction
 from django.http import HttpResponseRedirect
 from django.views.generic import FormView, TemplateView

--- a/ynr/apps/bulk_adding/views/sopns.py
+++ b/ynr/apps/bulk_adding/views/sopns.py
@@ -1,6 +1,6 @@
 from braces.views import LoginRequiredMixin
 from django.contrib import messages
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.db import transaction
 from django.db.models import F
 from django.http import HttpResponseRedirect

--- a/ynr/apps/candidates/admin.py
+++ b/ynr/apps/candidates/admin.py
@@ -1,6 +1,6 @@
 from django.contrib import admin
 
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.forms import ModelForm
 
 from .models import LoggedAction, PartySet, Ballot

--- a/ynr/apps/candidates/feeds.py
+++ b/ynr/apps/candidates/feeds.py
@@ -2,7 +2,7 @@ import re
 
 from django.contrib.sites.models import Site
 from django.contrib.syndication.views import Feed
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.utils.feedgenerator import Atom1Feed
 from django.conf import settings
 

--- a/ynr/apps/candidates/middleware.py
+++ b/ynr/apps/candidates/middleware.py
@@ -6,7 +6,7 @@ from django.conf import settings
 from django.contrib.sites.models import Site
 from django.contrib.auth import logout
 from django.core.mail import send_mail
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.http import Http404, HttpResponseRedirect
 from django.http import HttpResponseForbidden
 from django.shortcuts import render

--- a/ynr/apps/candidates/migrations/0008_membershipextra_organizationextra_personextra_postextra.py
+++ b/ynr/apps/candidates/migrations/0008_membershipextra_organizationextra_personextra_postextra.py
@@ -6,7 +6,6 @@ class Migration(migrations.Migration):
 
     dependencies = [
         migrations.swappable_dependency(settings.AUTH_USER_MODEL),
-        ("images", "0001_initial"),
         ("popolo", "0002_update_models_from_upstream"),
         ("elections", "0003_allow_null_winner_membership_role"),
         ("candidates", "0007_add_result_recorders_group"),
@@ -195,50 +194,6 @@ class Migration(migrations.Migration):
                         on_delete=models.CASCADE,
                     ),
                 ),
-            ],
-        ),
-        migrations.CreateModel(
-            name="ImageExtra",
-            fields=[
-                (
-                    "id",
-                    models.AutoField(
-                        verbose_name="ID",
-                        serialize=False,
-                        auto_created=True,
-                        primary_key=True,
-                    ),
-                ),
-                (
-                    "copyright",
-                    models.CharField(
-                        default=b"other", max_length=64, blank=True
-                    ),
-                ),
-                ("user_notes", models.TextField(blank=True)),
-                (
-                    "base",
-                    models.OneToOneField(
-                        related_name="extra",
-                        to="images.Image",
-                        on_delete=models.CASCADE,
-                    ),
-                ),
-                ("md5sum", models.CharField(max_length=32, blank=True)),
-                (
-                    "uploading_user",
-                    models.ForeignKey(
-                        blank=True,
-                        to=settings.AUTH_USER_MODEL,
-                        null=True,
-                        on_delete=models.CASCADE,
-                    ),
-                ),
-                (
-                    "user_copyright",
-                    models.CharField(max_length=128, blank=True),
-                ),
-                ("notes", models.TextField(blank=True)),
             ],
         ),
     ]

--- a/ynr/apps/candidates/migrations/0009_migrate_to_django_popolo.py
+++ b/ynr/apps/candidates/migrations/0009_migrate_to_django_popolo.py
@@ -8,7 +8,6 @@ class Migration(migrations.Migration):
             "candidates",
             "0008_membershipextra_organizationextra_personextra_postextra",
         ),
-        ("images", "0001_initial"),
         ("popolo", "0002_update_models_from_upstream"),
     ]
 

--- a/ynr/apps/candidates/migrations/0050_delete_imageextra.py
+++ b/ynr/apps/candidates/migrations/0050_delete_imageextra.py
@@ -14,9 +14,6 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        migrations.RemoveField(model_name="imageextra", name="base"),
-        migrations.RemoveField(model_name="imageextra", name="uploading_user"),
         migrations.RemoveField(model_name="organizationextra", name="base"),
-        migrations.DeleteModel(name="ImageExtra"),
         migrations.DeleteModel(name="OrganizationExtra"),
     ]

--- a/ynr/apps/candidates/models/db.py
+++ b/ynr/apps/candidates/models/db.py
@@ -44,16 +44,24 @@ class LoggedAction(models.Model):
     should be helpful in tracking down both bugs and the actions of
     malicious users."""
 
-    user = models.ForeignKey(User, blank=True, null=True)
-    person = models.ForeignKey("people.Person", blank=True, null=True)
+    user = models.ForeignKey(
+        User, blank=True, null=True, on_delete=models.CASCADE
+    )
+    person = models.ForeignKey(
+        "people.Person", blank=True, null=True, on_delete=models.CASCADE
+    )
     action_type = models.CharField(max_length=64)
     popit_person_new_version = models.CharField(max_length=32)
     created = models.DateTimeField(auto_now_add=True, db_index=True)
     updated = models.DateTimeField(auto_now=True)
     ip_address = models.CharField(max_length=50, blank=True, null=True)
     source = models.TextField()
-    post = models.ForeignKey("popolo.Post", blank=True, null=True)
-    ballot = models.ForeignKey("candidates.Ballot", null=True)
+    post = models.ForeignKey(
+        "popolo.Post", blank=True, null=True, on_delete=models.CASCADE
+    )
+    ballot = models.ForeignKey(
+        "candidates.Ballot", null=True, on_delete=models.CASCADE
+    )
 
     objects = LoggedActionQuerySet.as_manager()
 
@@ -136,7 +144,9 @@ class PersonRedirect(models.Model):
 
 
 class UserTermsAgreement(models.Model):
-    user = models.OneToOneField(User, related_name="terms_agreement")
+    user = models.OneToOneField(
+        User, related_name="terms_agreement", on_delete=models.CASCADE
+    )
     assigned_to_dc = models.BooleanField(default=False)
 
 

--- a/ynr/apps/candidates/models/db.py
+++ b/ynr/apps/candidates/models/db.py
@@ -3,7 +3,7 @@ from datetime import datetime, timedelta
 from functools import reduce
 
 from django.contrib.auth.models import User
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.db import models
 from django.db.models.signals import post_save
 from django.utils.html import escape

--- a/ynr/apps/candidates/models/popolo_extra.py
+++ b/ynr/apps/candidates/models/popolo_extra.py
@@ -54,8 +54,8 @@ def model_has_related_objects(model):
 
 
 class Ballot(models.Model):
-    post = models.ForeignKey("popolo.Post")
-    election = models.ForeignKey(Election)
+    post = models.ForeignKey("popolo.Post", on_delete=models.CASCADE)
+    election = models.ForeignKey(Election, on_delete=models.CASCADE)
     ballot_paper_id = models.CharField(blank=True, max_length=255, unique=True)
 
     candidates_locked = models.BooleanField(default=False)

--- a/ynr/apps/candidates/models/popolo_extra.py
+++ b/ynr/apps/candidates/models/popolo_extra.py
@@ -7,7 +7,7 @@ from django.contrib.admin.utils import NestedObjects
 from django.contrib.auth.models import User
 from django.contrib.contenttypes.fields import GenericRelation
 from django.core.files.storage import DefaultStorage
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.db import connection
 from django.db import models
 from django.utils.html import mark_safe

--- a/ynr/apps/candidates/templates/candidates/othername_edit.html
+++ b/ynr/apps/candidates/templates/candidates/othername_edit.html
@@ -1,7 +1,7 @@
 {% extends 'base.html' %}
 
 
-{% load staticfiles %}
+{% load static %}
 
 {% block body_class %}person-othername-update{% endblock %}
 

--- a/ynr/apps/candidates/templates/candidates/othername_list.html
+++ b/ynr/apps/candidates/templates/candidates/othername_list.html
@@ -1,7 +1,7 @@
 {% extends 'base.html' %}
 
 
-{% load staticfiles %}
+{% load static %}
 
 {% block body_class %}person-othernames-list{% endblock %}
 

--- a/ynr/apps/candidates/templates/candidates/othername_new.html
+++ b/ynr/apps/candidates/templates/candidates/othername_new.html
@@ -1,7 +1,7 @@
 {% extends 'base.html' %}
 
 
-{% load staticfiles %}
+{% load static %}
 
 {% block body_class %}person-othername-new{% endblock %}
 

--- a/ynr/apps/candidates/templates/candidates/person-edit.html
+++ b/ynr/apps/candidates/templates/candidates/person-edit.html
@@ -1,7 +1,7 @@
 {% extends 'base.html' %}
 
 
-{% load staticfiles %}
+{% load static %}
 {% load thumbnail %}
 
 {% block body_class %}person{% endblock %}

--- a/ynr/apps/candidates/templatetags/absolute.py
+++ b/ynr/apps/candidates/templatetags/absolute.py
@@ -1,5 +1,5 @@
 from django import template
-from django.contrib.staticfiles.templatetags.staticfiles import static
+from django.templatetags.static import static
 
 register = template.Library()
 

--- a/ynr/apps/candidates/templatetags/standing.py
+++ b/ynr/apps/candidates/templatetags/standing.py
@@ -2,7 +2,7 @@ from slugify import slugify
 
 from django import template
 from django.conf import settings
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.db.models import Prefetch
 from django.utils.safestring import mark_safe
 

--- a/ynr/apps/candidates/tests/test_caching.py
+++ b/ynr/apps/candidates/tests/test_caching.py
@@ -22,7 +22,7 @@ class TestCaching(TestUserMixin, UK2015ExamplesMixin, WebTest):
 
     def test_auth_user_cache_headers(self):
         response = self.app.get(
-            "/elections/parl.65808.2010-05-06/", user=self.user
+            "/elections/parl.65808.2015-05-07/", user=self.user
         )
 
         headers = response.headerlist

--- a/ynr/apps/candidates/tests/test_group_elections.py
+++ b/ynr/apps/candidates/tests/test_group_elections.py
@@ -128,7 +128,7 @@ class TestElectionGrouping(UK2015ExamplesMixin, TestCase):
         local_council_ballot = get_election_extra(
             self.local_post, self.local_election
         )
-        with self.assertNumQueries(4):
+        with self.assertNumQueries(3):
             self.assertEqual(
                 Election.group_and_order_elections(include_ballots=True),
                 [

--- a/ynr/apps/candidates/tests/test_record_winner.py
+++ b/ynr/apps/candidates/tests/test_record_winner.py
@@ -1,4 +1,4 @@
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.test.utils import override_settings
 from django_webtest import WebTest
 

--- a/ynr/apps/candidates/views/help.py
+++ b/ynr/apps/candidates/views/help.py
@@ -1,7 +1,7 @@
 from os.path import exists, join
 
 from django.conf import settings
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.views.generic import TemplateView
 
 from elections.models import Election

--- a/ynr/apps/candidates/views/helpers.py
+++ b/ynr/apps/candidates/views/helpers.py
@@ -1,7 +1,7 @@
 from collections import defaultdict
 
 from django.conf import settings
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.http import HttpResponseRedirect
 
 from elections.models import Election

--- a/ynr/apps/candidates/views/other_names.py
+++ b/ynr/apps/candidates/views/other_names.py
@@ -1,5 +1,5 @@
 from django.contrib.contenttypes.models import ContentType
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.db import transaction
 from django.http import JsonResponse
 from django.utils.functional import cached_property

--- a/ynr/apps/candidates/views/people.py
+++ b/ynr/apps/candidates/views/people.py
@@ -5,7 +5,7 @@ from slugify import slugify
 
 from django.conf import settings
 from django.contrib import messages
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.db import transaction
 from django.http import (
     HttpResponseRedirect,

--- a/ynr/apps/candidates/views/search.py
+++ b/ynr/apps/candidates/views/search.py
@@ -1,4 +1,4 @@
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.http import HttpResponseRedirect
 from django.utils.html import escape
 

--- a/ynr/apps/elections/models.py
+++ b/ynr/apps/elections/models.py
@@ -2,7 +2,7 @@ from collections import defaultdict, OrderedDict
 from datetime import date
 
 from django.contrib.admin.utils import NestedObjects
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.db import connection
 from django.db import models
 from django.shortcuts import get_object_or_404

--- a/ynr/apps/elections/models.py
+++ b/ynr/apps/elections/models.py
@@ -41,7 +41,7 @@ class Election(models.Model):
     current = models.BooleanField()
     use_for_candidate_suggestions = models.BooleanField(default=False)
     organization = models.ForeignKey(
-        "popolo.Organization", null=True, blank=True
+        "popolo.Organization", null=True, blank=True, on_delete=models.CASCADE
     )
     party_lists_in_use = models.BooleanField(default=False)
     people_elected_per_post = models.IntegerField(

--- a/ynr/apps/elections/templates/elections/election_list.html
+++ b/ynr/apps/elections/templates/elections/election_list.html
@@ -1,6 +1,6 @@
 {% extends 'base.html' %}
 {% load pipeline %}
-{% load staticfiles %}
+{% load static %}
 
 {% block body_class %}posts{% endblock %}
 

--- a/ynr/apps/elections/templates/elections/sopn_for_ballot.html
+++ b/ynr/apps/elections/templates/elections/sopn_for_ballot.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 {% load pipeline %}
-{% load staticfiles %}
+{% load static %}
 
 {% block extra_css %}
   {% stylesheet 'official_documents' %}

--- a/ynr/apps/elections/tests/test_ballot_lock.py
+++ b/ynr/apps/elections/tests/test_ballot_lock.py
@@ -1,4 +1,4 @@
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from django_webtest import WebTest
 from people.models import Person

--- a/ynr/apps/elections/uk/templates/base.html
+++ b/ynr/apps/elections/uk/templates/base.html
@@ -1,7 +1,7 @@
 {% extends 'uk_generic_base.html' %}
 
 
-{% load staticfiles %}
+{% load static %}
 
 {% block extra_js %}
   {% if settings.RAVEN_CONFIG %}

--- a/ynr/apps/elections/uk/templates/candidates/person-view.html
+++ b/ynr/apps/elections/uk/templates/candidates/person-view.html
@@ -2,7 +2,7 @@
 
 {% load absolute %}
 
-{% load staticfiles %}
+{% load static %}
 {% load standing %}
 {% load metadescription %}
 {% load extra_field_value %}

--- a/ynr/apps/elections/uk/views/frontpage.py
+++ b/ynr/apps/elections/uk/views/frontpage.py
@@ -1,7 +1,7 @@
 import random
 
 from django.conf import settings
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.http import HttpResponseRedirect
 from django.utils.decorators import method_decorator
 from django.views.decorators.cache import cache_control

--- a/ynr/apps/moderation_queue/models.py
+++ b/ynr/apps/moderation_queue/models.py
@@ -1,5 +1,5 @@
 from django.contrib.auth.models import User
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.db import models
 
 PHOTO_REVIEWERS_GROUP_NAME = "Photo Reviewers"

--- a/ynr/apps/moderation_queue/models.py
+++ b/ynr/apps/moderation_queue/models.py
@@ -62,8 +62,12 @@ class QueuedImage(models.Model):
     image = models.ImageField(
         upload_to="queued-images/%Y/%m/%d", max_length=512
     )
-    person = models.ForeignKey("people.Person", blank=True, null=True)
-    user = models.ForeignKey(User, blank=True, null=True)
+    person = models.ForeignKey(
+        "people.Person", blank=True, null=True, on_delete=models.CASCADE
+    )
+    user = models.ForeignKey(
+        User, blank=True, null=True, on_delete=models.CASCADE
+    )
 
     crop_min_x = models.IntegerField(blank=True, null=True)
     crop_min_y = models.IntegerField(blank=True, null=True)
@@ -93,8 +97,10 @@ class QueuedImage(models.Model):
 
 
 class SuggestedPostLock(models.Model):
-    ballot = models.ForeignKey("candidates.Ballot")
-    user = models.ForeignKey(User, blank=False, null=False)
+    ballot = models.ForeignKey("candidates.Ballot", on_delete=models.CASCADE)
+    user = models.ForeignKey(
+        User, blank=False, null=False, on_delete=models.CASCADE
+    )
     created = models.DateTimeField(auto_now_add=True)
     updated = models.DateTimeField(auto_now=True)
     justification = models.TextField(

--- a/ynr/apps/moderation_queue/templates/moderation_queue/suggestedpostlock_review.html
+++ b/ynr/apps/moderation_queue/templates/moderation_queue/suggestedpostlock_review.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 {% load pipeline %}
-{% load staticfiles %}
+{% load static %}
 {% load humanize %}
 {% block hero %}
   <h1>Ballots with lock suggestions</h1>

--- a/ynr/apps/moderation_queue/tests/test_queue.py
+++ b/ynr/apps/moderation_queue/tests/test_queue.py
@@ -5,7 +5,7 @@ from shutil import rmtree
 from django.contrib.auth.models import User, Group
 from django.conf import settings
 from django.core.files.storage import FileSystemStorage
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.test.utils import override_settings
 from django.utils.six.moves.urllib_parse import urlsplit
 

--- a/ynr/apps/moderation_queue/tests/test_upload_photo.py
+++ b/ynr/apps/moderation_queue/tests/test_upload_photo.py
@@ -6,7 +6,7 @@ from shutil import rmtree
 from django.contrib.auth.models import User
 from django.conf import settings
 from django.core.files.storage import FileSystemStorage
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.test.utils import override_settings
 from django.utils.six import text_type
 from django.utils.six.moves.urllib_parse import urlsplit

--- a/ynr/apps/moderation_queue/views.py
+++ b/ynr/apps/moderation_queue/views.py
@@ -12,7 +12,7 @@ from django.contrib.sites.models import Site
 from django.contrib import messages
 from django.core.files import File
 from django.core.mail import send_mail
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.db import models
 from django.http import (
     HttpResponseRedirect,

--- a/ynr/apps/official_documents/models.py
+++ b/ynr/apps/official_documents/models.py
@@ -32,7 +32,9 @@ class OfficialDocument(TimeStampedModel):
     uploaded_file = models.FileField(
         upload_to=document_file_name, max_length=800
     )
-    ballot = models.ForeignKey("candidates.Ballot", null=False)
+    ballot = models.ForeignKey(
+        "candidates.Ballot", null=False, on_delete=models.CASCADE
+    )
     source_url = models.URLField(
         help_text="The page that links to this document", max_length=1000
     )

--- a/ynr/apps/official_documents/models.py
+++ b/ynr/apps/official_documents/models.py
@@ -1,7 +1,7 @@
 import os
 
 from django.db import models
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from popolo.models import Post
 from elections.models import Election

--- a/ynr/apps/official_documents/tests/test_upload.py
+++ b/ynr/apps/official_documents/tests/test_upload.py
@@ -3,7 +3,7 @@ from os.path import join, realpath, dirname
 from django_webtest import WebTest
 from webtest import Upload
 
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from candidates.tests.auth import TestUserMixin
 from candidates.models import LoggedAction

--- a/ynr/apps/people/forms.py
+++ b/ynr/apps/people/forms.py
@@ -27,7 +27,9 @@ class StrippedCharField(forms.CharField):
         self, max_length=None, min_length=None, strip=True, *args, **kwargs
     ):
         self.strip = strip
-        super().__init__(max_length, min_length, *args, **kwargs)
+        super().__init__(
+            max_length=max_length, min_length=min_length, *args, **kwargs
+        )
 
     def to_python(self, value):
         value = super().to_python(value)

--- a/ynr/apps/people/models.py
+++ b/ynr/apps/people/models.py
@@ -6,7 +6,7 @@ from django.conf import settings
 from django.contrib.contenttypes.fields import GenericRelation
 from django.contrib.postgres.fields import JSONField
 from django.core.exceptions import ObjectDoesNotExist
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.db import models
 from django.template import loader
 from django.templatetags.static import static

--- a/ynr/apps/people/models.py
+++ b/ynr/apps/people/models.py
@@ -41,11 +41,15 @@ class PersonImage(models.Model):
     notes they have.
     """
 
-    person = models.ForeignKey("people.Person", related_name="images")
+    person = models.ForeignKey(
+        "people.Person", related_name="images", on_delete=models.CASCADE
+    )
     image = models.ImageField(upload_to=person_image_path, max_length=512)
     source = models.CharField(max_length=400)
     copyright = models.CharField(max_length=64, default="other", blank=True)
-    uploading_user = models.ForeignKey("auth.User", blank=True, null=True)
+    uploading_user = models.ForeignKey(
+        "auth.User", blank=True, null=True, on_delete=models.CASCADE
+    )
     user_notes = models.TextField(blank=True)
     md5sum = models.CharField(max_length=32, blank=True)
     user_copyright = models.CharField(max_length=128, blank=True)
@@ -75,7 +79,9 @@ class PersonIdentifier(TimeStampedModel):
     """
 
     person = models.ForeignKey(
-        "people.Person", related_name="tmp_person_identifiers"
+        "people.Person",
+        related_name="tmp_person_identifiers",
+        on_delete=models.CASCADE,
     )
     value = models.CharField(
         max_length=800,

--- a/ynr/apps/people/templates/search/search.html
+++ b/ynr/apps/people/templates/search/search.html
@@ -1,6 +1,6 @@
 {% extends 'base.html' %}
 
-{% load staticfiles %}
+{% load static %}
 {% load thumbnail %}
 
 {% block content %}

--- a/ynr/apps/people/tests/test_person_form_identifier_crud.py
+++ b/ynr/apps/people/tests/test_person_form_identifier_crud.py
@@ -1,6 +1,6 @@
 from django_webtest import WebTest
 
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.test import override_settings
 
 from candidates.tests.auth import TestUserMixin

--- a/ynr/apps/popolo/behaviors/models.py
+++ b/ynr/apps/popolo/behaviors/models.py
@@ -19,7 +19,9 @@ class GenericRelatable(models.Model):
     An abstract class that provides the possibility of generic relations
     """
 
-    content_type = models.ForeignKey(ContentType, blank=True, null=True)
+    content_type = models.ForeignKey(
+        ContentType, blank=True, null=True, on_delete=models.CASCADE
+    )
     object_id = models.PositiveIntegerField(blank=True, null=True)
     content_object = GenericForeignKey("content_type", "object_id")
 

--- a/ynr/apps/popolo/migrations/0009_move_extra_person_data_to_base.py
+++ b/ynr/apps/popolo/migrations/0009_move_extra_person_data_to_base.py
@@ -5,43 +5,12 @@ from __future__ import unicode_literals
 from django.db import migrations
 
 
-def add_extra_fields_to_base(apps, schema_editor):
-    Person = apps.get_model("popolo", "Person")
-    PersonExtra = apps.get_model("candidates", "PersonExtra")
-    ContentType = apps.get_model("contenttypes", "ContentType")
-    Image = apps.get_model("images", "Image")
-
-    old_to_new_map = {}
-
-    # First, delete any Person objects with no extra
-    Person.objects.filter(extra=None).delete()
-
-    for base in Person.objects.all().select_related("extra"):
-        old_to_new_map[base.extra.pk] = base.pk
-        base.versions = base.extra.versions
-        base.save()
-        for election in base.extra.not_standing.all():
-            base.not_standing.add(election)
-
-    # Update the content type ID for the images generic relation
-    pe_content_type_id = ContentType.objects.get_for_model(PersonExtra).pk
-    p_content_type_id = ContentType.objects.get_for_model(Person).pk
-    Image.objects.filter(content_type_id=pe_content_type_id).update(
-        content_type_id=p_content_type_id
-    )
-    images = Image.objects.filter(content_type_id=p_content_type_id)
-    for image in images:
-        if image.object_id in old_to_new_map:
-            image.object_id = old_to_new_map[image.object_id]
-            image.save()
-
-
 class Migration(migrations.Migration):
 
     dependencies = [("popolo", "0008_add_person_extra_fields")]
 
     operations = [
         migrations.RunPython(
-            add_extra_fields_to_base, migrations.RunPython.noop
+            migrations.RunPython.noop, migrations.RunPython.noop
         )
     ]

--- a/ynr/apps/popolo/migrations/0020_move_extra_organization_data_to_base.py
+++ b/ynr/apps/popolo/migrations/0020_move_extra_organization_data_to_base.py
@@ -5,42 +5,12 @@ from __future__ import unicode_literals
 from django.db import migrations
 
 
-def add_extra_fields_to_base(apps, schema_editor):
-    Organization = apps.get_model("popolo", "Organization")
-    OrganizationExtra = apps.get_model("candidates", "OrganizationExtra")
-    ContentType = apps.get_model("contenttypes", "ContentType")
-    Image = apps.get_model("images", "Image")
-
-    old_to_new_map = {}
-
-    # First, delete any Organization objects with no extra
-    Organization.objects.filter(extra=None).delete()
-
-    for base in Organization.objects.all().select_related("extra"):
-        old_to_new_map[base.extra.pk] = base.pk
-        base.slug = base.extra.slug
-        base.register = base.extra.register
-        base.save()
-
-    # Update the content type ID for the images generic relation
-    oe_content_type_id = ContentType.objects.get_for_model(OrganizationExtra).pk
-    org_content_type_id = ContentType.objects.get_for_model(Organization).pk
-    Image.objects.filter(content_type_id=oe_content_type_id).update(
-        content_type_id=org_content_type_id
-    )
-    images = Image.objects.filter(content_type_id=org_content_type_id)
-    for image in images:
-        if image.object_id in old_to_new_map:
-            image.object_id = old_to_new_map[image.object_id]
-            image.save()
-
-
 class Migration(migrations.Migration):
 
     dependencies = [("popolo", "0019_move_organization_extra_fields_to_base")]
 
     operations = [
         migrations.RunPython(
-            add_extra_fields_to_base, migrations.RunPython.noop
+            migrations.RunPython.noop, migrations.RunPython.noop
         )
     ]

--- a/ynr/apps/popolo/migrations/0022_populate_person_image_from_image.py
+++ b/ynr/apps/popolo/migrations/0022_populate_person_image_from_image.py
@@ -5,42 +5,6 @@ from __future__ import unicode_literals
 from django.db import migrations
 
 
-def popolate_person_image_model(apps, schema_editor):
-    """
-    Add this migration here as it's part of the *[Extra] migration work
-    and will be safe to delete as part of a migration clean up in future.
-
-    That is, it won't generally be useful to new users of the codebase once
-    the merging work is done, and it's nice to keep the migration tree smaller
-    in the People app.
-    """
-
-    Person = apps.get_model("popolo", "Person")
-    Image = apps.get_model("images", "Image")
-    ContentType = apps.get_model("contenttypes", "ContentType")
-    PersonImage = apps.get_model("people", "PersonImage")
-
-    person_content_type_id = ContentType.objects.get_for_model(Person).pk
-    image_qs = Image.objects.select_related("extra").filter(
-        content_type_id=person_content_type_id
-    )
-    for image in image_qs:
-        PersonImage.objects.create(
-            person_id=image.object_id,
-            image=image.image,
-            source=image.source,
-            copyright=image.extra.copyright,
-            uploading_user=image.extra.uploading_user,
-            user_notes=image.extra.user_notes,
-            md5sum=image.extra.md5sum,
-            user_copyright=image.extra.user_copyright,
-            notes=image.extra.notes,
-            is_primary=image.is_primary,
-        )
-    # Make sure we've copied all the images
-    assert PersonImage.objects.count() == image_qs.count()
-
-
 class Migration(migrations.Migration):
 
     dependencies = [
@@ -50,6 +14,6 @@ class Migration(migrations.Migration):
 
     operations = [
         migrations.RunPython(
-            popolate_person_image_model, migrations.RunPython.noop
+            migrations.RunPython.noop, migrations.RunPython.noop
         )
     ]

--- a/ynr/apps/popolo/models.py
+++ b/ynr/apps/popolo/models.py
@@ -81,6 +81,7 @@ class Organization(Dateframeable, Timestampable, models.Model):
         null=True,
         related_name="children",
         help_text="The organization that contains this organization",
+        on_delete=models.CASCADE,
     )
 
     founding_date = models.CharField(
@@ -202,6 +203,7 @@ class Post(Dateframeable, Timestampable, models.Model):
         "Organization",
         related_name="posts",
         help_text="The organization in which the post is held",
+        on_delete=models.CASCADE,
     )
 
     # array of items referencing "http://popoloproject.com/schemas/contact_detail.json#"
@@ -221,7 +223,9 @@ class Post(Dateframeable, Timestampable, models.Model):
         "elections.Election", related_name="posts", through="candidates.Ballot"
     )
     group = models.CharField(max_length=1024, blank=True)
-    party_set = models.ForeignKey("candidates.PartySet", blank=True, null=True)
+    party_set = models.ForeignKey(
+        "candidates.PartySet", blank=True, null=True, on_delete=models.CASCADE
+    )
 
     @property
     def short_label(self):
@@ -267,6 +271,7 @@ class Membership(Dateframeable, Timestampable, models.Model):
         to_field="id",
         related_name="memberships",
         help_text="The person who is a party to the relationship",
+        on_delete=models.CASCADE,
     )
 
     party = models.ForeignKey(
@@ -283,6 +288,7 @@ class Membership(Dateframeable, Timestampable, models.Model):
         null=True,
         related_name="memberships",
         help_text="The post held by the person in the organization through this membership",
+        on_delete=models.CASCADE,
     )
 
     # array of items referencing "http://popoloproject.com/schemas/contact_detail.json#"
@@ -299,7 +305,7 @@ class Membership(Dateframeable, Timestampable, models.Model):
     # Moved from MembeshipExtra
     elected = models.NullBooleanField()
     party_list_position = models.IntegerField(null=True)
-    ballot = models.ForeignKey("candidates.Ballot")
+    ballot = models.ForeignKey("candidates.Ballot", on_delete=models.CASCADE)
 
     def save(self, *args, **kwargs):
         if self.ballot and getattr(self, "check_for_broken", True):

--- a/ynr/apps/results/admin.py
+++ b/ynr/apps/results/admin.py
@@ -1,5 +1,5 @@
 from django.contrib import admin
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.utils.text import slugify
 from .models import ResultEvent
 

--- a/ynr/apps/results/models.py
+++ b/ynr/apps/results/models.py
@@ -10,14 +10,20 @@ class ResultEvent(models.Model):
         ordering = ["created"]
 
     created = models.DateTimeField(auto_now_add=True)
-    election = models.ForeignKey(Election, blank=True, null=True)
-    winner = models.ForeignKey("people.Person")
+    election = models.ForeignKey(
+        Election, blank=True, null=True, on_delete=models.CASCADE
+    )
+    winner = models.ForeignKey("people.Person", on_delete=models.CASCADE)
     old_post_id = models.CharField(blank=False, max_length=256)
     old_post_name = models.CharField(blank=True, null=True, max_length=1024)
-    post = models.ForeignKey(Post, blank=True, null=True)
-    winner_party = models.ForeignKey("parties.Party")
+    post = models.ForeignKey(
+        Post, blank=True, null=True, on_delete=models.CASCADE
+    )
+    winner_party = models.ForeignKey("parties.Party", on_delete=models.CASCADE)
     source = models.CharField(max_length=512)
-    user = models.ForeignKey(User, blank=True, null=True)
+    user = models.ForeignKey(
+        User, blank=True, null=True, on_delete=models.CASCADE
+    )
     parlparse_id = models.CharField(blank=True, null=True, max_length=256)
     retraction = models.BooleanField(default=False)
 

--- a/ynr/apps/results/tests/test_results.py
+++ b/ynr/apps/results/tests/test_results.py
@@ -207,7 +207,7 @@ class TestResultsFeedWithRetraction(
   <link href="http://example.com/" rel="alternate"/>
   <link href="http://example.com/results/all.atom" rel="self"/>
   <id>http://example.com/</id>
-  <updated>{updated[0]}</updated>
+  <updated>{updated[2]}</updated>
   <entry>
     <title>Tessa Jowell (Labour Party) won in Dulwich and West Norwood</title>
     <link href="http://example.com/#{item_id[0]}" rel="alternate"/>
@@ -305,7 +305,7 @@ class TestResultsFeedWithRetraction(
   <link href="http://example.com/" rel="alternate"/>
   <link href="http://example.com/results/all-basic.atom" rel="self"/>
   <id>http://example.com/</id>
-  <updated>{updated[0]}</updated>
+  <updated>{updated[2]}</updated>
   <entry>
     <title>Tessa Jowell (Labour Party) won in Dulwich and West Norwood</title>
     <link href="http://example.com/#{item_id[0]}" rel="alternate"/>

--- a/ynr/apps/sopn_parsing/models.py
+++ b/ynr/apps/sopn_parsing/models.py
@@ -10,7 +10,9 @@ class ParsedSOPN(TimeStampedModel):
 
     """
 
-    sopn = models.OneToOneField("official_documents.OfficialDocument")
+    sopn = models.OneToOneField(
+        "official_documents.OfficialDocument", on_delete=models.CASCADE
+    )
     raw_data = models.TextField()
     raw_data_type = models.CharField(max_length=255, default="pandas")
     parsed_data = models.TextField(null=True)

--- a/ynr/apps/sopn_parsing/tests/test_extract_page_numbers.py
+++ b/ynr/apps/sopn_parsing/tests/test_extract_page_numbers.py
@@ -29,6 +29,6 @@ class TestSOPNHelpers(UK2015ExamplesMixin, TestCase):
             source_url="example.com",
         )
         self.assertEqual(doc.first_page_number, None)
-        call_command("sopn_parsing_extract_page_numbers", all_documents=True)
+        call_command("sopn_parsing_extract_page_numbers")
         doc.refresh_from_db()
         self.assertEqual(doc.relevant_pages, "all")

--- a/ynr/apps/uk_results/models.py
+++ b/ynr/apps/uk_results/models.py
@@ -4,7 +4,7 @@ from django_extensions.db.models import TimeStampedModel
 
 
 class ResultSet(TimeStampedModel):
-    ballot = models.OneToOneField("candidates.Ballot")
+    ballot = models.OneToOneField("candidates.Ballot", on_delete=models.CASCADE)
 
     num_turnout_reported = models.IntegerField(
         null=True, verbose_name="Reported Turnout"

--- a/ynr/apps/uk_results/tests/test_smoke_test_views.py
+++ b/ynr/apps/uk_results/tests/test_smoke_test_views.py
@@ -1,5 +1,5 @@
 from django.core.exceptions import ObjectDoesNotExist
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.test import TestCase
 from django_webtest import WebTest
 

--- a/ynr/apps/wombles/models.py
+++ b/ynr/apps/wombles/models.py
@@ -3,7 +3,7 @@ from django.contrib.auth.models import User
 from django.db.models.signals import post_save
 from django.dispatch import receiver
 from django.db import connection
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 from .managers import WombleQuerySet
 

--- a/ynr/apps/wombles/models.py
+++ b/ynr/apps/wombles/models.py
@@ -43,7 +43,9 @@ class WombleTags(models.Model):
 
 
 class WombleProfile(models.Model):
-    user = models.OneToOneField("auth.User", related_name="womble_profile")
+    user = models.OneToOneField(
+        "auth.User", related_name="womble_profile", on_delete=models.CASCADE
+    )
     tags = models.ManyToManyField(WombleTags)
 
     objects = WombleQuerySet.as_manager()

--- a/ynr/apps/ynr_refactoring/views.py
+++ b/ynr/apps/ynr_refactoring/views.py
@@ -1,6 +1,6 @@
 from django.views.generic import RedirectView
 from django.views.defaults import page_not_found
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.shortcuts import get_object_or_404
 
 from elections.models import Election

--- a/ynr/settings/base.py
+++ b/ynr/settings/base.py
@@ -98,7 +98,6 @@ INSTALLED_APPS = (
     "rest_framework",
     "rest_framework.authtoken",
     "django_filters",
-    "images",
     "haystack",
     "elections",
     "popolo",

--- a/ynr/templates/generic_base.html
+++ b/ynr/templates/generic_base.html
@@ -14,7 +14,7 @@
     {% block extra_head %}
     {% endblock %}
 
-    {% load staticfiles %}
+    {% load static %}
     <link rel="shortcut icon" href="{% static 'img/favicon.ico' %}"/>
     <link rel="apple-touch-icon" href="{% static 'img/apple-touch-icon.png' %}"/>
 


### PR DESCRIPTION
This does all the donkey work needed to get the tests passing, apart from one remaining problem:

We don't actually use the functionality of [mysociety-django-images](https://pypi.org/project/mysociety-django-images/) package any more, but we've kept it on as a dependency because we've used it in the past and we've got migrations that depend on its migrations.

Because of the new "every model has to specify an `on_delete` behaviour" requirement in django 2, our migrations now fail to apply with `mysociety-django-images` installed, but also fail with it not installed.

There are a couple of vaguely sensible options here:

1. Continue to pull in `mysociety-django-images`, but try and get a PR accepted for django 2 compatibility. I've submitted https://github.com/mysociety/django-images/pull/4 to see where that goes..
2. Squash our entire migration history (which we kind of want to do anyway, but becomes.. messy)

The other issue this PR raises is that converting every implicit `on_delete=models.CASCADE` to an explicit one does make me wonder about whether that is definitely what we want in all cases (obviously the intent of this change), but this PR doesn't change any existing behaviour so reviewing that can probably be its own issue..

This could probably do with some extra review/testing beyond that, but I reckon this is a pretty good start..