### PR TITLE
Fix tests on Travis by making sure RabbitMQ is running 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,9 @@ python:
   - '3.6'
 addons:
   postgresql: "9.5"
+  apt:
+    packages:
+    - rabbitmq-server
 
 before_install:
   - sudo apt-get update && sudo apt install -y python3-tk ghostscript

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -58,3 +58,18 @@ Read up on how to install them, and then install the SOPN parsing requirements:
 ```
 pip install -r requirements/sopn_parsing.txt
 ```
+
+## (Optional) Run automated tests
+
+To run the test suite locally, run:
+
+```
+pytest
+```
+
+(Note that if the tests hang in `ynr/apps/bulk_adding/tests/test_bulk_add.py`
+that's likely due to you not having an AMQP broker listening on
+port 5672. One way of fixing this is to install RabbitMQ.)
+
+On Travis, the tests will be run on all supported Python version
+with `tox`.


### PR DESCRIPTION
When running on Travis, the tests were hanging in `ynr/apps/bulk_adding/tests/test_bulk_add.py` because of a call to `post_action_to_slack` - this function is decorated with Celery's `@shared_task`, which will hang, repeatedly trying to connect to port 5672, unless you have an AMQP broker listening there. The simplest way to fix this seems to be to make sure that RabbitMQ is running in the Travis environment, which is done in this commit by adding the RabbitMQ add-on, as suggested here:

  https://docs.travis-ci.com/user/database-setup/#rabbitmq

This PR also includes a commit to add a couple of notes to `doc/INSTALL.md` about running the tests locally, with a hint about what to do if you run into the same problem locally (as I did).