### PR TITLE
Use distinct when counting on election list view annotations

### DIFF
--- a/ynr/apps/elections/templates/elections/election_list.html
+++ b/ynr/apps/elections/templates/elections/election_list.html
@@ -103,7 +103,7 @@
           <td>
             <a href="{{ ballot.get_absolute_url }}">{{ ballot.post.label }}</a>
             {% if ballot.election.modgov_url %}
-              <span class="round alert label">Results added by API</span>
+              <span class="round alert label">Results may be added by ResultsBot</span>
             {% endif %}
           </td>
           <td>{{ ballot.memberships_count }}</td>

--- a/ynr/apps/elections/uk/every_election.py
+++ b/ynr/apps/elections/uk/every_election.py
@@ -240,7 +240,7 @@ class EEElection(dict):
             # Get the winner count
             winner_count = self["seats_contested"]
 
-            voting_system = parent["voting_system"] or {}
+            voting_system = self.get("voting_system", {}) or {}
             (
                 self.ballot_object,
                 self.ballot_created,

--- a/ynr/apps/elections/views.py
+++ b/ynr/apps/elections/views.py
@@ -67,11 +67,10 @@ class ElectionListView(TemplateView):
             .select_related("election", "post")
             .prefetch_related("suggestedpostlock_set")
             .prefetch_related("officialdocument_set")
-            .annotate(memberships_count=Count("membership"))
-            .annotate(elected_count=Count("membership__elected"))
+            .annotate(memberships_count=Count("membership", distinct=True))
+            .annotate(elected_count=Count("membership__elected", distinct=True))
             .order_by("election__election_date", "election__name")
         )
-
         f = CurrentOrFutureBallotFilter(self.request.GET, qs)
 
         context["filter"] = f

--- a/ynr/apps/popolo/querysets.py
+++ b/ynr/apps/popolo/querysets.py
@@ -91,7 +91,12 @@ class MembershipQuerySet(DateframeableQuerySet):
     def memberships_for_ballot(
         self, ballot, exclude_memberships_qs=None, exclude_people_qs=None
     ):
-        order_by = ["elected", "-result__is_winner", "-result__num_ballots"]
+        elected_ordering = models.F("elected").desc(nulls_last=True)
+        order_by = [
+            elected_ordering,
+            "-result__is_winner",
+            "-result__num_ballots",
+        ]
         if ballot.election.party_lists_in_use:
             order_by += ["party__name", "party_list_position"]
         else:

--- a/ynr/apps/uk_results/templates/uk_results/ballot_paper_results_form.html
+++ b/ynr/apps/uk_results/templates/uk_results/ballot_paper_results_form.html
@@ -15,9 +15,7 @@
   {% if ballot.election.modgov_url %}
     <h3>Before entering results please note:</h3>
     <p>
-      We have a possible API url for this ballot to retrieve the results direct
-      from the council when they have been published. This may save time unless
-      you already have found the results for this ballot and which to enter them manually.
+      Results may be added by ResultsBot - but go ahead if you wish to enter them yourself.
     </p>
   {% endif %}
   {% include "uk_results/includes/ballot_paper_results_form.html" with results_form=form %}


### PR DESCRIPTION
Baffled as to why this _wouldnt_ be the default.

Before changes screenshot - candidates for Ecclesall should be 3, and should say results "Completed":

<img width="1304" alt="Screenshot 2021-05-07 at 09 38 13" src="https://user-images.githubusercontent.com/15347726/117422916-09988b00-af18-11eb-861a-bc263e772e69.png">

After changes:

<img width="1304" alt="Screenshot 2021-05-07 at 09 38 30" src="https://user-images.githubusercontent.com/15347726/117423008-203ee200-af18-11eb-930e-6aa0210b92a9.png">
