### PR TITLE
Always return Ballot QS in geo_helpers

### DIFF
--- a/ynr/apps/elections/uk/geo_helpers.py
+++ b/ynr/apps/elections/uk/geo_helpers.py
@@ -73,7 +73,7 @@ def get_ballots_from_postcode(
     cache_key = f"geolookup-postcodes:{current_only}:{postcode}"
     cached_result = cache.get(cache_key)
     if cached_result:
-        return cached_result
+        return Ballot.objects.filter(ballot_paper_id__in=cached_result)
 
     url = urljoin(EE_BASE_URL, f"/api/elections/?postcode={urlquote(postcode)}")
     if current_only:
@@ -99,6 +99,6 @@ def get_ballots_from_coords(coords, current_only=True):
     cache_key = f"geolookup-coords:{current_only}:{coords}"
     cached_result = cache.get(cache_key)
     if cached_result:
-        return cached_result
+        return Ballot.objects.filter(ballot_paper_id__in=cached_result)
 
     return get_ballots(url, cache_key, BadCoordinatesException)


### PR DESCRIPTION
- If we have a cached result, use it to get get Ballot qs and return
- Fix https://sentry.io/organizations/democracy-club-gp/issues/2381324246/events/54445a4e29ee4522bf4b7b54cd03d0a9/?project=169287
- Previously was returning a list of ballot ID's which caused AttributeError 
- Tested by enabling redis as cache locally, allowing a request to cache, then making request again to recreate the error. With these changes error resolved