### PR TITLE
Dont validate against winner count if it is None

### DIFF
--- a/ynr/apps/uk_results/forms.py
+++ b/ynr/apps/uk_results/forms.py
@@ -89,6 +89,9 @@ class ResultSetForm(forms.ModelForm):
         """
         cleaned_data = super().clean()
 
+        if self.ballot.winner_count is None:
+            return cleaned_data
+
         if len(self._tied_vote_winners) > self.ballot.winner_count:
             raise forms.ValidationError(
                 "Cant have more coin toss winners than seats up!"

--- a/ynr/apps/uk_results/tests/test_forms.py
+++ b/ynr/apps/uk_results/tests/test_forms.py
@@ -58,6 +58,19 @@ class TestResultSetForm(TestUserMixin, UK2015ExamplesMixin, WebTest, TestCase):
                 str(e), "Cant have more coin toss winners than seats up!"
             )
 
+    def test_clean_winner_count_none(self):
+        """
+        If we dont know the winner count, dont validate it against the tied vote winners
+        """
+        self.ballot.winner_count = None
+        form = ResultSetForm(ballot=self.ballot)
+        cleaned_data = {}
+        for candidacy in self.candidacies:
+            cleaned_data[f"tied_vote_memberships_{candidacy.pk}"] = True
+
+        form.cleaned_data = cleaned_data
+        self.assertEqual(form.clean(), cleaned_data)
+
     def test_tied_vote_winners(self):
         form = ResultSetForm(ballot=self.ballot)
         cleaned_data = {}


### PR DESCRIPTION
- Fixes bug when saving a result where we dont know the winner_count
- https://sentry.io/organizations/democracy-club-gp/issues/2405035070/?project=169287&query=is%3Aunresolved

Related to https://github.com/DemocracyClub/yournextrepresentative/issues/1497