### PR TITLE
Make sure changes to other names appear in recent changes

### DIFF
--- a/ynr/apps/candidates/templates/candidates/frontpage.html
+++ b/ynr/apps/candidates/templates/candidates/frontpage.html
@@ -123,6 +123,15 @@
               User <strong>{{ username }}</strong>
               marked <a href="{{ person_url }}">{{ person_name }}</a> as the winner
               <span class="when">{{ when }} ago</span>
+            {% elif action.action_type == 'person-other-name-create' %}
+              User <strong>{{ username }}</strong>
+              added an alternate name for <a href="{{ person_url }}">{{ person_name }}</a>
+            {% elif action.action_type == 'person-other-name-delete' %}
+              User <strong>{{ username }}</strong>
+              removed an alternate name for <a href="{{ person_url }}">{{ person_name }}</a>
+            {% elif action.action_type == 'person-other-name-update' %}
+              User <strong>{{ username }}</strong>
+              changed an alternate name for <a href="{{ person_url }}">{{ person_name }}</a>
             {% else %}
               User <strong>{{ username }}</strong>
               updated <a href="{{ person_url }}">{{ person_name }}</a>

--- a/ynr/apps/candidates/views/other_names.py
+++ b/ynr/apps/candidates/views/other_names.py
@@ -6,11 +6,12 @@ from django.urls import reverse
 from django.utils.functional import cached_property
 from django.views.generic import CreateView, DeleteView, ListView, UpdateView
 
+from candidates.models import LoggedAction
 from people.forms import OtherNameForm
 from people.models import Person
 from popolo.models import OtherName
 
-from .version_data import get_change_metadata
+from .version_data import get_change_metadata, get_client_ip
 
 
 class PersonMixin(object):
@@ -69,6 +70,14 @@ class PersonOtherNameCreateView(LoginRequiredMixin, PersonMixin, CreateView):
             )
             self.person.record_version(change_metadata)
             self.person.save()
+            LoggedAction.objects.create(
+                user=self.request.user,
+                person=self.person,
+                action_type="person-other-name-create",
+                ip_address=get_client_ip(self.request),
+                popit_person_new_version=change_metadata["version_id"],
+                source=change_metadata["information_source"],
+            )
             """
             On the bulk edit page this view is inlined and the data
             sent over ajax so we have to return an ajax response, and
@@ -110,6 +119,14 @@ class PersonOtherNameDeleteView(LoginRequiredMixin, PersonMixin, DeleteView):
             )
             self.person.record_version(change_metadata)
             self.person.save()
+            LoggedAction.objects.create(
+                user=self.request.user,
+                person=self.person,
+                action_type="person-other-name-delete",
+                ip_address=get_client_ip(self.request),
+                popit_person_new_version=change_metadata["version_id"],
+                source=change_metadata["information_source"],
+            )
             return result_redirect
 
 
@@ -128,4 +145,12 @@ class PersonOtherNameUpdateView(LoginRequiredMixin, PersonMixin, UpdateView):
             )
             self.person.record_version(change_metadata)
             self.person.save()
+            LoggedAction.objects.create(
+                user=self.request.user,
+                person=self.person,
+                action_type="person-other-name-update",
+                ip_address=get_client_ip(self.request),
+                popit_person_new_version=change_metadata["version_id"],
+                source=change_metadata["information_source"],
+            )
             return result

--- a/ynr/apps/elections/uk/templates/candidates/finder.html
+++ b/ynr/apps/elections/uk/templates/candidates/finder.html
@@ -162,6 +162,12 @@
             {% elif action.action_type == 'suggest-ballot-lock' %}
               Suggested locking ballot
               <a href="{{ action.ballot.get_absolute_url }}">{{ action.ballot.ballot_paper_id }}</a>
+            {% elif action.action_type == 'person-other-name-create' %}
+              added an alternate name for <a href="{% url 'person-view' person_id=action.person.id %}">candidate #{{ action.person.id }}</a>
+            {% elif action.action_type == 'person-other-name-delete' %}
+              removed an alternate name for <a href="{% url 'person-view' person_id=action.person.id %}">candidate #{{ action.person.id }}</a>
+            {% elif action.action_type == 'person-other-name-update' %}
+              changed an alternate name for <a href="{% url 'person-view' person_id=action.person.id %}">candidate #{{ action.person.id }}</a>
             {% else %}
               {% if action.person %}
                 updated <a href="{% url 'person-view' person_id=action.person.id %}">candidate #{{ action.person.id }}</a>

--- a/ynr/apps/people/tests/test_other_names.py
+++ b/ynr/apps/people/tests/test_other_names.py
@@ -1,5 +1,6 @@
 from django_webtest import WebTest
 
+from candidates.models import LoggedAction
 from candidates.tests.auth import TestUserMixin
 from candidates.tests.uk_examples import UK2015ExamplesMixin
 from people.tests.factories import PersonFactory
@@ -65,6 +66,16 @@ class TestOtherNamesViews(TestUserMixin, UK2015ExamplesMixin, WebTest):
             self.person_other_names.other_names.get().name, "Mr Fozziewig"
         )
 
+        latest_logged_action = LoggedAction.objects.latest("updated")
+        self.assertEqual(
+            latest_logged_action.action_type, "person-other-name-delete"
+        )
+        self.assertEqual(latest_logged_action.person_id, 5678)
+        self.assertEqual(
+            latest_logged_action.source,
+            "Some good reasons for deleting this name",
+        )
+
     # Adding
 
     def test_add_other_name_get_not_authenticated(self):
@@ -116,6 +127,15 @@ class TestOtherNamesViews(TestUserMixin, UK2015ExamplesMixin, WebTest):
             submission_response.location, "/person/5678/other-names"
         )
         self.assertEqual(3, self.person_other_names.other_names.count())
+
+        latest_logged_action = LoggedAction.objects.latest("updated")
+        self.assertEqual(
+            latest_logged_action.action_type, "person-other-name-create"
+        )
+        self.assertEqual(latest_logged_action.person_id, 5678)
+        self.assertEqual(
+            latest_logged_action.source, "Some reasonable explanation"
+        )
 
     # Editing
 
@@ -179,6 +199,15 @@ class TestOtherNamesViews(TestUserMixin, UK2015ExamplesMixin, WebTest):
             submission_response.location, "/person/5678/other-names"
         )
         self.assertEqual(2, self.person_other_names.other_names.count())
+
+        latest_logged_action = LoggedAction.objects.latest("updated")
+        self.assertEqual(
+            latest_logged_action.action_type, "person-other-name-update"
+        )
+        self.assertEqual(latest_logged_action.person_id, 5678)
+        self.assertEqual(
+            latest_logged_action.source, "Some reasonable explanation"
+        )
 
     def test_other_names_on_update_page(self):
         response = self.app.get(


### PR DESCRIPTION
When a user made a change to the alternative names for a candidate, this wasn't being recorded in the candidates_loggedaction table, so they didn't appear in the site's list of recent changes.

(The creation of LoggedAction objects throughout the codebase is quite repetitive, and could be refactored to be much less verbose, but it didn't seem worth doing that for this particular change.)

Fixes #1024