### PR TITLE
Add ID to BulkAddReviewFormSet and use in tests

### DIFF
--- a/ynr/apps/bulk_adding/templates/bulk_add/sopns/add_review_form.html
+++ b/ynr/apps/bulk_adding/templates/bulk_add/sopns/add_review_form.html
@@ -35,7 +35,7 @@
 {% include "bulk_add/sopns/_known-people.html" %}
 
 
-<form method=POST>
+<form method=POST id="bulk_add_review_formset">
   {% csrf_token %}
   {{ formset.management_form }}
   {% if formset.non_form_errors %}

--- a/ynr/apps/bulk_adding/tests/test_bulk_add.py
+++ b/ynr/apps/bulk_adding/tests/test_bulk_add.py
@@ -111,7 +111,7 @@ class TestBulkAdding(TestUserMixin, UK2015ExamplesMixin, WebTest):
         self.assertEqual(response.status_code, 302)
         response = response.follow()
         #  confirm as a new person and submit lock suggestion
-        form = response.forms[1]
+        form = response.forms["bulk_add_review_formset"]
         form["form-0-select_person"].select("_new")
         response = form.submit().follow()
         # previously this raised a 500 error caused by
@@ -150,7 +150,7 @@ class TestBulkAdding(TestUserMixin, UK2015ExamplesMixin, WebTest):
         # as a new person or alternative radio buttons if any
         # candidates with similar names were found.
         response = response.follow()
-        form = response.forms[1]
+        form = response.forms["bulk_add_review_formset"]
         form["form-0-select_person"].select("_new")
 
         # As Chris points out[1], this is quite a large number, and also quite
@@ -219,7 +219,7 @@ class TestBulkAdding(TestUserMixin, UK2015ExamplesMixin, WebTest):
         # as a new person or alternative radio buttons if any
         # candidates with similar names were found.
         response = response.follow()
-        form = response.forms[1]
+        form = response.forms["bulk_add_review_formset"]
         form["form-0-select_person"].select("1234567")
         response = form.submit()
 
@@ -320,7 +320,7 @@ class TestBulkAdding(TestUserMixin, UK2015ExamplesMixin, WebTest):
         # as a new person or alternative radio buttons if any
         # candidates with similar names were found.
         response = response.follow()
-        form = response.forms[1]
+        form = response.forms["bulk_add_review_formset"]
         form["form-0-select_person"].select("1234567")
         response = form.submit()
 
@@ -368,7 +368,7 @@ class TestBulkAdding(TestUserMixin, UK2015ExamplesMixin, WebTest):
         response = self.app.get(
             "/bulk_adding/sopn/parl.65808.2015-05-07/?edit=1", user=self.user
         )
-        form = response.forms[1]
+        form = response.forms["bulk_add_form"]
         response = form.submit()
         self.assertContains(
             response, "At least one person required on this ballot"
@@ -440,7 +440,7 @@ class TestBulkAdding(TestUserMixin, UK2015ExamplesMixin, WebTest):
         response = self.app.get(
             "/bulk_adding/sopn/parl.65808.2015-05-07/?edit=1", user=self.user
         )
-        form = response.forms[1]
+        form = response.forms["bulk_add_form"]
         response = form.submit()
         self.assertEqual(response.status_code, 302)
 
@@ -482,7 +482,7 @@ class TestBulkAdding(TestUserMixin, UK2015ExamplesMixin, WebTest):
         response = form.submit()
 
         response = response.follow()
-        form = response.forms[1]
+        form = response.forms["bulk_add_review_formset"]
         form["form-0-select_person"].select("1234567")
         response = form.submit()
         self.assertEqual(response.context["formset"].is_valid(), False)

--- a/ynr/apps/candidates/views/candidacies.py
+++ b/ynr/apps/candidates/views/candidacies.py
@@ -10,7 +10,7 @@ from candidates.models.constraints import check_no_candidancy_for_election
 from elections.mixins import ElectionMixin
 from people.forms.forms import CandidacyCreateForm, CandidacyDeleteForm
 from people.models import Person
-from popolo.models import Membership, Post
+from popolo.models import Membership
 
 from ..models import TRUSTED_TO_LOCK_GROUP_NAME, LoggedAction
 from .version_data import get_change_metadata, get_client_ip


### PR DESCRIPTION
Fix failing tests after new form was added to the bulk review template. Have added an ID so that the tests are no longer reliant on the order the form is displayed in the template