### PR TITLE
Feature/parse split names

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -70,6 +70,7 @@ pytest-flakes==4.0.1
 pytest-pep8==1.0.6
 python-dateutil==2.8.1
 pytest-black==0.3.10
+pytest-subtests<1.0
 python-magic==0.4.6
 python-memcached==1.59
 python-openid==2.2.5

--- a/ynr/apps/sopn_parsing/helpers/parse_tables.py
+++ b/ynr/apps/sopn_parsing/helpers/parse_tables.py
@@ -99,13 +99,17 @@ def guess_description_field(row):
 
 def clean_name(name):
     name = name.replace("\n", "")
-    return re.sub(r"([A-Z\-]+)\s([A-Za-z\-\s]+)", r"\g<2> \g<1>", name).title()
+    name = name.replace("`", "'")
+    return re.sub(
+        r"([A-Z\-\']+)\s([A-Za-z\-\s]+)", r"\g<2> \g<1>", name
+    ).title()
 
 
 def clean_description(description):
     description = str(description)
     description = description.replace("\\n", "")
     description = description.replace("\n", "")
+    description = description.replace("`", "'")
     description = re.sub(r"\s+", " ", description)
     return description
 

--- a/ynr/apps/sopn_parsing/helpers/parse_tables.py
+++ b/ynr/apps/sopn_parsing/helpers/parse_tables.py
@@ -9,18 +9,19 @@ from bulk_adding.models import RawPeople
 from parties.models import Party, PartyDescription
 from sopn_parsing.helpers.text_helpers import clean_text
 
-NAME_FIELDS = (
-    "name of candidate",
-    "names of candidate",
-    "candidate name",
+FIRST_NAME_FIELDS = ["other name", "other names", "candidate forename"]
+LAST_NAME_FIELDS = [
     "surname",
-    "candidates surname",
-    "other name",
     "candidate surname",
-    "candidate forename",
-    "other names",
+    "candidates surname",
     "last name",
+]
+NAME_FIELDS = (
+    FIRST_NAME_FIELDS
+    + LAST_NAME_FIELDS
+    + ["name of candidate", "names of candidate", "candidate name"]
 )
+
 
 INDEPENDENT_VALUES = ("Independent", "")
 
@@ -61,18 +62,15 @@ def looks_like_header(row, avg_row):
 
 def order_name_fields(name_fields):
     """
-    Takes a list of name fields and attempts to reorder them so that the
-    'surname' field is last in the returned list
+    Takes a list of name fields and attempts to find a field with in the
+    LAST_NAME_FIELDS and move to the end of the list
     """
-    last = None
     for index, field in enumerate(name_fields):
-        if "surname" in field or "last" in field:
-            last = index
+        if field in LAST_NAME_FIELDS:
+            # found the fieldname we think is for the last name,
+            # so move that to the end of our name fields
+            name_fields.append(name_fields.pop(index))
             break
-
-    if last is not None:
-        # move value at stored index to the end of the list
-        name_fields.append(name_fields.pop(last))
 
     return name_fields
 

--- a/ynr/apps/sopn_parsing/helpers/parse_tables.py
+++ b/ynr/apps/sopn_parsing/helpers/parse_tables.py
@@ -96,11 +96,19 @@ def guess_description_field(row):
 
 
 def clean_name(name):
+    """
+    - Strips some special characters from the name string
+    - Splits the string in to a list, removing any empty strings
+    - Build a string to represent the last name by looking for all words that are in all caps
+    - Build a string to represent the other names by looking for all words not in all caps
+    - Strip whitespace in case last_names is empty and return string titleized
+    """
     name = name.replace("\n", "")
     name = name.replace("`", "'")
-    return re.sub(
-        r"([A-Z\-\']+)\s([A-Za-z\-\s]+)", r"\g<2> \g<1>", name
-    ).title()
+    names = list(filter(None, name.split(" ")))
+    last_names = " ".join([name for name in names if name.isupper()])
+    first_names = " ".join([name for name in names if not name.isupper()])
+    return f"{first_names} {last_names}".strip().title()
 
 
 def clean_description(description):

--- a/ynr/apps/sopn_parsing/tests/test_parse_tables.py
+++ b/ynr/apps/sopn_parsing/tests/test_parse_tables.py
@@ -249,3 +249,32 @@ class TestParseTablesUnitTests(TestCase):
                 result = parse_tables.order_name_fields(name_fields)
                 assert result == case["ordered_name_fields"]
 
+    def test_clean_name_replaces_backticks(self):
+        name = parse_tables.clean_name("D`SOUZA")
+        assert "`" not in name
+        assert "'" in name
+
+    def test_clean_name_replaces_newlines(self):
+        name = parse_tables.clean_name(
+            "A Very Long Name That Splits \nOver Lines"
+        )
+        assert "\n" not in name
+
+    def test_clean_name_capitalized_last_and_titalized(self):
+        name = parse_tables.clean_name("SMITH John")
+        assert name == "John Smith"
+
+    def test_clean_description_removes_newlines(self):
+        cleaned_description = parse_tables.clean_description(
+            "A Long Description That Splits \nOver \\nLines"
+        )
+        assert "\n" not in cleaned_description
+        assert "\\n" not in cleaned_description
+
+    def test_clean_description_replaces_backticks(self):
+        cleaned_description = parse_tables.clean_description(
+            "All People`s Party"
+        )
+        assert "`" not in cleaned_description
+        assert "'" in cleaned_description
+        assert cleaned_description == "All People's Party"

--- a/ynr/apps/sopn_parsing/tests/test_parse_tables.py
+++ b/ynr/apps/sopn_parsing/tests/test_parse_tables.py
@@ -264,6 +264,22 @@ class TestParseTablesUnitTests(TestCase):
         name = parse_tables.clean_name("SMITH John")
         assert name == "John Smith"
 
+    def test_clean_name_two_word_surnames(self):
+        names = [
+            ("EDE COOPER \nPalmer", "Palmer Ede Cooper"),
+            ("VAN DULKEN \nRichard Michael", "Richard Michael Van Dulken"),
+            ("ARMSTRONG LILLEY \nLynne", "Lynne Armstrong Lilley"),
+            (
+                " D`SOUZA  Aaron Anthony Jose \nHasan",
+                "Aaron Anthony Jose Hasan D'Souza",
+            ),
+            ("Michael James Collins", "Michael James Collins"),
+            ("   Michael    James    Collins   ", "Michael James Collins"),
+        ]
+        for name in names:
+            with self.subTest(name=names[0]):
+                assert parse_tables.clean_name(name[0]) == name[1]
+
     def test_clean_description_removes_newlines(self):
         cleaned_description = parse_tables.clean_description(
             "A Long Description That Splits \nOver \\nLines"

--- a/ynr/apps/sopn_parsing/tests/test_parse_tables.py
+++ b/ynr/apps/sopn_parsing/tests/test_parse_tables.py
@@ -9,7 +9,9 @@ from official_documents.models import OfficialDocument
 from parties.tests.factories import PartyFactory
 from parties.tests.fixtures import DefaultPartyFixtures
 from sopn_parsing.models import ParsedSOPN
+from sopn_parsing.helpers import parse_tables
 from unittest import skipIf
+from pandas import Index, Series
 
 from sopn_parsing.tests import should_skip_pdf_tests
 
@@ -81,3 +83,169 @@ class TestSOPNHelpers(DefaultPartyFixtures, UK2015ExamplesMixin, TestCase):
                 {"name": "Melanie Jenner", "party_id": "PP53"},
             ],
         )
+
+
+class TestParseTablesUnitTests(TestCase):
+    def get_two_name_field_cases(self):
+        # this could be updated with more combinations as we come across them
+        return [
+            {
+                "name_fields": ["candidate surname", "candidate forename"],
+                "row": {
+                    "candidate surname": "BAGSHAW",
+                    "candidate forename": "Elaine Sheila",
+                    "home address": "1 Foo Street \n London \nE14 6FW",
+                    "description": "London Liberal \nDemocrats",
+                    "reason why no longer nominated": "",
+                },
+                "ordered_name_fields": [
+                    "candidate forename",
+                    "candidate surname",
+                ],
+                "expected_name": "BAGSHAW Elaine Sheila",
+            },
+            {
+                "name_fields": ["surname", "other names"],
+                "row": {
+                    "surname": "BAGSHAW",
+                    "other names": "Elaine Sheila",
+                    "home address": "1 Foo Street \nLondon \nE14 6FW",
+                    "description": "London Liberal \nDemocrats",
+                    "reason why no longer nominated": "",
+                },
+                "ordered_name_fields": ["other names", "surname"],
+                "expected_name": "BAGSHAW Elaine Sheila",
+            },
+            {
+                "name_fields": ["last name", "other names"],
+                "row": {
+                    "last name": "BAGSHAW",
+                    "other names": "Elaine Sheila",
+                    "home address": "1 Foo Street \nLondon \nE14 6FW",
+                    "description": "London Liberal \nDemocrats",
+                    "reason why no longer nominated": "",
+                },
+                "ordered_name_fields": ["other names", "last name"],
+                "expected_name": "BAGSHAW Elaine Sheila",
+            },
+            {
+                "name_fields": ["candidate forename", "candidate surname"],
+                "row": {
+                    "candidate forename": "Elaine Sheila",
+                    "candidate surname": "BAGSHAW",
+                    "home address": "1 Foo Street \n London \nE14 6FW",
+                    "description": "London Liberal \nDemocrats",
+                    "reason why no longer nominated": "",
+                },
+                "ordered_name_fields": [
+                    "candidate forename",
+                    "candidate surname",
+                ],
+                "expected_name": "Elaine Sheila BAGSHAW",
+            },
+        ]
+
+    def get_single_name_field_cases(self):
+        return [
+            {
+                "name_fields": ["name of candidate"],
+                "row": {
+                    "name of candidate": "BAGSHAW Elaine Sheila",
+                    "home address": "1 Foo Street \n London \nE14 6FW",
+                    "description": "London Liberal \nDemocrats",
+                    "reason why no longer nominated": "",
+                },
+            },
+            {
+                "name_fields": ["names of candidate"],
+                "row": {
+                    "names of candidate": "BAGSHAW Elaine Sheila",
+                    "home address": "1 Foo Street \nLondon \nE14 6FW",
+                    "description": "London Liberal \nDemocrats",
+                    "reason why no longer nominated": "",
+                },
+            },
+            {
+                "name_fields": ["candidate name"],
+                "row": {
+                    "candidate name": "BAGSHAW Elaine Sheila",
+                    "home address": "1 Foo Street \nLondon \nE14 6FW",
+                    "description": "London Liberal \nDemocrats",
+                    "reason why no longer nominated": "",
+                },
+            },
+            {
+                "name_fields": ["surname"],
+                "row": {
+                    "surname": "BAGSHAW Elaine Sheila",
+                    "home address": "1 Foo Street \nLondon \nE14 6FW",
+                    "description": "London Liberal \nDemocrats",
+                    "reason why no longer nominated": "",
+                },
+            },
+            {
+                "name_fields": ["candidates surname"],
+                "row": {
+                    "candidates surname": "BAGSHAW Elaine Sheila",
+                    "home address": "1 Foo Street \nLondon \nE14 6FW",
+                    "description": "London Liberal \nDemocrats",
+                    "reason why no longer nominated": "",
+                },
+            },
+            {
+                "name_fields": ["other name"],
+                "row": {
+                    "other name": "BAGSHAW Elaine Sheila",
+                    "home address": "1 Foo Street \nLondon \nE14 6FW",
+                    "description": "London Liberal \nDemocrats",
+                    "reason why no longer nominated": "",
+                },
+            },
+        ]
+
+    def test_get_name_single_field(self):
+        for case in self.get_single_name_field_cases():
+            row = Series(case["row"])
+            name_fields = case["name_fields"]
+            with self.subTest(name_fields=name_fields):
+                assert len(case["name_fields"]) == 1
+                name = parse_tables.get_name(row=row, name_fields=name_fields)
+                assert name == "BAGSHAW Elaine Sheila"
+
+    def test_get_name_two_fields(self):
+        for case in self.get_two_name_field_cases():
+            row = Series(case["row"])
+            name_fields = case["name_fields"]
+            with self.subTest(name_fields=name_fields):
+                assert len(case["name_fields"]) == 2
+                name = parse_tables.get_name(row=row, name_fields=name_fields)
+                assert name == case["expected_name"]
+
+    def test_get_name_fields_single(self):
+        for case in self.get_single_name_field_cases():
+            row = Index(case["row"])
+            with self.subTest(row=row):
+                name_fields = parse_tables.get_name_fields(row=row)
+                assert len(name_fields) == 1
+                assert name_fields == case["name_fields"]
+
+    def test_get_name_fields_two(self):
+        for case in self.get_two_name_field_cases():
+            row = Index(case["row"])
+            with self.subTest(row=row):
+                name_fields = parse_tables.get_name_fields(row=row)
+                assert len(name_fields) == 2
+                assert name_fields == case["name_fields"]
+
+    def test_get_name_fields_raises_error(self):
+        row = Index({"foo": "Bar"})
+        with self.assertRaises(ValueError):
+            parse_tables.get_name_fields(row=row)
+
+    def test_order_name_fields(self):
+        for case in self.get_two_name_field_cases():
+            name_fields = case["name_fields"]
+            with self.subTest(name_fields=name_fields):
+                result = parse_tables.order_name_fields(name_fields)
+                assert result == case["ordered_name_fields"]
+


### PR DESCRIPTION
Closes #888 and #903

Updates the table parsing helper to methods to account for SOPN documents that have names split over multiple fields

Screenshot of parsed SOPN mentioned in ticket #888 when run locally with these changes:

<img width="1552" alt="Screenshot 2021-03-19 at 17 35 19" src="https://user-images.githubusercontent.com/15347726/111820524-86749480-88d9-11eb-89e5-7cb9c3674b49.png">

Screenshot of parsed SOPN mentioned in ticket #903 when run locally with these changes:
![Screen Shot 2021-03-22 at 10 40 40 AM](https://user-images.githubusercontent.com/7017118/111977916-3c6af900-8afb-11eb-82d3-382850a46d14.png)

Screenshot of similar [ballot](https://candidates.democracyclub.org.uk/elections/gla.c.city-and-east.2016-05-05/sopn/) that I tested with:
<img width="503" alt="Screenshot 2021-03-19 at 17 37 20" src="https://user-images.githubusercontent.com/15347726/111820765-c9cf0300-88d9-11eb-97c8-2e96b83cffab.png">

In process of testing with the above I came across an [issue that I have documented here](#1367)