### PR TITLE
Stop edits of cancelled elections

### DIFF
--- a/ynr/apps/candidates/forms.py
+++ b/ynr/apps/candidates/forms.py
@@ -53,6 +53,7 @@ class SingleElectionForm(AddElectionFieldsMixin, forms.Form):
         super().__init__(*args, **kwargs)
 
         election_data = kwargs["initial"]["election"]
+        user = kwargs["initial"]["user"]
 
         self.fields["extra_election_id"] = forms.CharField(
             max_length=256,
@@ -60,4 +61,4 @@ class SingleElectionForm(AddElectionFieldsMixin, forms.Form):
             initial=election_data.slug,
         )
 
-        self.add_election_fields(election_data)
+        self.add_election_fields(election_data, user=user)

--- a/ynr/apps/candidates/models/popolo_extra.py
+++ b/ynr/apps/candidates/models/popolo_extra.py
@@ -254,14 +254,20 @@ class Ballot(models.Model):
         if not user.is_authenticated:
             return False
 
-        # If the ballot is unlocked, anyone can edit the memberships
-        if not self.candidates_locked:
+        # If the ballot is unlocked and not cancelled, anyone
+        # can edit the memberships
+        if not self.candidates_locked and not self.cancelled:
             return True
 
         if (
             allow_if_trusted_to_lock
             and user.groups.filter(name=TRUSTED_TO_LOCK_GROUP_NAME).exists()
         ):
+            return True
+
+        # Special case where elections are cancelled before they are locked
+        # Don't allow most people to edit them, but do allow staff to
+        if self.cancelled and not self.candidates_locked and user.is_staff:
             return True
 
         return False

--- a/ynr/apps/candidates/models/popolo_extra.py
+++ b/ynr/apps/candidates/models/popolo_extra.py
@@ -159,18 +159,32 @@ class Ballot(models.Model):
         self.delete()
 
     @property
+    def cancelled_status_text(self):
+        if self.cancelled:
+            return "(❌ cancelled)"
+
+    @property
     def cancelled_status_html(self):
         if self.cancelled:
             return mark_safe(
-                '<abbr title="The poll for this election was cancelled">(❌ cancelled)</abbr>'
+                '<abbr title="The poll for this election was cancelled">{}</abbr>'.format(
+                    self.cancelled_status_text
+                )
             )
         return ""
+
+    @property
+    def locked_status_text(self):
+        if self.candidates_locked:
+            return mark_safe("🔐")
 
     @property
     def locked_status_html(self):
         if self.candidates_locked:
             return mark_safe(
-                '<abbr title="Candidates verified and post locked">🔐</abbr>'
+                '<abbr title="Candidates verified and post locked">{}</abbr>'.format(
+                    self.locked_status_text
+                )
             )
         if self.has_lock_suggestion:
             self.suggested_lock_html

--- a/ynr/apps/candidates/views/people.py
+++ b/ynr/apps/candidates/views/people.py
@@ -550,4 +550,5 @@ class SingleElectionFormView(LoginRequiredMixin, FormView):
             Election.objects.all(), slug=self.kwargs["election"]
         )
         initial_data["election"] = election
+        initial_data["user"] = self.request.user
         return initial_data

--- a/ynr/apps/utils/widgets.py
+++ b/ynr/apps/utils/widgets.py
@@ -1,0 +1,27 @@
+"""
+For storing custom Django form widgets
+"""
+from django.forms.widgets import Select
+
+
+class SelectWithAttrs(Select):
+    """
+    Subclass of Django's select widget that allows passing attrs to each item
+
+    For example, to diable a single option, pass:
+
+    choices=[(value, {'label': 'option label', 'disabled': True})]
+    """
+
+    def create_option(
+        self, name, value, label, selected, index, subindex=None, attrs=None
+    ):
+        if type(label) == dict:
+            label_text = label.pop("label")
+        else:
+            label_text = label
+        option = super().create_option(
+            name, value, label_text, selected, index, subindex=None, attrs=None
+        )
+        option["attrs"].update(label)
+        return option


### PR DESCRIPTION
I did a bit more than planned - basuically this allows disabling select options when selecting ballots on the person forms.

This is useful for preventing edits of candidacies for locked and cancelled elections.

At the moment, I've just given "staff" the ability to edit candidacies for cancelled elections that aren't locked. We don't really have a use case for this, but without allowing _someone_ to do this, it would be impossible to edit them without a direct DB edit, and if we know one thing it's that there will be an odd reason to perform an edit in this situation.

I could pull this out in to a permission group, but I don't think we really need it at the moment.