### PR TITLE
Remove /by-?/ from By election CTAS (temporary)

### DIFF
--- a/ynr/apps/elections/uk/templates/includes/by-election-ctas.html
+++ b/ynr/apps/elections/uk/templates/includes/by-election-ctas.html
@@ -1,7 +1,7 @@
 {% if SHOW_BY_ELECTION_CTA %}
-    <h2>By-elections</h2>
+    <h2>Elections</h2>
     {% if upcoming_ballots %}
-    <h3>Upcoming by-elections</h3>
+    <h3>Upcoming elections</h3>
 
     <table>
         <thead>


### PR DESCRIPTION
As of today, the list displayed under this heading at the url / is not even mostly of the type "by election posts".
(GE 2019).