### PR TITLE
Remove need for migrations in tests

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -79,7 +79,7 @@ raven==6.10.0
 requests-oauthlib==1.2.0
 requests==2.22.0
 simplegeneric==0.8.1
-six==1.12.0
+six==1.14.0
 git+https://github.com/symroe/slacker.git
 sorl-thumbnail==12.5.0
 sqlparse==0.3.0

--- a/ynr/apps/api/tests/test_api_next.py
+++ b/ynr/apps/api/tests/test_api_next.py
@@ -8,11 +8,18 @@ from candidates.tests.uk_examples import UK2015ExamplesMixin
 from moderation_queue.tests.paths import EXAMPLE_IMAGE_FILENAME
 from official_documents.models import OfficialDocument
 from parties.tests.factories import PartyDescriptionFactory, PartyEmblemFactory
+from parties.tests.fixtures import DefaultPartyFixtures
 from people.models import PersonImage
 from people.tests.factories import PersonFactory
 
 
-class TestAPI(TmpMediaRootMixin, TestUserMixin, UK2015ExamplesMixin, WebTest):
+class TestAPI(
+    DefaultPartyFixtures,
+    TmpMediaRootMixin,
+    TestUserMixin,
+    UK2015ExamplesMixin,
+    WebTest,
+):
     def setUp(self):
         super().setUp()
         self.storage = DefaultStorage()

--- a/ynr/apps/candidates/tests/auth.py
+++ b/ynr/apps/candidates/tests/auth.py
@@ -15,6 +15,7 @@ class TestUserMixin(object):
         super(TestUserMixin, cls).setUpTestData()
         cls.users_to_delete = []
         for username, attr, group_names in (
+            ("TwitterBot", "user", []),
             ("john", "user", []),
             ("alice", "user_who_can_merge", [TRUSTED_TO_MERGE_GROUP_NAME]),
             ("charles", "user_who_can_lock", [TRUSTED_TO_LOCK_GROUP_NAME]),
@@ -41,7 +42,7 @@ class TestUserMixin(object):
             terms.assigned_to_dc = True
             terms.save()
             for group_name in group_names:
-                group = Group.objects.get(name=group_name)
+                group, _ = Group.objects.get_or_create(name=group_name)
                 group.user_set.add(u)
             setattr(cls, attr, u)
             cls.users_to_delete.append(u)

--- a/ynr/apps/candidates/tests/uk_examples.py
+++ b/ynr/apps/candidates/tests/uk_examples.py
@@ -55,6 +55,7 @@ class UK2015ExamplesMixin(object, metaclass=ABCMeta):
     @classmethod
     def setUpTestData(cls):
         super(UK2015ExamplesMixin, cls).setUpTestData()
+
         cls.gb_parties = factories.PartySetFactory.create(
             slug="gb", name="Great Britain"
         )

--- a/ynr/apps/moderation_queue/tests/test_queue.py
+++ b/ynr/apps/moderation_queue/tests/test_queue.py
@@ -85,9 +85,8 @@ class PhotoReviewTests(UK2015ExamplesMixin, WebTest):
         )
         self.test_reviewer.terms_agreement.assigned_to_dc = True
         self.test_reviewer.terms_agreement.save()
-        self.test_reviewer.groups.add(
-            Group.objects.get(name=PHOTO_REVIEWERS_GROUP_NAME)
-        )
+        group, _ = Group.objects.get_or_create(name=PHOTO_REVIEWERS_GROUP_NAME)
+        self.test_reviewer.groups.add(group)
         self.q1 = QueuedImage.objects.create(
             why_allowed="public-domain",
             justification_for_use="It's their Twitter avatar",

--- a/ynr/apps/parties/tests/fixtures.py
+++ b/ynr/apps/parties/tests/fixtures.py
@@ -1,0 +1,20 @@
+from parties.models import Party
+
+
+class DefaultPartyFixtures:
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+
+        Party.objects.update_or_create(
+            ec_id="ynmp-party:12522",
+            legacy_slug="ynmp-party:12522",
+            defaults={
+                "name": "Speaker seeking re-election",
+                "date_registered": "1376-04-28",
+            },
+        )
+        Party.objects.update_or_create(
+            ec_id="ynmp-party:2",
+            defaults={"name": "Independent", "date_registered": "1832-06-07"},
+        )

--- a/ynr/apps/parties/tests/test_importer.py
+++ b/ynr/apps/parties/tests/test_importer.py
@@ -17,6 +17,7 @@ from moderation_queue.tests.paths import (
 from parties.importer import ECParty, ECPartyImporter
 from parties.management.commands.parties_import_from_ec import Command
 from parties.models import Party, PartyDescription, PartyEmblem
+from parties.tests.fixtures import DefaultPartyFixtures
 
 from .factories import PartyDescriptionFactory, PartyFactory
 
@@ -57,7 +58,7 @@ def make_tmp_file_from_source(source):
             return ntf.name
 
 
-class TestECPartyImporter(TmpMediaRootMixin, TestCase):
+class TestECPartyImporter(DefaultPartyFixtures, TmpMediaRootMixin, TestCase):
     def setUp(self):
         super().setUp()
         self.storage = DefaultStorage()

--- a/ynr/apps/parties/tests/test_managers.py
+++ b/ynr/apps/parties/tests/test_managers.py
@@ -8,6 +8,7 @@ from django.test import TestCase
 from django.utils import timezone
 
 from parties.models import Party
+from parties.tests.fixtures import DefaultPartyFixtures
 
 from .factories import PartyFactory
 
@@ -21,7 +22,7 @@ PARTY_DATES = (
 )
 
 
-class TestPartyManager(TestCase):
+class TestPartyManager(DefaultPartyFixtures, TestCase):
     def setUp(self):
         PartyFactory.reset_sequence()
         for party_date in PARTY_DATES:

--- a/ynr/apps/parties/tests/test_party_choices.py
+++ b/ynr/apps/parties/tests/test_party_choices.py
@@ -3,11 +3,14 @@ from django_webtest import WebTest
 from candidates.tests.auth import TestUserMixin
 from candidates.tests.uk_examples import UK2015ExamplesMixin
 from parties.models import Party
+from parties.tests.fixtures import DefaultPartyFixtures
 
 from .factories import PartyDescriptionFactory
 
 
-class TestPartyChoices(TestUserMixin, UK2015ExamplesMixin, WebTest):
+class TestPartyChoices(
+    DefaultPartyFixtures, TestUserMixin, UK2015ExamplesMixin, WebTest
+):
     def test_hardly_any_candidates_at_all(self):
         party_choices = Party.objects.register("GB").party_choices()
         self.assertEqual(

--- a/ynr/apps/sopn_parsing/tests/test_parse_tables.py
+++ b/ynr/apps/sopn_parsing/tests/test_parse_tables.py
@@ -7,10 +7,11 @@ from bulk_adding.models import RawPeople
 from candidates.tests.uk_examples import UK2015ExamplesMixin
 from official_documents.models import OfficialDocument
 from parties.tests.factories import PartyFactory
+from parties.tests.fixtures import DefaultPartyFixtures
 from sopn_parsing.models import ParsedSOPN
 
 
-class TestSOPNHelpers(UK2015ExamplesMixin, TestCase):
+class TestSOPNHelpers(DefaultPartyFixtures, UK2015ExamplesMixin, TestCase):
     def setUp(self):
         PartyFactory(ec_id="PP85", name="UK Independence Party (UKIP)")
 

--- a/ynr/settings/testing.py
+++ b/ynr/settings/testing.py
@@ -5,6 +5,17 @@ from .base import *  # noqa
 DATABASES["default"]["CONN_MAX_AGE"] = 0  # noqa
 SITE_NAME = "example.com"
 
+
+class DisableMigrations(object):
+    def __contains__(self, item):
+        return True
+
+    def __getitem__(self, item):
+        return None
+
+
+MIGRATION_MODULES = DisableMigrations()
+
 CACHES = {"default": {"BACKEND": "django.core.cache.backends.dummy.DummyCache"}}
 
 


### PR DESCRIPTION
This is a yak shave that I've wanted to do for a while – we have so many
migrations that running tests without a cached database takes forever.

This stops migrations being run at all in tests.

The implications of this are that we can't use data migrations to set up
test fixtures or things like, that, but I expect this is a good idea in
general.