### PR TITLE
Update RawPeople.as_form_kwargs method

### DIFF
--- a/ynr/apps/bulk_adding/models.py
+++ b/ynr/apps/bulk_adding/models.py
@@ -63,16 +63,15 @@ class RawPeople(TimeStampedModel):
             return {}
         initial = []
         for candidacy in self.data:
-            if candidacy.get("description_id"):
-                party = "{}__{}".format(
-                    candidacy["party_id"], candidacy["description_id"]
-                )
-            else:
-                party = candidacy["party_id"]
+            party_id = candidacy["party_id"]
+            description_id = candidacy.get("description_id")
+            if description_id:
+                party_id = f"{party_id}__{description_id}"
+
             initial.append(
                 {
                     "name": candidacy["name"],
-                    "party": party,
+                    "party": [party_id, party_id],
                     "source": self.source,
                 }
             )

--- a/ynr/apps/bulk_adding/tests/test_bulk_add.py
+++ b/ynr/apps/bulk_adding/tests/test_bulk_add.py
@@ -47,6 +47,29 @@ class TestBulkAdding(TestUserMixin, UK2015ExamplesMixin, WebTest):
 
         self.assertContains(response, "Review")
 
+    def test_with_raw_people_regression_test(self):
+        """
+        Simple test to check that the page renders when a RawPeople object
+        exists for the ballot. This is a regression test, as previously the
+        BulkAddFormSet would initialise with party data returned as a string
+        but now expects a list or tuple.
+        """
+        OfficialDocument.objects.create(
+            source_url="http://example.com",
+            document_type=OfficialDocument.NOMINATION_PAPER,
+            ballot=self.dulwich_post_ballot,
+            uploaded_file="sopn.pdf",
+        )
+        RawPeople.objects.create(
+            ballot=self.dulwich_post_ballot,
+            data=[{"name": "Bart", "party_id": "PP52"}],
+            source_type=RawPeople.SOURCE_PARSED_PDF,
+        )
+        response = self.app.get(
+            "/bulk_adding/sopn/parl.65808.2015-05-07/", user=self.user
+        )
+        self.assertEqual(response.status_code, 200)
+
     def test_submitting_form(self):
         post = self.dulwich_post
 


### PR DESCRIPTION
Recent changes seem to have introduced a bug loading the initial data from a `RawPeople` object. Bug occurred when:

- uploading SOPN for ballot e.g. `local.gedling.calverton.2019-05-02` with SOPN doc from https://candidates.democracyclub.org.uk/elections/local.gedling.calverton.2019-05-02/sopn/
- SOPN is parsed correctly and displayed
- Go to ballot page for `local.gedling.calverton.2019-05-02` and click on "Add candidates from nomination paper"
- 500 error raised:
```
File "/Users/michaelcollins/code/dc/yournextrepresentative/ynr/apps/parties/forms.py" in __init__
  126.         self.populate_parties()
File "/Users/michaelcollins/code/dc/yournextrepresentative/ynr/apps/parties/forms.py" in populate_parties
  146.                     raise ValueError("list or tuple required for initial")
Exception Type: ValueError at /bulk_adding/sopn/local.gedling.calverton.2019-05-02/
Exception Value: list or tuple required for initial
```

This changes the logic within RawPeople.as_form_kwargs method so that:
- A list is returned for the initial party value
- This is made up of party_id and party_id with description_id if we
have a value to use