### PR TITLE
Make sure future election fields are on the person edit page

### DIFF
--- a/ynr/apps/people/models.py
+++ b/ynr/apps/people/models.py
@@ -535,7 +535,7 @@ class Person(Timestampable, models.Model):
         from elections.models import Election
 
         for election_data in (
-            Election.objects.current()
+            Election.objects.future()
             .filter(ballot__membership__person=self)
             .by_date()
         ):


### PR DESCRIPTION
This fixes a bug where it was possible to add someone to a ballot but
not edit them after. Thanks to @sjorford for reporting