### PR TITLE
Various fixes for the "Title Case" button

### DIFF
--- a/ynr/apps/candidates/static/js/person_form.js
+++ b/ynr/apps/candidates/static/js/person_form.js
@@ -296,6 +296,9 @@ $(document).ready(function() {
       /* Now enable the "add an extra election" button if it's present */
       $('#add_election_button').on('click', showElectionsForm);
       $('.add_more_elections_field').hide();
+      /* Check for the common name form like "SMITH Ali" found on
+         SOPNs and suggest changing it to "Ali Smith" in any name
+         fields */
       $('[name=name]').on('paste keyup', checkNameFormat);
       $('[name*=-name]').on('paste keyup', checkNameFormat);
   });

--- a/ynr/apps/candidates/static/js/person_form.js
+++ b/ynr/apps/candidates/static/js/person_form.js
@@ -243,8 +243,17 @@ function showElectionsForm() {
   });
 }
 
+/* This title-casing function should uppercase any letter after a word
+   boundary, and lowercases any letters up to the next word boundary:
+
+     toTitleCase("john travolta") => "John Travolta"
+     toTitleCase("olivia newton-john") => "Olivia Newton-John"
+     toTitleCase("miles o'brien") => "Miles O'Brien"
+     toTitleCase("miles o’brien") => "Miles O’Brien"
+     toTitleCase("BENJAMIN SISKO") => "Benjamin Sisko"
+*/
 function toTitleCase(str) {
-    return str.replace(/\w\S*/g, function(txt){return txt.charAt(0).toUpperCase() + txt.substr(1).toLowerCase();});
+    return str.replace(/\b(\w)(.*?)\b/g, function (_, first, rest) { return first.toUpperCase() + rest.toLowerCase() })
 }
 
 function compressWhitespace(str) {

--- a/ynr/apps/candidates/static/js/person_form.js
+++ b/ynr/apps/candidates/static/js/person_form.js
@@ -247,6 +247,10 @@ function toTitleCase(str) {
     return str.replace(/\w\S*/g, function(txt){return txt.charAt(0).toUpperCase() + txt.substr(1).toLowerCase();});
 }
 
+function compressWhitespace(str) {
+    return str.replace(/\s\s+/g, ' ');
+}
+
 suggest_correction = function(el, suggestion) {
 
     suggestion_el = $('<a class="suggested">Change to <span>' + suggestion + '</span>?</a>');
@@ -270,6 +274,16 @@ function checkNameFormat(e) {
         var name = name_parts.join(' ') + ' ' + toTitleCase(last_name);
         suggest_correction(e.target, name);
     }
+}
+
+function addTitleCaseButton() {
+    var b = $('<button type="button" class="button tiny secondary">Title Case</botton>');
+    b.on('click', function() {
+        var name_val = $('#id_name').val();
+        $('#id_name').val(compressWhitespace(toTitleCase(name_val)));
+        return false;
+    });
+    $('#id_name').after(b);
 }
 
 $(document).ready(function() {

--- a/ynr/apps/candidates/templates/candidates/person-edit.html
+++ b/ynr/apps/candidates/templates/candidates/person-edit.html
@@ -84,7 +84,7 @@
         str = str.replace(/\s\s+/g, ' ');
         return str;
     }
-    b = $('<button class="button tiny secondary">Title Case</botton>');
+    b = $('<button type="button" class="button tiny secondary">Title Case</botton>');
     b.on('click', function() {
             var name_val = $('#id_name').val();
             $('#id_name').val(toTitleCase(name_val));

--- a/ynr/apps/candidates/templates/candidates/person-edit.html
+++ b/ynr/apps/candidates/templates/candidates/person-edit.html
@@ -78,20 +78,7 @@
 
 {% if user_can_merge %}
 <script>
-    function toTitleCase(str)
-    {
-        str = str.replace(/\w\S*/g, function(txt){return txt.charAt(0).toUpperCase() + txt.substr(1).toLowerCase();});
-        str = str.replace(/\s\s+/g, ' ');
-        return str;
-    }
-    b = $('<button type="button" class="button tiny secondary">Title Case</botton>');
-    b.on('click', function() {
-            var name_val = $('#id_name').val();
-            $('#id_name').val(toTitleCase(name_val));
-            return false;
-    });
-    $('#id_name').after(b);
-
+    addTitleCaseButton();
 </script>
 {% endif %}
 


### PR DESCRIPTION
As @sjorford points out in #1042 there are various problems with the title-case buttons, which this PR should address:
* It fixes "Enter" anywhere in the person edit form title-casing the name
* It fixes the title-casing of hyphenated names, and names containing apostrophes
It also removes some duplication of code, since there were two `toTitleCase` JavaScript functions previously.