### PR TITLE
Fix the "Upload SOPN" link on the ballot paper view

### DIFF
--- a/ynr/apps/elections/templates/elections/includes/_ballot_sopn_links.html
+++ b/ynr/apps/elections/templates/elections/includes/_ballot_sopn_links.html
@@ -4,7 +4,7 @@
   </p>
 {% else %}
   {% if user_can_upload_documents %}
-    {% url 'upload_document_view' election=election post_id=post_data.extra.slug as url %}
+    {% url 'upload_document_view' election=ballot.election.slug post_id=ballot.post.slug as url %}
     <a href="{{ url }}" class="button">Upload SOPN</a>
   {% endif %}
 {% endif %}

--- a/ynr/apps/elections/tests/test_ballot_view.py
+++ b/ynr/apps/elections/tests/test_ballot_view.py
@@ -109,8 +109,8 @@ class TestBallotView(
         self.assertInHTML(
             """
             <p>
-                These candidates haven't been confirmed by the official 
-                "nomination papers" from the council yet. This means they might 
+                These candidates haven't been confirmed by the official
+                "nomination papers" from the council yet. This means they might
                 not all end up on the ballot paper.
             </p>
             """,

--- a/ynr/apps/elections/tests/test_ballot_view.py
+++ b/ynr/apps/elections/tests/test_ballot_view.py
@@ -98,6 +98,17 @@ class TestBallotView(
 
         self.assertDataTimelineCandidateAddingInProgress(response)
 
+    def test_ballot_sopn_upload_link(self):
+        self.create_memberships(self.ballot, self.parties)
+        response = self.app.get(
+            self.ballot.get_absolute_url(),
+            user=self.user_who_can_upload_documents,
+        )
+        self.assertContains(
+            response,
+            '<a href="/upload_document/upload/election/sp.2019-11-25/post/bar-ward/" class="button">Upload SOPN</a>',
+        )
+
     def test_ballot_with_candidates_no_sopn(self):
 
         self.create_memberships(self.ballot, self.parties)


### PR DESCRIPTION
The `{% url ... as url %}` template tag was being passed bad parameters, so the "Upload SOPN" link didn't work.