### PR TITLE
Correct button labels for votes api

### DIFF
--- a/ynr/apps/uk_results/templates/uk_results/home.html
+++ b/ynr/apps/uk_results/templates/uk_results/home.html
@@ -29,9 +29,9 @@
   <a href="https://candidates.democracyclub.org.uk/api/v0.9/result_sets/?election_date=2018-05-03" class="button success">
     All 2018 results</a>
   <a href="https://candidates.democracyclub.org.uk/api/v0.9/result_sets/?election_date=2019-05-02" class="button success">
-    All 2021 results</a>
-  <a href="https://candidates.democracyclub.org.uk/api/next/results/?election_date=2021-05-06" class="button success">
     All 2019 results</a>
+  <a href="https://candidates.democracyclub.org.uk/api/next/results/?election_date=2021-05-06" class="button success">
+    All 2021 results</a>
 </p>
 
 <h4>CSV</h4>


### PR DESCRIPTION
2019 was linking to 2021 results and vice versa. This  work swaps the buttons.