### PR TITLE
Set CELERY_TASK_ALWAYS_EAGER by default

### DIFF
--- a/ynr/settings/base.py
+++ b/ynr/settings/base.py
@@ -138,6 +138,11 @@ INSTALLED_APPS = (
 )
 
 CELERY_RESULT_BACKEND = "django-db"
+# Set ALWAYS_EAGER so that by default tasks blocking when running and
+# always return the value. This essentially disabled Celery unless it's enabled.
+# This is useful for testing and local development, and we enable it in
+# production
+CELERY_TASK_ALWAYS_EAGER = True
 
 MIDDLEWARE = (
     "debug_toolbar.middleware.DebugToolbarMiddleware",


### PR DESCRIPTION
Even though the docs recommend against this[1], setting `task_always_eager`[2]
by default means that local developers and Travis don't need celery working
in order to run the code and tests.

We can set this to False in prod, to make sure celery is actually run, but
it's still a reasonable default, as the only implication is that tasks end
up blocking on requests, but still get run.

1: https://docs.celeryproject.org/en/latest/userguide/testing.html
2: https://docs.celeryproject.org/en/latest/userguide/configuration.html#std:setting-task_always_eager