### PR TITLE
Hotfix/Handle last names

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -50,6 +50,7 @@ jsonpointer==2.0
 libsass==0.20.1
 lxml==4.6.2
 mock==1.0.1
+nameparser==1.0.2
 ndg-httpsclient==0.5.1
 numpy==1.18.4
 oauthlib==3.1.0

--- a/ynr/apps/sopn_parsing/tests/test_parse_tables.py
+++ b/ynr/apps/sopn_parsing/tests/test_parse_tables.py
@@ -264,6 +264,10 @@ class TestParseTablesUnitTests(TestCase):
         name = parse_tables.clean_name("SMITH John")
         assert name == "John Smith"
 
+    def test_clean_last_names(self):
+        name = parse_tables.clean_last_names(["MACDONALD", "John"])
+        assert name == "MacDonald"
+
     def test_clean_name_two_word_surnames(self):
         names = [
             ("EDE COOPER \nPalmer", "Palmer Ede Cooper"),


### PR DESCRIPTION
Closes #889 

Correctly parses last names with a need for multiple capitalisations such as McDonnell, MacDonald, or Van Gough. 
<img width="671" alt="Screen Shot 2021-03-31 at 4 56 07 PM" src="https://user-images.githubusercontent.com/7017118/113174219-1273ae00-9242-11eb-92a4-a8a72a812413.png">
