### PR TITLE
Hotfix/Fix add candidates button

### DIFF
--- a/ynr/apps/elections/templates/elections/election_detail.html
+++ b/ynr/apps/elections/templates/elections/election_detail.html
@@ -72,7 +72,7 @@
   {% endif %}
 
   {% if not ballot.cancelled %}
-    <a class="show-new-candidate-form button tiny" href="{{ ballot.get_absolute_url }}">Add candidates</a>
+    <a class="button tiny" href="{{ ballot.get_absolute_url }}">Add candidates</a>
     {% if ballot.election.in_past %}
       {% if ballot.resultset %}
       <a class="button tiny" href="{% url "ballot_paper_results_form" ballot.ballot_paper_id %}">Edit Results</a>


### PR DESCRIPTION
Closes https://github.com/DemocracyClub/yournextrepresentative/issues/1331

This is a quick fix to get the button working again. However, we might consider refactoring to add the new candidate form on click - as it's done on the ballot page - but I think this is a larger convo around user journeys. 