### PR TITLE
Fix bug stopping users edit candidate profile

### DIFF
--- a/ynr/apps/candidates/static/js/person_form.js
+++ b/ynr/apps/candidates/static/js/person_form.js
@@ -19,7 +19,11 @@ var setup_ballot_select2 = function(ballots) {
       .insertAfter(BallotInput);
     BallotInput.hide().attr("required", false);
 
-    BallotSelect.select2();
+    BallotSelect.select2({
+      placeholder: "Select a ballot",
+      width: '100%',
+      allowClear: true
+    });
     BallotSelect.on('select2:select', function (e) {
       var selected_ballot = $(e.params.data.element);
       var uses_party_lists = selected_ballot.data("usesPartyLists");

--- a/ynr/apps/elections/tests/test_select_ajax_view.py
+++ b/ynr/apps/elections/tests/test_select_ajax_view.py
@@ -15,7 +15,9 @@ class TestPostsView(UK2015ExamplesMixin, WebTest):
         resp = self.app.get(reverse("ajax_ballots_for_select"))
         self.assertHTMLEqual(
             resp.text,
-            """<optgroup label='Maidstone local election'>
+            """
+            <option></option>
+            <optgroup label='Maidstone local election'>
             <option value='local.maidstone.DIW:E05005004.2016-05-05' data-party-register='GB' data-uses-party-lists='False'>Shepway South Ward</option>
             </optgroup>
             <optgroup label='2015 General Election'>
@@ -35,13 +37,14 @@ class TestPostsView(UK2015ExamplesMixin, WebTest):
         resp = self.app.get(reverse("ajax_ballots_for_select"))
         self.assertHTMLEqual(
             resp.text,
-            """<optgroup label='Maidstone local election'>
-        <option value='local.maidstone.DIW:E05005004.2016-05-05' data-party-register='GB' data-uses-party-lists='False'>Shepway South Ward</option>
-        </optgroup>
-        <optgroup label='2015 General Election'>
-        <option value='parl.65913.2015-05-07' data-party-register='GB' data-uses-party-lists='False'>Member of Parliament for Camberwell and Peckham (❌ cancelled)</option>
-        <option data-party-register="GB" data-uses-party-lists="False" disabled="True" value="parl.65808.2015-05-07">Member of Parliament for Dulwich and West Norwood 🔐</option>
-        <option value='parl.14419.2015-05-07' data-party-register='GB' data-uses-party-lists='False'>Member of Parliament for Edinburgh East</option>
-        <option value='parl.14420.2015-05-07' data-party-register='GB' data-uses-party-lists='False'>Member of Parliament for Edinburgh North and Leith</option>
-        </optgroup>""",
+            """<option></option>
+            <optgroup label='Maidstone local election'>
+            <option value='local.maidstone.DIW:E05005004.2016-05-05' data-party-register='GB' data-uses-party-lists='False'>Shepway South Ward</option>
+            </optgroup>
+            <optgroup label='2015 General Election'>
+            <option value='parl.65913.2015-05-07' data-party-register='GB' data-uses-party-lists='False'>Member of Parliament for Camberwell and Peckham (❌ cancelled)</option>
+            <option data-party-register="GB" data-uses-party-lists="False" disabled="True" value="parl.65808.2015-05-07">Member of Parliament for Dulwich and West Norwood 🔐</option>
+            <option value='parl.14419.2015-05-07' data-party-register='GB' data-uses-party-lists='False'>Member of Parliament for Edinburgh East</option>
+            <option value='parl.14420.2015-05-07' data-party-register='GB' data-uses-party-lists='False'>Member of Parliament for Edinburgh North and Leith</option>
+            </optgroup>""",
         )

--- a/ynr/apps/elections/views.py
+++ b/ynr/apps/elections/views.py
@@ -349,6 +349,7 @@ class BallotsForSelectAjaxView(View):
             if ballot.election.name != election_name:
                 election_name = ballot.election.name
                 if data:
+
                     data.append("</optgroup>")
                 data.append(f"<optgroup label='{election_name}'>")
 
@@ -370,5 +371,8 @@ class BallotsForSelectAjaxView(View):
             )
             data.append(f"<option {attrs_str}>" f"{ballot_label}" f"</option>")
         data.append("</optgroup>")
-
+        # empty option needs to be included for select2 to display a placeholder
+        # see https://select2.org/placeholders#single-select-placeholders
+        #  https://github.com/DemocracyClub/yournextrepresentative/issues/1435
+        data.insert(0, "<option></option>")
         return HttpResponse("\n".join(data))


### PR DESCRIPTION
- Closes #1435
- Closes #1419 
- Add empty value to ballot options so that select2 can display
placeholder text
- Stops issue where user couldnt submit edit profile form without as
they were being forced to select a ballot option
- Allows user to deselect a ballot if they select one in error

Screenshot from Safari

<img width="1550" alt="Screenshot 2021-04-09 at 15 53 02" src="https://user-images.githubusercontent.com/15347726/114201381-09739280-994e-11eb-8963-9674ca5dff88.png">
