### PR TITLE
Feature/parse uploaded sopn

### DIFF
--- a/ynr/apps/candidates/models/popolo_extra.py
+++ b/ynr/apps/candidates/models/popolo_extra.py
@@ -143,14 +143,17 @@ class Ballot(models.Model):
             ),
         )
 
-    def get_absolute_url(self):
-        return reverse("election_view", args=[self.ballot_paper_id])
+    def get_absolute_url(self, viewname="election_view"):
+        return reverse(viewname, args=[self.ballot_paper_id])
 
     def get_bulk_add_url(self):
-        return reverse("bulk_add_from_sopn", args=[self.ballot_paper_id])
+        return self.get_absolute_url("bulk_add_from_sopn")
 
     def get_bulk_add_review_url(self):
-        return reverse("bulk_add_sopn_review", args=[self.ballot_paper_id])
+        return self.get_absolute_url("bulk_add_sopn_review")
+
+    def get_sopn_url(self):
+        return self.get_absolute_url("ballot_paper_sopn")
 
     def safe_delete(self):
         collector = NestedObjects(using=connection.cursor().db.alias)

--- a/ynr/apps/candidates/tests/test_models.py
+++ b/ynr/apps/candidates/tests/test_models.py
@@ -1,0 +1,26 @@
+from django.test import TestCase
+
+from ..models import Ballot
+
+
+class TestBallotUrlMethods(TestCase):
+    def setUp(self):
+        self.ballot = Ballot(
+            ballot_paper_id="local.sheffield.ecclesall.2021-05-06"
+        )
+
+    def test_get_absolute_url(self):
+        url = self.ballot.get_absolute_url()
+        assert url == f"/elections/{self.ballot.ballot_paper_id}/"
+
+    def test_get_bulk_add_url(self):
+        url = self.ballot.get_bulk_add_url()
+        assert url == f"/bulk_adding/sopn/{self.ballot.ballot_paper_id}/"
+
+    def test_get_bulk_add_review_url(self):
+        url = self.ballot.get_bulk_add_review_url()
+        assert url == f"/bulk_adding/sopn/{self.ballot.ballot_paper_id}/review/"
+
+    def test_get_sopn_view(self):
+        url = self.ballot.get_sopn_url()
+        assert url == f"/elections/{self.ballot.ballot_paper_id}/sopn/"

--- a/ynr/apps/official_documents/templates/official_documents/unlocked_with_documents.html
+++ b/ynr/apps/official_documents/templates/official_documents/unlocked_with_documents.html
@@ -4,7 +4,7 @@
 <h2>Unlocked posts with nomination papers</h2>
 {% for doc in unlocked_sopns %}
   <li>
-    <a href="{{ ballot.get_bulk_add_url }}?source={{ doc.source_url }}">
+    <a href="{{ doc.ballot.get_bulk_add_url }}?source={{ doc.source_url }}">
     {{ doc.ballot.post.label }}</a>
   </li>
 {% endfor %}

--- a/ynr/apps/official_documents/tests/test_upload.py
+++ b/ynr/apps/official_documents/tests/test_upload.py
@@ -1,5 +1,4 @@
 from os.path import dirname, join, realpath
-from unittest import skip
 
 from django.urls import reverse
 from django_webtest import WebTest

--- a/ynr/apps/official_documents/tests/test_upload.py
+++ b/ynr/apps/official_documents/tests/test_upload.py
@@ -73,7 +73,6 @@ class TestModels(TestUserMixin, WebTest):
             response.text,
         )
 
-    @skip("SOPN Upload form on ballot page")
     def test_upload_authorized(self):
         self.assertFalse(LoggedAction.objects.exists())
         response = self.app.get(
@@ -81,9 +80,7 @@ class TestModels(TestUserMixin, WebTest):
             user=self.user_who_can_upload_documents,
         )
 
-        self.assertInHTML(
-            "Upload the Statement of Persons Nominated", response.text
-        )
+        self.assertInHTML("Upload SOPN", response.text)
 
         response = self.app.get(
             reverse(
@@ -121,9 +118,6 @@ class TestModels(TestUserMixin, WebTest):
         self.assertEqual(qs.get().source, "http://example.org/foo")
 
         response = self.app.get(
-            self.ballot.get_absolute_url(),
-            user=self.user_who_can_upload_documents,
+            self.ballot.get_sopn_url(), user=self.user_who_can_upload_documents
         )
-        self.assertInHTML(
-            "Change Statement of Persons Nominated document", response.text
-        )
+        self.assertInHTML("Update SOPN", response.text)

--- a/ynr/apps/official_documents/urls.py
+++ b/ynr/apps/official_documents/urls.py
@@ -4,11 +4,6 @@ from . import views
 
 urlpatterns = [
     url(
-        r"^(?P<ballot_paper_id>[^/]+)/$",
-        views.CreateDocumentView.as_view(),
-        name="upload_document_view",
-    ),
-    url(
         r"^posts_for_document/(?P<pk>\d+)/$",
         views.PostsForDocumentView.as_view(),
         name="posts_for_document",
@@ -17,5 +12,10 @@ urlpatterns = [
         r"^uploaded/$",
         views.UnlockedWithDocumentsView.as_view(),
         name="unlocked_posts_with_documents",
+    ),
+    url(
+        r"^(?P<ballot_paper_id>[^/]+)/$",
+        views.CreateDocumentView.as_view(),
+        name="upload_document_view",
     ),
 ]

--- a/ynr/apps/official_documents/views.py
+++ b/ynr/apps/official_documents/views.py
@@ -47,9 +47,11 @@ class CreateDocumentView(GroupRequiredMixin, CreateView):
         """
         self.object = form.save()
         try:
-            extract_pages_for_ballot(self.object.ballot)
-            extract_ballot_table(self.object.ballot)
-            parse_raw_data_for_ballot(self.object.ballot)
+            extract_pages_for_ballot(
+                ballot=self.object.ballot, manual_upload=True
+            )
+            extract_ballot_table(ballot=self.object.ballot)
+            parse_raw_data_for_ballot(ballot=self.object.ballot)
         except (ValueError, NoTextInDocumentError):
             # If PDF couldnt be parsed continue
             # TODO should be log this error?

--- a/ynr/apps/sopn_parsing/helpers/extract_pages.py
+++ b/ynr/apps/sopn_parsing/helpers/extract_pages.py
@@ -5,7 +5,7 @@ from sopn_parsing.helpers.pdf_helpers import SOPNDocument
 from sopn_parsing.helpers.text_helpers import NoTextInDocumentError
 
 
-def extract_pages_for_ballot(ballot):
+def extract_pages_for_ballot(ballot, manual_upload=False):
     """
     Try to extract the page numbers for the latest SOPN document related to this
     ballot.
@@ -13,15 +13,21 @@ def extract_pages_for_ballot(ballot):
     Because documents can apply to more than one ballot, we also perform
     "drive by" parsing of other ballots contained in a given document.
 
+    The manual_upload arg is used to force full page number extraction of from
+    the document when it is uploaded manually, in case the document covers
+    multiple ballots but this is the first ballot where it is being uploaded
+
     :type ballot: candidates.models.Ballot
 
     """
+    for other_doc, pages in extract_pages_for_single_document(
+        document=ballot.sopn, manual_upload=manual_upload
+    ):
+        other_doc.relevant_pages = pages
+        other_doc.save()
 
-    sopn = ballot.sopn
-    save_page_numbers_for_single_document(sopn)
 
-
-def extract_pages_for_single_document(document):
+def extract_pages_for_single_document(document, manual_upload):
     all_documents_with_source = (
         OfficialDocument.objects.filter(source_url=document.source_url)
         .select_related("ballot", "ballot__post")
@@ -31,7 +37,8 @@ def extract_pages_for_single_document(document):
     if not doc_file:
         return
 
-    if all_documents_with_source.count() == 1:
+    # if manual upload dont check for shared sources as this might be the first
+    if not manual_upload and all_documents_with_source.count() == 1:
         yield document, "all"
         return
     try:
@@ -46,9 +53,3 @@ def extract_pages_for_single_document(document):
             continue
         page_numbers = ",".join(str(p.page_number) for p in pages)
         yield doc, page_numbers
-
-
-def save_page_numbers_for_single_document(document):
-    for other_doc, pages in extract_pages_for_single_document(document):
-        other_doc.relevant_pages = pages
-        other_doc.save()

--- a/ynr/apps/sopn_parsing/helpers/extract_pages.py
+++ b/ynr/apps/sopn_parsing/helpers/extract_pages.py
@@ -37,10 +37,25 @@ def extract_pages_for_single_document(document, manual_upload):
     if not doc_file:
         return
 
-    # if manual upload dont check for shared sources as this might be the first
-    if not manual_upload and all_documents_with_source.count() == 1:
-        yield document, "all"
-        return
+    # if there are multiple documents with the same source it suggests multi
+    # page SOPN covering multiple ballots
+    if all_documents_with_source.count() == 1:
+
+        # if not a manual upload assume all pages relate to the ballot
+        if not manual_upload:
+            yield document, "all"
+            return
+
+        #  check if the ballot is for a by-election - if so it is very likely to
+        # be for a single ballot
+        ballot = all_documents_with_source.get().ballot
+        if ".by." in ballot.ballot_paper_id:
+            yield document, "all"
+            return
+
+    # ... otherwise parse is as if we had multiple sources as the document
+    # may contain multiple ballots, but this is the first time parsing it
+
     try:
         sopn = SOPNDocument(doc_file)
     except (NoTextInDocumentError):

--- a/ynr/apps/sopn_parsing/helpers/extract_pages.py
+++ b/ynr/apps/sopn_parsing/helpers/extract_pages.py
@@ -38,7 +38,7 @@ def extract_pages_for_single_document(document):
         sopn = SOPNDocument(doc_file)
     except (NoTextInDocumentError):
         raise NoTextInDocumentError(
-            "No text in {}, skipping".format(document.uploaded_file.url)
+            "No text in {}, skipping".format(document.uploaded_file.path)
         )
     for doc in all_documents_with_source:
         pages = sopn.get_pages_by_ward_name(doc.ballot.post.label)

--- a/ynr/apps/sopn_parsing/helpers/extract_tables.py
+++ b/ynr/apps/sopn_parsing/helpers/extract_tables.py
@@ -22,7 +22,7 @@ def extract_ballot_table(ballot, parse_flavor="lattice"):
 
     try:
         tables = camelot.read_pdf(
-            document.uploaded_file.url,
+            document.uploaded_file.path,
             pages=document.relevant_pages,
             flavor=parse_flavor,
         )

--- a/ynr/storages.py
+++ b/ynr/storages.py
@@ -59,6 +59,16 @@ class MediaStorage(PatchedS3Boto3Storage):
         """
         return self.url("")
 
+    def path(self, name):
+        """
+        This is a hack to allow us to use uploaded_file.path in application code
+        in extract_ballot_table which helps with local development.
+
+        Path is not implemented by S3BotoStorage so we call the url method to
+        return the URL to the media in our S3 bucket.
+        """
+        return self.url(name)
+
 
 class TestMediaStorage(FileSystemStorage):
     """


### PR DESCRIPTION
Closes #905 

The key changes here are:
- When a user manually uploads an SOPN to a ballot, parsing is attempted
- Refactors page extraction helpers to add flag that forces page extraction on a manual upload. This is to resolve an issue where the file uploaded covers multiple ballots/wards, but this is the first ballot with the source URL to have the SOPN uploaded. Previously this would have resulted in "all" being stored as the `relevant_pages` and parsing would fail. Instead now parsing relevant pages is forced.

In the process of implementing the above I made some additional related changes to help improve local dev and testing:
- Update media storage to make it easier to run SOPN parsing in local development
- Refactors existing SOPN upload test so that it is no longer skipped
- Add some simple tests for Ballot urls
- Came across an [error](https://sentry.io/organizations/democracy-club-gp/issues/2100894650/?project=169287&query=is%3Aunresolved) due to URL ordering which is resolved [here](https://github.com/DemocracyClub/yournextrepresentative/pull/1375/files#diff-fbb6a7c82d173457c3a745379d48d86de66441c4fc1e0c8fd78e0705cfdb9bcbR16) but if this page is no longed needed/used I can update to remove