### PR TITLE
Dont always make twitterAPI request on person save

### DIFF
--- a/ynr/apps/people/forms/forms.py
+++ b/ynr/apps/people/forms/forms.py
@@ -93,6 +93,10 @@ class PersonIdentifierForm(forms.ModelForm):
     def clean_twitter_username(self, username):
         if self.instance.value != username:
             self.instance.internal_identifier = None
+
+        if self.instance.internal_identifier:
+            return username
+
         try:
             return clean_twitter_username(username)
         except ValueError as e:


### PR DESCRIPTION
- When saving a Person, we should not make a request to get their
internal identifier if the username has not changed and we already
have one stored

Related to [sentry error](https://sentry.io/organizations/democracy-club-gp/issues/2354426635/?project=169287&query=is%3Aunresolved) that is causing a 500 when saving a candidate