### PR TITLE
Update to get ID from json returned by show.json

### DIFF
--- a/ynr/apps/candidates/twitter_api.py
+++ b/ynr/apps/candidates/twitter_api.py
@@ -38,7 +38,7 @@ def get_twitter_user_id(twitter_screen_name):
                     )
                 )
         else:
-            result = str(data[0]["id"])
+            result = str(data["id"])
     else:
         result = ""
     # Cache Twitter screen name -> user ID results for 5 minutes -


### PR DESCRIPTION
- Previous PR had changed endpoint used to get twitter user id to
show.json, however returned json structure change was not accounted
for
- Fixes https://sentry.io/organizations/democracy-club-gp/issues/2350229443/?project=169287&query=is%3Aunresolved