### PR TITLE
make ALWAYS_ALLOW_RESULT_RECORDING setting optional

### DIFF
--- a/ynr/context_processors.py
+++ b/ynr/context_processors.py
@@ -84,7 +84,7 @@ def add_group_permissions(request):
     }
     result["user_can_edit"] = settings.EDITS_ALLOWED or request.user.is_staff
     if (
-        settings.ALWAYS_ALLOW_RESULT_RECORDING
+        getattr(settings, "ALWAYS_ALLOW_RESULT_RECORDING", False)
         and request.user.is_authenticated
         and request.user.loggedaction_set.count() > 10
     ):


### PR DESCRIPTION
Starting the application without this explicitly set throws `'Settings' object has no attribute 'ALWAYS_ALLOW_RESULT_RECORDING'` but based on https://github.com/DemocracyClub/yournextrepresentative/blob/980fedf15c4f045c0f97cc792606f9168fe68097/ynr/apps/candidates/views/constituencies.py#L29 it looks like the intent was that this setting should be optional.