### PR TITLE
Display results progress by region/election type

### DIFF
--- a/ynr/apps/candidates/models/popolo_extra.py
+++ b/ynr/apps/candidates/models/popolo_extra.py
@@ -131,15 +131,21 @@ class BallotQueryset(models.QuerySet):
 
     def has_results(self):
         """
-        Return a QuerySet of ballots that have results
+        Return a QuerySet of ballots that either have a ResultSet or have a candidate marked elected
         """
-        return self.filter(resultset__isnull=False)
+        return self.filter(
+            models.Q(resultset__isnull=False)
+            | models.Q(membership__elected=True)
+        ).distinct()
 
     def no_results(self):
         """
-        Return a QuerySet of ballots that do not have results
+        Return a QuerySet of ballots that excluding those with a ResultSet or have a candidate marked elected
         """
-        return self.filter(resultset__isnull=True)
+        return self.exclude(
+            models.Q(resultset__isnull=False)
+            | models.Q(membership__elected=True)
+        ).distinct()
 
 
 class Ballot(models.Model):

--- a/ynr/apps/candidates/static/candidates/_finder.scss
+++ b/ynr/apps/candidates/static/candidates/_finder.scss
@@ -138,7 +138,7 @@
       box-shadow: 0 2px 2px rgba(0,0,0,0.1);
     }
   }
-  .cta-SOPN_TRACKER .finder__forms__container {
+  .cta-SOPN_TRACKER .finder__forms__container, .cta-RESULTS_PROGRESS .finder__forms__container {
     width:100%
   }
   .finder__description {

--- a/ynr/apps/candidates/tests/factories.py
+++ b/ynr/apps/candidates/tests/factories.py
@@ -93,6 +93,15 @@ class BallotPaperFactory(factory.DjangoModelFactory):
     class Meta:
         model = "candidates.Ballot"
 
+    @factory.lazy_attribute_sequence
+    def ballot_paper_id(self, n):
+        """
+        Builds a unique string to use as a ballot paper ID.
+        TODO make this more realistic like actual ballot paper ID's.
+        """
+        slug = faker_factory.slug()
+        return f"{slug}-{n}"
+
 
 class OrganizationFactory(factory.DjangoModelFactory):
     class Meta:

--- a/ynr/apps/candidates/tests/test_models.py
+++ b/ynr/apps/candidates/tests/test_models.py
@@ -1,6 +1,12 @@
+import faker
 from django.test import TestCase
 
+from elections.tests.test_ballot_view import SingleBallotStatesMixin
+from uk_results.models import ResultSet
+
 from ..models import Ballot
+
+fake = faker.Faker()
 
 
 class TestBallotUrlMethods(TestCase):
@@ -38,3 +44,63 @@ class TestBallotUrlMethods(TestCase):
         assert fptp.results_button_text == "Add results"
         assert other.get_results_url() == "/elections/gla.a.2021-05-06/"
         assert other.results_button_text == "Mark elected candidates"
+
+
+class TestBallotQuerysetMethods(SingleBallotStatesMixin, TestCase):
+    def setUp(self):
+        self.election = self.create_election("local.sheffield.2021-05-06")
+        self.post = self.create_post("Bar")
+        self.parties = self.create_parties(3)
+
+    def test_has_results_and_no_results(self):
+        """
+        Test that the has_results QS method only returns Ballots which either
+        have a resultset, or have a candidate marked as elected. Test that
+        no_results doesnt include Ballots that have a ResultSet or a candidate
+        marked elected
+        """
+        no_results = []
+        for i in range(5):
+            ballot = self.create_ballot(
+                ballot_paper_id=f"{fake.slug()}-{i}",
+                post=self.post,
+                election=self.election,
+            )
+            self.create_memberships(ballot=ballot, parties=self.parties)
+            no_results.append(ballot)
+
+        has_results = []
+        for i in range(5):
+            ballot = self.create_ballot(
+                ballot_paper_id=f"{fake.slug()}-{i}",
+                post=self.post,
+                election=self.election,
+            )
+            self.create_memberships(ballot=ballot, parties=self.parties)
+            ResultSet.objects.create(
+                ballot=ballot,
+                num_turnout_reported=10000,
+                num_spoilt_ballots=30,
+                source="Example ResultSet for testing",
+            )
+            has_results.append(ballot)
+
+        has_winner_no_result = []
+        for i in range(5):
+            ballot = self.create_ballot(
+                ballot_paper_id=f"{fake.slug()}-{i}",
+                post=self.post,
+                election=self.election,
+            )
+            self.create_memberships(ballot=ballot, parties=self.parties)
+            winner = ballot.membership_set.first()
+            winner.elected = True
+            winner.save()
+            has_winner_no_result.append(ballot)
+
+        self.assertEqual(Ballot.objects.count(), 15)
+        self.assertEqual(Ballot.objects.has_results().count(), 10)
+        self.assertEqual(Ballot.objects.no_results().count(), 5)
+        all_winners = set(has_results + has_winner_no_result)
+        self.assertEqual(set(Ballot.objects.has_results()), all_winners)
+        self.assertEqual(set(Ballot.objects.no_results()), set(no_results))

--- a/ynr/apps/candidates/tests/test_models.py
+++ b/ynr/apps/candidates/tests/test_models.py
@@ -1,12 +1,9 @@
-import faker
 from django.test import TestCase
 
 from elections.tests.test_ballot_view import SingleBallotStatesMixin
 from uk_results.models import ResultSet
 
 from ..models import Ballot
-
-fake = faker.Faker()
 
 
 class TestBallotUrlMethods(TestCase):
@@ -63,10 +60,7 @@ class BallotsWithResultsMixin(SingleBallotStatesMixin):
         results = []
         for i in range(num):
             ballot = self.create_ballot(
-                ballot_paper_id=f"{fake.slug()}-{i}",
-                post=self.post,
-                election=self.election,
-                **kwargs,
+                post=self.post, election=self.election, **kwargs
             )
             self.create_memberships(ballot=ballot, parties=self.parties)
 

--- a/ynr/apps/elections/templates/elections/election_list.html
+++ b/ynr/apps/elections/templates/elections/election_list.html
@@ -82,7 +82,10 @@
           <th>Ballot</th>
           <th>Candidates known</th>
           <th>Status</th>
-          <th>Has Results</th>
+          {% if group.list.0.polls_closed %}
+            <th>Has Results</th>
+          {% endif %}
+
         </tr>
       </thead>
       <tbody>
@@ -121,8 +124,8 @@
 
             {% endif %}
           </td>
+          {% if ballot.polls_closed %}
           <td>
-            {% if ballot.polls_closed %}
               {% if ballot.elected_count == ballot.winner_count %}
                 Completed
               {% elif user_can_record_results %}
@@ -130,10 +133,8 @@
               {% else %}
                 No results
               {% endif %}
-            {% else %}
-              Polls not closed
-            {% endif %}
           </td>
+          {% endif %}
         </tr>
       {% endfor %}
       </tbody>

--- a/ynr/apps/elections/uk/templates/candidates/finder.html
+++ b/ynr/apps/elections/uk/templates/candidates/finder.html
@@ -53,31 +53,32 @@
     </div>
   {% endif %}
 
-  <div class="finder__forms cta-{{ front_page_cta }}">
-    <div class="finder__forms__container">
-      <h3>🎤 Help us find out about hustings events 🎤</h3>
-      <p>‘Hustings’ are debates between election candidates. They are a great opportunity for voters to hear from their candidates.</p>
-
-      <p>We’d like to help more people learn about relevant hustings events for the 6 May elections. We’ll be displaying these on
-        <a href="https://whocanivotefor.co.uk">WhoCanIVoteFor.co.uk</a></p>
-      <a href="https://docs.google.com/spreadsheets/d/1Krf0icsp-bExEKBpnQi_WZ6pcsT10MJ3p1NDBquf_ik/edit#gid=1412900278" class="button">
-        Go to the hustings spreadsheet!</a><br> or browse to the elections and ballot pages for a link to the
-      <a href="https://docs.google.com/forms/d/e/1FAIpQLSfvUNUTxY7lPpNVrbgagp4C5-eXG6hGSTuKpuyQAHuus8WTKw/viewform">Google Form</a>
-    </div>
-  </div>
-  <div class="finder__forms cta-{{ front_page_cta }}">
-    <div class="finder__forms__container">
-      <h3>📋 Find contact details local parties 📋</h3>
-
-      <p>Typically, there is more information available about local branches of political parties, which nominate most of the candidates.</p>
-
-      <p>So please help us complete this spreadsheet with information on those branches!</p>
-
-      <p>We’ll add this information to <a href="https://whocanivotefor.co.uk">WhoCanIVoteFor.co.uk</a>, so as to help people learn more before they vote.</p>
-      <a href="https://docs.google.com/spreadsheets/d/1DkmKrC9pMC-3db8Ka-eoG2abSU8wr637yvBVup8467E/edit#gid=425047470" class="button">
-        Go to the local party spreadsheet!</a>
-    </div>
-  </div>
+{#  <div class="finder__forms cta-{{ front_page_cta }}">#}
+{#    <div class="finder__forms__container">#}
+{#      <h3>🎤 Help us find out about hustings events 🎤</h3>#}
+{#      <p>‘Hustings’ are debates between election candidates. They are a great opportunity for voters to hear from their candidates.</p>#}
+{##}
+{#      <p>We’d like to help more people learn about relevant hustings events for the 6 May elections. We’ll be displaying these on#}
+{#        <a href="https://whocanivotefor.co.uk">WhoCanIVoteFor.co.uk</a></p>#}
+{#      <a href="https://docs.google.com/spreadsheets/d/1Krf0icsp-bExEKBpnQi_WZ6pcsT10MJ3p1NDBquf_ik/edit#gid=1412900278" class="button">#}
+{#        Go to the hustings spreadsheet!</a><br> or browse to the elections and ballot pages for a link to the#}
+{#      <a href="https://docs.google.com/forms/d/e/1FAIpQLSfvUNUTxY7lPpNVrbgagp4C5-eXG6hGSTuKpuyQAHuus8WTKw/viewform">Google Form</a>#}
+{#    </div>#}
+{#  </div>#}
+{# #}
+{#  <div class="finder__forms cta-{{ front_page_cta }}">#}
+{#    <div class="finder__forms__container">#}
+{#      <h3>📋 Find contact details local parties 📋</h3>#}
+{##}
+{#      <p>Typically, there is more information available about local branches of political parties, which nominate most of the candidates.</p>#}
+{##}
+{#      <p>So please help us complete this spreadsheet with information on those branches!</p>#}
+{##}
+{#      <p>We’ll add this information to <a href="https://whocanivotefor.co.uk">WhoCanIVoteFor.co.uk</a>, so as to help people learn more before they vote.</p>#}
+{#      <a href="https://docs.google.com/spreadsheets/d/1DkmKrC9pMC-3db8Ka-eoG2abSU8wr637yvBVup8467E/edit#gid=425047470" class="button">#}
+{#        Go to the local party spreadsheet!</a>#}
+{#    </div>#}
+{#  </div>#}
 
 
 

--- a/ynr/apps/elections/uk/templates/includes/results_progress.html
+++ b/ynr/apps/elections/uk/templates/includes/results_progress.html
@@ -1,13 +1,63 @@
 {% load humanize %}
 {% if SHOW_RESULTS_PROGRESS %}
   <h3>Enter results as they come in</h3>
-<p><a href="{% url "results-home"%}" class="button">Get started</a></p>
+  <p><a href="{% url "results-home"%}" class="button">Get started</a></p>
 
-<h3>{{ results_percent }}% of votes for {{ areas_total|intcomma }} areas in total have been entered</h3>
-<div class="radius progress success large-12" role="progressbar" aria-valuenow="{{ results_entered }}" aria-valuemin="0" aria-valuemax="{{ areas_total }}">
-  <span class="meter" style="width: {{ results_percent }}%"></span>
+  <h3>{{ results_percent }}% of votes for {{ areas_total|intcomma }} areas in total have been entered</h3>
+  <div class="radius progress success large-12" role="progressbar" aria-valuenow="{{ results_entered }}" aria-valuemin="0" aria-valuemax="{{ areas_total }}">
+    <span class="meter" style="width: {{ results_percent }}%"></span>
 
-</div>
+  </div>
 
+
+  <h2>By region</h2>
+  <div class="region-grid" style="display: flex;flex-wrap: wrap;margin: -0.5em;">
+    {% for nuts1_id, stats in results_progress_by_region.items %}
+      <section style="flex: 1 0 45%;margin: 0.5em;">
+        <hr>
+        <h3 style="font-size: 1.2em"><a
+        href="{% url "election_list_view" %}?filter_by_region={{ nuts1_id }}">{{ stats.label }}: {{ stats.posts_total }}
+          ballots</a></h3>
+        <div class="row">
+          <div class="columns large-12">
+            <p style="margin-bottom: 0"><strong>{{ stats.has_results|intcomma }}</strong> entered</p>
+            <div class="radius progress success large-12" role="progressbar"
+                aria-valuenow="{{ stats.has_results }}"
+                aria-valuemin="0" aria-valuemax="{{ stats.posts_total }}">
+              <span class="meter" style="width: {{ stats.has_results_percent }}%"></span>
+            </div>
+          </div>
+        </div>
+        <p>Out of {{ stats.posts_total|intcomma }} areas in total
+          <strong>{{ stats.has_results|intcomma }}</strong> areas have had results entered.
+        </p>
+      </section>
+    {% endfor %}
+  </div>
+
+  <h2>By election type</h2>
+  <div class="region-grid" style="display: flex;flex-wrap: wrap;margin: -0.5em;">
+    {% for election_type, stats in results_progress_by_election_type.items %}
+      <section style="flex: 1 0 45%;margin: 0.5em;">
+        <hr>
+        <h3 style="font-size: 1.2em"><a
+        href="{% url "election_list_view" %}?election_type={{ election_type }}">{{ stats.label }}: {{ stats.posts_total }}
+          ballots</a></h3>
+        <div class="row">
+          <div class="columns large-12">
+            <p style="margin-bottom: 0"><strong>{{ stats.has_results|intcomma }}</strong> entered</p>
+            <div class="radius progress success large-12" role="progressbar"
+                 aria-valuenow="{{ stats.has_results }}"
+                 aria-valuemin="0" aria-valuemax="{{ stats.posts_total }}">
+              <span class="meter" style="width: {{ stats.has_results_percent }}%"></span>
+            </div>
+          </div>
+        </div>
+        <p>Out of {{ stats.posts_total|intcomma }} areas in total
+          <strong>{{ stats.has_results|intcomma }}</strong> areas have had results entered.
+        </p>
+      </section>
+    {% endfor %}
+  </div>
 
 {% endif %}

--- a/ynr/apps/elections/uk/templates/includes/results_progress.html
+++ b/ynr/apps/elections/uk/templates/includes/results_progress.html
@@ -15,7 +15,7 @@
     {% for nuts1_id, stats in results_progress_by_region.items %}
       <section style="flex: 1 0 45%;margin: 0.5em;">
         <hr>
-        <h3 style="font-size: 1.2em"><a
+        <h3 style="font-size: 1.2em; min-width: 275.5px; min-height: 52px"><a
         href="{% url "election_list_view" %}?filter_by_region={{ nuts1_id }}&{{ has_results_shortcut.querystring }}">{{ stats.label }}: {{ stats.posts_total }}
           ballots</a></h3>
         <div class="row">
@@ -40,7 +40,7 @@
     {% for election_type, stats in results_progress_by_election_type.items %}
       <section style="flex: 1 0 45%;margin: 0.5em;">
         <hr>
-        <h3 style="font-size: 1.2em"><a
+        <h3 style="font-size: 1.2em; min-width: 275.5px; min-height: 52px"><a
         href="{% url "election_list_view" %}?election_type={{ election_type }}&{{ has_results_shortcut.querystring }}">{{ stats.label }}: {{ stats.posts_total }}
           ballots</a></h3>
         <div class="row">

--- a/ynr/apps/elections/uk/templates/includes/results_progress.html
+++ b/ynr/apps/elections/uk/templates/includes/results_progress.html
@@ -16,7 +16,7 @@
       <section style="flex: 1 0 45%;margin: 0.5em;">
         <hr>
         <h3 style="font-size: 1.2em"><a
-        href="{% url "election_list_view" %}?filter_by_region={{ nuts1_id }}">{{ stats.label }}: {{ stats.posts_total }}
+        href="{% url "election_list_view" %}?filter_by_region={{ nuts1_id }}&{{ has_results_shortcut.querystring }}">{{ stats.label }}: {{ stats.posts_total }}
           ballots</a></h3>
         <div class="row">
           <div class="columns large-12">
@@ -41,7 +41,7 @@
       <section style="flex: 1 0 45%;margin: 0.5em;">
         <hr>
         <h3 style="font-size: 1.2em"><a
-        href="{% url "election_list_view" %}?election_type={{ election_type }}">{{ stats.label }}: {{ stats.posts_total }}
+        href="{% url "election_list_view" %}?election_type={{ election_type }}&{{ has_results_shortcut.querystring }}">{{ stats.label }}: {{ stats.posts_total }}
           ballots</a></h3>
         <div class="row">
           <div class="columns large-12">

--- a/ynr/apps/elections/uk/templates/includes/results_progress.html
+++ b/ynr/apps/elections/uk/templates/includes/results_progress.html
@@ -1,14 +1,13 @@
 {% load humanize %}
 {% if SHOW_RESULTS_PROGRESS %}
   <h3>Enter results as they come in</h3>
-  <p><a href="{% url "results-home"%}" class="button">Get started</a></p>
+  <p><a href="{% url "election_list_view"%}?{{ has_results_shortcut.querystring }}" class="button">Get started</a></p>
+  <p><a href="{% url "results-home"%}" class="button">Get the data</a></p>
 
   <h3>{{ results_percent }}% of votes for {{ areas_total|intcomma }} areas in total have been entered</h3>
   <div class="radius progress success large-12" role="progressbar" aria-valuenow="{{ results_entered }}" aria-valuemin="0" aria-valuemax="{{ areas_total }}">
     <span class="meter" style="width: {{ results_percent }}%"></span>
-
   </div>
-
 
   <h2>By region</h2>
   <div class="region-grid" style="display: flex;flex-wrap: wrap;margin: -0.5em;">

--- a/ynr/apps/elections/uk/templatetags/home_page_tags.py
+++ b/ynr/apps/elections/uk/templatetags/home_page_tags.py
@@ -4,6 +4,7 @@ from django.db.models import Sum, IntegerField, Count, Func, F, Value, TextField
 from django.db.models.functions import Cast
 
 from candidates.models import Ballot
+from elections.filters import filter_shortcuts
 from elections.models import Election
 from popolo.models import Membership
 
@@ -200,6 +201,11 @@ def results_progress(context):
             lookup_value="election_type",
             label_field="election__for_post_role",
         )
+
+    shortcuts = filter_shortcuts(context["request"])["list"]
+    context["has_results_shortcut"] = [
+        shortcut for shortcut in shortcuts if shortcut["name"] == "has_results"
+    ][0]
 
     return context
 

--- a/ynr/apps/elections/uk/templatetags/home_page_tags.py
+++ b/ynr/apps/elections/uk/templatetags/home_page_tags.py
@@ -40,7 +40,7 @@ def results_progress_by_value(base_qs, lookup_value, label_field=None):
         results_count=Count(
             "ballot_paper_id", distinct=True, filter=results_filter
         )
-    )
+    ).order_by(lookup_value)
     values_dict = {}
 
     for row in ballot_qs:

--- a/ynr/apps/elections/uk/tests/test_hompage_tags.py
+++ b/ynr/apps/elections/uk/tests/test_hompage_tags.py
@@ -1,0 +1,47 @@
+from django.test import TestCase
+from candidates.models.popolo_extra import Ballot
+
+from candidates.tests.test_models import BallotsWithResultsMixin
+from elections.filters import region_choices
+from elections.uk.templatetags.home_page_tags import results_progress_by_value
+
+
+class TestResultsProgress(BallotsWithResultsMixin, TestCase):
+    def test_for_regions(self):
+        values = ["tags__NUTS1__key", "tags__NUTS1__value"]
+        # create 10 ballots for each region without any results
+        for code, label in region_choices():
+            tags = {"NUTS1": {"key": code, "value": label}}
+            self.create_ballots_with_results(num=10, tags=tags)
+
+        # create 5 ballots for each region WITH results
+        for code, label in region_choices():
+            tags = {"NUTS1": {"key": code, "value": label}}
+            self.create_ballots_with_results(num=4, resultset=True, tags=tags)
+
+        # create 1 ballots for each region with only elected candidate
+        for code, label in region_choices():
+            tags = {"NUTS1": {"key": code, "value": label}}
+            self.create_ballots_with_results(
+                num=1, resultset=False, elected=True, tags=tags
+            )
+
+        result = results_progress_by_value(
+            base_qs=Ballot.objects.all(),
+            lookup_value="tags__NUTS1__key",
+            label_field="tags__NUTS1__value",
+        )
+        # build how we expect
+        expected = {}
+        for code, label in region_choices():
+            expected[code] = {
+                "tags__NUTS1__key": code,
+                "tags__NUTS1__value": label,
+                "count": 15,
+                "results_count": 5,
+                "label": label,
+                "posts_total": 15,
+                "has_results": 5,
+                "has_results_percent": 33,
+            }
+        self.assertEqual(result, expected)

--- a/ynr/apps/uk_results/templates/uk_results/current_elections_with_no_resuts.html
+++ b/ynr/apps/uk_results/templates/uk_results/current_elections_with_no_resuts.html
@@ -16,6 +16,6 @@
 {% empty %}
 <p>There are no recent elections requiring results!</p>
 
-<p>Why not view the <a href="https://candidates.democracyclub.org.uk/elections/">list of upcoming elections</a>instead?</p>
+<p>Why not view the <a href="https://candidates.democracyclub.org.uk/elections/">list of upcoming elections </a>instead?</p>
 {% endfor %}
 {% endblock content %}

--- a/ynr/apps/uk_results/templates/uk_results/home.html
+++ b/ynr/apps/uk_results/templates/uk_results/home.html
@@ -29,6 +29,8 @@
   <a href="https://candidates.democracyclub.org.uk/api/v0.9/result_sets/?election_date=2018-05-03" class="button success">
     All 2018 results</a>
   <a href="https://candidates.democracyclub.org.uk/api/v0.9/result_sets/?election_date=2019-05-02" class="button success">
+    All 2021 results</a>
+  <a href="https://candidates.democracyclub.org.uk/api/next/results/?election_date=2021-05-06" class="button success">
     All 2019 results</a>
 </p>
 

--- a/ynr/settings/base.py
+++ b/ynr/settings/base.py
@@ -266,7 +266,6 @@ PIPELINE = {
                 "scss/select2.css",
                 "moderation_queue/css/photo-upload.scss",
                 "frontend/css/frontend.scss",
-                "scss/results.scss",
             ),
             "output_filename": "css/all.css",
         },

--- a/ynr/settings/base.py
+++ b/ynr/settings/base.py
@@ -266,6 +266,7 @@ PIPELINE = {
                 "scss/select2.css",
                 "moderation_queue/css/photo-upload.scss",
                 "frontend/css/frontend.scss",
+                "scss/results.scss",
             ),
             "output_filename": "css/all.css",
         },


### PR DESCRIPTION
- Adds results_progress_by_value helper
- Display progress bars per region/election type
- Format region grid equally regardless of contents, for both mobile and web
<img width="678" alt="Screen Shot 2021-05-06 at 6 30 06 PM" src="https://user-images.githubusercontent.com/7017118/117340923-63a63b80-ae99-11eb-871c-d06bd8dd0c18.png">, 

<img width="415" alt="Screen Shot 2021-05-06 at 6 30 45 PM" src="https://user-images.githubusercontent.com/7017118/117340920-62750e80-ae99-11eb-8b18-65b412fe093f.png">
