### PR TITLE
Fix elected_count annotation on ElectionListView

### DIFF
--- a/ynr/apps/candidates/tests/test_models.py
+++ b/ynr/apps/candidates/tests/test_models.py
@@ -55,7 +55,7 @@ class BallotsWithResultsMixin(SingleBallotStatesMixin):
         self.parties = self.create_parties(3)
 
     def create_ballots_with_results(
-        self, num, resultset=False, elected=False, **kwargs
+        self, num, resultset=False, elected=False, num_winners=1, **kwargs
     ):
         results = []
         for i in range(num):
@@ -74,9 +74,10 @@ class BallotsWithResultsMixin(SingleBallotStatesMixin):
                 elected = True
 
             if elected:
-                winner = ballot.membership_set.first()
-                winner.elected = True
-                winner.save()
+                winners = ballot.membership_set.all()[:num_winners]
+                for winner in winners:
+                    winner.elected = True
+                    winner.save()
 
             results.append(ballot)
 

--- a/ynr/apps/elections/tests/test_election_list_view.py
+++ b/ynr/apps/elections/tests/test_election_list_view.py
@@ -1,11 +1,21 @@
 from django.contrib.auth.models import User
+from django.http import QueryDict
+from django.test import RequestFactory, TestCase
 from django_webtest import WebTest
+from candidates.models.popolo_extra import Ballot
+from candidates.tests.test_models import BallotsWithResultsMixin
 
 from candidates.tests.uk_examples import UK2015ExamplesMixin
+from elections.views import ElectionListView
 from moderation_queue.models import SuggestedPostLock
+
+from mock import patch
 
 
 class TestPostsView(UK2015ExamplesMixin, WebTest):
+    def setUp(self):
+        return super().setUp()
+
     def test_single_election_posts_page(self):
 
         response = self.app.get("/elections/")
@@ -71,3 +81,52 @@ class TestPostsView(UK2015ExamplesMixin, WebTest):
         self.assertEqual(
             dict(response.context["filter"].data), {"election_type": ["local"]}
         )
+
+
+class TestResultsAnnotated(BallotsWithResultsMixin, TestCase):
+    def setUp(self):
+        self.rf = RequestFactory()
+        self.request = self.rf.get("/elections/")
+        self.request.GET = QueryDict(
+            "has_results=1&review_required=locked&is_cancelled=0"
+        )
+        return super().setUp()
+
+    def test_elections_annotated_correctly(self):
+
+        # create 10 ballots matching out filter above
+        self.create_ballots_with_results(
+            num=10,
+            resultset=True,
+            candidates_locked=True,
+            winner_count=1,
+            num_winners=1,
+        )
+
+        # create 10 more with two winners each
+        self.create_ballots_with_results(
+            num=10,
+            resultset=True,
+            candidates_locked=True,
+            winner_count=2,
+            num_winners=2,
+        )
+        view = ElectionListView()
+        view.setup(request=self.request)
+
+        with patch.object(
+            Ballot.objects,
+            "current_or_future",
+            return_value=Ballot.objects.all(),
+        ):
+            context = view.get_context_data()
+
+            qs = context["queryset"]
+            # expect 20 in total
+            self.assertEqual(qs.count(), 20)
+            # 10 where 1 person elected
+            self.assertEqual(qs.filter(elected_count=1).count(), 10)
+            # 10 where two people were elected
+            self.assertEqual(qs.filter(elected_count=2).count(), 10)
+            # all have same num candidates
+            self.assertEqual(qs.filter(memberships_count=9).count(), 20)


### PR DESCRIPTION
Figured out why the `elected_count` value being annotated was returning strange results - the query wasn't correct. Updated so that we explicitly only count the members that are elected=True.

Added a unit test to check - with previous query applied this fails.
