### PR TITLE
Don't revert memberships

### DIFF
--- a/ynr/apps/candidates/models/popolo_extra.py
+++ b/ynr/apps/candidates/models/popolo_extra.py
@@ -26,6 +26,13 @@ class UnsafeToDelete(Exception):
 
 
 def raise_if_unsafe_to_delete(model):
+    if model._meta.label == "popolo.Membership":
+        if model.ballot.candidates_locked:
+            raise UnsafeToDelete(
+                "Can't delete a membership of a locked ballot ({})".format(
+                    model.ballot.ballot_paper_id
+                )
+            )
     related_models = model_has_related_objects(model)
     if related_models:
         msg = (

--- a/ynr/apps/candidates/models/versions.py
+++ b/ynr/apps/candidates/models/versions.py
@@ -160,7 +160,12 @@ def revert_person_from_version_data(person, version_data):
         )
 
     # Remove all candidacies, and recreate:
-    for membership in Membership.objects.filter(person=person):
+    qs = (
+        Membership.objects.filter(person=person)
+        .filter(result=None)
+        .filter(ballot__candidates_locked=False)
+    )
+    for membership in qs:
         raise_if_unsafe_to_delete(membership)
         membership.delete()
     # Also remove the indications of elections that this person is

--- a/ynr/apps/candidates/tests/test_changes_for_review.py
+++ b/ynr/apps/candidates/tests/test_changes_for_review.py
@@ -279,7 +279,6 @@ class TestNeedsReviewFeed(UK2015ExamplesMixin, TestUserMixin, WebTest):
         form["constituency_parl.2015-05-07"] = "65808"
         form["party_GB_parl.2015-05-07"] = str(Party.objects.first().ec_id)
         response = form.submit().follow()
-
         person = response.context["person"]
         self.person = person
 

--- a/ynr/apps/people/helpers.py
+++ b/ynr/apps/people/helpers.py
@@ -2,9 +2,14 @@ import re
 
 from dateutil import parser
 from django.conf import settings
+from django.forms import ValidationError
 from django_date_extensions.fields import ApproximateDate
 
-from candidates.models import PartySet, raise_if_unsafe_to_delete
+from candidates.models import (
+    PartySet,
+    raise_if_unsafe_to_delete,
+    UnsafeToDelete,
+)
 from candidates.twitter_api import TwitterAPITokenMissing, get_twitter_user_id
 from parties.models import Party
 from popolo.models import Membership, Post
@@ -155,7 +160,10 @@ def mark_as_standing(person, election_data, post, party, party_list_position):
     for membership_to_remove in Membership.objects.filter(
         pk__in=membership_ids_to_remove
     ):
-        raise_if_unsafe_to_delete(membership_to_remove)
+        try:
+            raise_if_unsafe_to_delete(membership_to_remove)
+        except UnsafeToDelete as e:
+            raise ValidationError(e)
         membership_to_remove.delete()
 
 

--- a/ynr/apps/people/tests/test_other_names.py
+++ b/ynr/apps/people/tests/test_other_names.py
@@ -30,8 +30,8 @@ class TestOtherNamesViews(TestUserMixin, UK2015ExamplesMixin, WebTest):
 
     def test_list_other_names_some_Names(self):
         response = self.app.get("/person/5678/other-names")
-        self.assertIn("<strong>Name</strong>: Fozzie Bear", response.text)
-        self.assertIn("<strong>Name</strong>: Mr Fozziewig", response.text)
+        self.assertIn("<td><strong>Fozzie Bear</strong></td>", response.text)
+        self.assertIn("<td><strong>Mr Fozziewig</strong></td>", response.text)
 
     # Deleting
 

--- a/ynr/apps/people/tests/test_revert.py
+++ b/ynr/apps/people/tests/test_revert.py
@@ -284,3 +284,6 @@ class TestRevertPersonView(TestUserMixin, UK2015ExamplesMixin, WebTest):
         # details are the same as the earlier version:
         person = Person.objects.get(id=2009)
         self.assertTrue(Membership.objects.filter(person_id=2009).count(), 2)
+        self.assertTrue(
+            CandidateResult.objects.filter(membership__person_id=2009).exists()
+        )

--- a/ynr/apps/people/tests/test_revert.py
+++ b/ynr/apps/people/tests/test_revert.py
@@ -11,6 +11,7 @@ from candidates.tests.uk_examples import UK2015ExamplesMixin
 from compat import deep_sort
 from people.models import Person, PersonIdentifier
 from popolo.models import Membership
+from uk_results.models import CandidateResult, ResultSet
 
 example_timestamp = "2014-09-29T10:11:59.216159"
 example_version_id = "5aa6418325c1a0bb"
@@ -248,3 +249,38 @@ class TestRevertPersonView(TestUserMixin, UK2015ExamplesMixin, WebTest):
         # one removed, and the theyworkforyou ID created:
         self.assertEqual(3, person.tmp_person_identifiers.all().count())
         self.assertIsNone(person.get_single_identifier_value("wikipedia_url"))
+
+    @patch("candidates.views.version_data.get_current_timestamp")
+    @patch("candidates.views.version_data.create_version_id")
+    def test_revert_to_earlier_version_with_results(
+        self, mock_create_version_id, mock_get_current_timestamp
+    ):
+        mock_get_current_timestamp.return_value = example_timestamp
+        mock_create_version_id.return_value = example_version_id
+
+        result_set = ResultSet.objects.create(
+            ballot=self.dulwich_post_ballot_earlier,
+            num_turnout_reported=51561,
+            num_spoilt_ballots=42,
+            ip_address="127.0.0.1",
+        )
+        CandidateResult.objects.create(
+            result_set=result_set,
+            membership=Person.objects.get(pk=2009).memberships.first(),
+            num_ballots=32614,
+            is_winner=True,
+        )
+
+        response = self.app.get("/person/2009/update", user=self.user)
+        revert_form = response.forms["revert-form-5469de7db0cbd155"]
+        revert_form[
+            "source"
+        ] = "Reverting to version 5469de7db0cbd155 for testing purposes"
+        response = revert_form.submit()
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(response.location, "/person/2009")
+
+        # Now get the person from the database and check if the
+        # details are the same as the earlier version:
+        person = Person.objects.get(id=2009)
+        self.assertTrue(Membership.objects.filter(person_id=2009).count(), 2)


### PR DESCRIPTION
Couple of related changes here:

1. Raise `UnsafeToDelete` when changing locked posts on the person update form. This previously raised a hard error

2. When reverting, don't try to delete and recreate `Memberships` that can't be deleted (the implementation of this was why I did 1. above first).

We talked about how this is an improvement, and fixes #1001, but this isn't ideal and doesn't try to address all the points in #1035.