### PR TITLE
Fix bogus merge version bug

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -25,7 +25,7 @@ django-markdown-deux==1.0.5
 django-model-utils==3.1.2
 django-pipeline==1.6.14
 django-storages==1.6.6
-django-webtest==1.9.4
+django-webtest==1.9.7
 Django==2.2.4
 djangorestframework-jsonp==1.0.2
 djangorestframework==3.9.4
@@ -86,6 +86,6 @@ Unidecode==1.0.23
 urllib3>=1.21.1,<1.26
 waitress==1.2.1
 WebOb==1.8.5
-WebTest==2.0.15
+WebTest==2.0.32
 Whoosh==2.7.4
 yanc==0.3.3

--- a/ynr/apps/candidates/tests/test_update_view.py
+++ b/ynr/apps/candidates/tests/test_update_view.py
@@ -155,16 +155,19 @@ class TestUpdatePersonView(TestUserMixin, UK2015ExamplesMixin, WebTest):
         # Now fake the addition of elements to the form as would
         # happen with the Javascript addition of a new candidacy.
         form = response.forms["person-details"]
-        for name, value in [
+        extra_fields = [
             ("extra_election_id", "local.maidstone.2016-05-05"),
             ("party_GB_local.maidstone.2016-05-05", self.labour_party.ec_id),
             ("constituency_local.maidstone.2016-05-05", "DIW:E05005004"),
             ("standing_local.maidstone.2016-05-05", "standing"),
             ("source", "Testing dynamic election addition"),
-        ]:
-            field = Text(form, "input", None, None, value)
-            form.fields[name] = [field]
+        ]
+        start_pos = len(form.field_order)
+        for pos, data in enumerate(extra_fields):
+            name, value = data
+            field = Text(form, "input", name, start_pos + pos, value)
             form.field_order.append((name, field))
+            form.fields[name] = [field]
         response = form.submit()
         self.assertEqual(response.status_code, 302)
         split_location = urlsplit(response.location)
@@ -189,14 +192,17 @@ class TestUpdatePersonView(TestUserMixin, UK2015ExamplesMixin, WebTest):
         # Now fake the addition of elements to the form as would
         # happen with the Javascript addition of a new candidacy.
         form = response.forms["person-details"]
-        for name, value in [
+        extra_fields = [
             ("extra_election_id", "local.maidstone.2016-05-05"),
             ("party_GB_local.maidstone.2016-05-05", self.labour_party.ec_id),
             ("constituency_local.maidstone.2016-05-05", "DIW:E05005004"),
             ("standing_local.maidstone.2016-05-05", "not-sure"),
             ("source", "Testing dynamic election addition"),
-        ]:
-            field = Text(form, "input", None, None, value)
+        ]
+        starting_pos = len(form.field_order)
+        for pos, data in enumerate(extra_fields):
+            name, value = data
+            field = Text(form, "input", None, starting_pos + pos, value)
             form.fields[name] = [field]
             form.field_order.append((name, field))
         response = form.submit()

--- a/ynr/apps/people/merging.py
+++ b/ynr/apps/people/merging.py
@@ -300,6 +300,11 @@ class PersonMerger:
                 self.request,
                 "After merging person {}".format(self.source_person.pk),
             )
+            # Save the dest person before creating a LoggedAction
+            # See https://github.com/DemocracyClub/yournextrepresentative/issues/1037
+            # for more
+            self.dest_person.record_version(change_metadata)
+            self.dest_person.save()
 
             # Log that the merge has taken place, and will be shown in
             # the recent changes, leaderboards, etc.
@@ -312,9 +317,6 @@ class PersonMerger:
                     person=self.dest_person,
                     source=change_metadata["information_source"],
                 )
-
-            self.dest_person.record_version(change_metadata)
-            self.dest_person.save()
 
             self.setup_redirect()
 


### PR DESCRIPTION
This is a WIP PR to try to write a regression test for:

> It looks like there was a bogus merge version for person with ID 49283; there were 0 merge versions and 2 person IDs

Both Sym and Chris hit this bug with, seemingly, any combination of people, however the tests didn't hit it.

Chris's idea was that the test data wasn't doing something that would happen if the people were created in the front end, so this is a set of tests to set up those conditions.

They're still not hitting the bug, but the tests might be helpful still. One to chat about.