### PR TITLE
Bump sopn_parsing deps to latest version

### DIFF
--- a/requirements/sopn_parsing.txt
+++ b/requirements/sopn_parsing.txt
@@ -1,4 +1,4 @@
 -r base.txt
 
-pdfminer.six==20200124
-camelot-py[cv]==0.7.3
+pdfminer.six==20201018
+camelot-py[cv]==0.8.2


### PR DESCRIPTION
Closes https://github.com/DemocracyClub/yournextrepresentative/pull/1254

I have updated and installed in my local env and haven't had any issues when testing parsing documents that I had been testing with previously, although this is not extensive.

I don't see anything in the changelog for either dependency that looks like it would cause any problems

https://github.com/camelot-dev/camelot/blob/master/HISTORY.md
https://github.com/pdfminer/pdfminer.six/blob/20201018/CHANGELOG.md
