### PR TITLE
Hotfix/add results button

### DIFF
--- a/ynr/apps/elections/templates/elections/election_list.html
+++ b/ynr/apps/elections/templates/elections/election_list.html
@@ -126,7 +126,7 @@
           </td>
           {% if ballot.polls_closed %}
           <td>
-              {% if ballot.elected_count == ballot.winner_count %}
+              {% if ballot.elected_count >= ballot.get_winner_count %}
                 Completed
               {% elif user_can_record_results %}
                 <a href="{{ ballot.get_results_url }}" class="button tiny">{{ ballot.results_button_text }}</a>

--- a/ynr/apps/uk_results/models.py
+++ b/ynr/apps/uk_results/models.py
@@ -44,7 +44,7 @@ class ResultSet(TimeStampedModel):
             return None
 
         percentage = (self.num_turnout_reported / self.total_electorate) * 100
-        self.turnout_percentage = round(percentage, 2)
+        self.turnout_percentage = min(round(percentage, 2), 100)
 
     def as_dict(self):
         """

--- a/ynr/apps/uk_results/tests/test_uk_results.py
+++ b/ynr/apps/uk_results/tests/test_uk_results.py
@@ -125,3 +125,8 @@ class TestUKResults(TestUserMixin, UK2015ExamplesMixin, TestCase):
             with self.subTest(msg=result):
                 result.calculate_turnout_percentage()
                 self.assertIsNone(result.turnout_percentage)
+
+    def test_turnout_percentage_max_100(self):
+        result = ResultSet(num_turnout_reported=100, total_electorate=50)
+        result.calculate_turnout_percentage()
+        self.assertEqual(result.turnout_percentage, 100)


### PR DESCRIPTION
There is still something weird going on when the [elected_count](https://github.com/DemocracyClub/yournextrepresentative/blob/master/ynr/apps/elections/views.py#L71) is being annotated - it is coming back as 2 in cases where only 1 person is elected. Which ends up meaning the "Add results" button still displays after results have been added. 

Cant get to the bottom of the issue with the query, but while I keep investigating changing the conditional in the template to use ` ballot.elected_count >= ballot.get_winner_count` should stop the button being displayed incorrectly.

Also updates `calculate_turnout_percentage` to stop this ever being more than 100%.