### PR TITLE
Skip more sopn_parsing tests locally

### DIFF
--- a/ynr/apps/sopn_parsing/helpers/extract_tables.py
+++ b/ynr/apps/sopn_parsing/helpers/extract_tables.py
@@ -1,7 +1,5 @@
 import json
 
-import camelot
-
 from sopn_parsing.helpers.text_helpers import NoTextInDocumentError, clean_text
 from sopn_parsing.models import ParsedSOPN
 
@@ -14,6 +12,8 @@ def extract_ballot_table(ballot, parse_flavor="lattice"):
     :type ballot: candidates.models.Ballot
 
     """
+    import camelot  # import here to avoid import error running tests without pdf deps installed
+
     document = ballot.sopn
     if not document.relevant_pages:
         raise ValueError(

--- a/ynr/apps/sopn_parsing/tests/test_extract_page_numbers.py
+++ b/ynr/apps/sopn_parsing/tests/test_extract_page_numbers.py
@@ -12,8 +12,8 @@ from popolo.models import Post
 from sopn_parsing.tests import should_skip_pdf_tests
 
 
+@skipIf(should_skip_pdf_tests(), "Required PDF libs not installed")
 class TestSOPNHelpers(UK2015ExamplesMixin, TestCase):
-    @skipIf(should_skip_pdf_tests(), "Required PDF libs not installed")
     def test_extract_pages_management_command(self):
         example_doc_path = abspath(
             join(

--- a/ynr/apps/sopn_parsing/tests/test_extract_tables.py
+++ b/ynr/apps/sopn_parsing/tests/test_extract_tables.py
@@ -168,6 +168,7 @@ class TestSOPNHelpers(TmpMediaRootMixin, UK2015ExamplesMixin, TestCase):
             },
         )
 
+    @skipIf(should_skip_pdf_tests(), "Required PDF libs not installed")
     def test_extract_command_current(self):
         self.assertEqual(ParsedSOPN.objects.count(), 0)
         call_command("sopn_parsing_extract_tables", current=True)

--- a/ynr/apps/sopn_parsing/tests/test_parse_tables.py
+++ b/ynr/apps/sopn_parsing/tests/test_parse_tables.py
@@ -9,12 +9,16 @@ from official_documents.models import OfficialDocument
 from parties.tests.factories import PartyFactory
 from parties.tests.fixtures import DefaultPartyFixtures
 from sopn_parsing.models import ParsedSOPN
+from unittest import skipIf
+
+from sopn_parsing.tests import should_skip_pdf_tests
 
 
 class TestSOPNHelpers(DefaultPartyFixtures, UK2015ExamplesMixin, TestCase):
     def setUp(self):
         PartyFactory(ec_id="PP85", name="UK Independence Party (UKIP)")
 
+    @skipIf(should_skip_pdf_tests(), "Required PDF libs not installed")
     def test_basic_parsing(self):
         self.assertFalse(RawPeople.objects.exists())
         doc = OfficialDocument.objects.create(

--- a/ynr/apps/sopn_parsing/tests/test_sopn_helpers.py
+++ b/ynr/apps/sopn_parsing/tests/test_sopn_helpers.py
@@ -1,8 +1,10 @@
 from os.path import abspath, dirname, join
 
 from django.test import TestCase
+from unittest import skipIf
 
 from sopn_parsing.helpers.text_helpers import clean_text
+from sopn_parsing.tests import should_skip_pdf_tests
 
 try:
     from sopn_parsing.helpers.pdf_helpers import SOPNDocument
@@ -15,6 +17,7 @@ class TestSOPNHelpers(TestCase):
         text = "\n C andidates (Namés)"
         self.assertEqual(clean_text(text), "candidates")
 
+    @skipIf(should_skip_pdf_tests(), "Required PDF libs not installed")
     def test_sopn_document(self):
         example_doc_path = abspath(
             join(dirname(__file__), "data/sopn-berkeley-vale.pdf")
@@ -77,6 +80,7 @@ class TestSOPNHelpers(TestCase):
             doc.get_pages_by_ward_name("berkeley")[0].page_number, 1
         )
 
+    @skipIf(should_skip_pdf_tests(), "Required PDF libs not installed")
     def test_multipage_doc(self):
         example_doc_path = abspath(
             join(dirname(__file__), "data/NI-Assembly-Election-2016.pdf")


### PR DESCRIPTION
- Update skip tests logic to exclude more tests that fail when running
locally if PDF parsing requirements are not installed

Extends existing logic to skip soon parsing tests when PDF parsing libs are not installed. Tested by building a fresh virtual env and only installing from `requirements/base.txt`