### PR TITLE
Fix revert_person_from_version_data's handling of biscuits :)

### DIFF
--- a/ynr/apps/candidates/models/versions.py
+++ b/ynr/apps/candidates/models/versions.py
@@ -133,6 +133,10 @@ def revert_person_from_version_data(person, version_data):
         else:
             setattr(person, field.name, "")
 
+    person.favourite_biscuit = version_data.get("extra_fields", {}).get(
+        "favourite_biscuits"
+    )
+
     # Remove old PersonIdentifier objects
     from people.models import PersonIdentifier
 


### PR DESCRIPTION
The person.favourite_biscuit field is serialized to extra_fields.favourite_biscuits (note the plural, for consistency with old version data), but revert_person_from_version_data wasn't setting person.favourite_biscuit back from the version data. This commit fixes that, so reverting someone to an earlier version also reverts the data about their favourite biscuits.

Fixes #940 🍪