### PR TITLE
Flake 8

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,5 +1,5 @@
 [flake8]
-ignore = E203, E266, E501, W503, F403, F401 E722 F841 F405
+ignore = E203, E266, E501, W503, E722
 max-line-length = 79
 max-complexity = 18
 select = B,C,E,F,W,T4,B9

--- a/.flake8
+++ b/.flake8
@@ -3,3 +3,4 @@ ignore = E203, E266, E501, W503, F403, F401 E722 F841 F405
 max-line-length = 79
 max-complexity = 18
 select = B,C,E,F,W,T4,B9
+exclude = ynr/settings/local.py

--- a/ynr/apps/api/tests/test_api_v09.py
+++ b/ynr/apps/api/tests/test_api_v09.py
@@ -173,9 +173,7 @@ class TestAPI(TestUserMixin, TmpMediaRootMixin, UK2015ExamplesMixin, WebTest):
         from candidates.tests.uk_examples import EXAMPLE_PARTIES
 
         for party in EXAMPLE_PARTIES:
-            p = OrganizationFactory(
-                slug=party["legacy_slug"], name=party["name"]
-            )
+            OrganizationFactory(slug=party["legacy_slug"], name=party["name"])
 
     def test_api_legacy_organizations_with_parties(self):
         self._make_legacy_parties()
@@ -326,7 +324,6 @@ class TestAPI(TestUserMixin, TmpMediaRootMixin, UK2015ExamplesMixin, WebTest):
         # timestamped
         # timestamped
         mock_datetime.now.return_value = datetime(2017, 5, 14, 12, 33, 5, 0)
-        target_directory = settings.MEDIA_ROOT
         call_command(
             "candidates_cache_api_to_directory",
             page_size="3",

--- a/ynr/apps/api/v09/views.py
+++ b/ynr/apps/api/v09/views.py
@@ -97,7 +97,6 @@ class CandidatesAndElectionsForPostcodeViewSet(ViewSet):
         coords = request.GET.get("coords", None)
 
         # TODO: postcode may not make sense everywhere
-        errors = None
         if not postcode and not coords:
             return self._error("Postcode or Co-ordinates required")
 

--- a/ynr/apps/bulk_adding/tests/test_bulk_add.py
+++ b/ynr/apps/bulk_adding/tests/test_bulk_add.py
@@ -27,8 +27,6 @@ class TestBulkAdding(TestUserMixin, UK2015ExamplesMixin, WebTest):
         self.assertNotContains(response, "Review")
 
     def testFormIfSopn(self):
-        post = self.dulwich_post
-
         OfficialDocument.objects.create(
             source_url="http://example.com",
             document_type=OfficialDocument.NOMINATION_PAPER,
@@ -120,8 +118,6 @@ class TestBulkAdding(TestUserMixin, UK2015ExamplesMixin, WebTest):
         self.assertEqual(response.status_code, 200)
 
     def test_submitting_form(self):
-        post = self.dulwich_post
-
         OfficialDocument.objects.create(
             source_url="http://example.com",
             document_type=OfficialDocument.NOMINATION_PAPER,
@@ -423,7 +419,7 @@ class TestBulkAdding(TestUserMixin, UK2015ExamplesMixin, WebTest):
         existing_person = PersonFactory.create(
             id="1234567", name="Bart Simpson"
         )
-        existing_membership = MembershipFactory.create(
+        MembershipFactory.create(
             person=existing_person,
             # !!! This is the line that differs from the previous test:
             post=self.dulwich_post,
@@ -453,7 +449,7 @@ class TestBulkAdding(TestUserMixin, UK2015ExamplesMixin, WebTest):
             id="1234567", name="Bart Simpson"
         )
 
-        existing_membership = MembershipFactory.create(
+        MembershipFactory.create(
             person=existing_person,
             # !!! This is the line that differs from the previous test:
             post=self.dulwich_post,

--- a/ynr/apps/cached_counts/models.py
+++ b/ynr/apps/cached_counts/models.py
@@ -1,12 +1,9 @@
-from datetime import datetime
-
 from django.db.models import Count
 
 from candidates.models import Ballot
 
 
 def get_attention_needed_posts():
-    now = datetime.now()
     qs = Ballot.objects.current_or_future()
     qs = qs.select_related("election", "post")
     qs = qs.annotate(count=Count("membership"))

--- a/ynr/apps/cached_counts/report_helpers.py
+++ b/ynr/apps/cached_counts/report_helpers.py
@@ -532,6 +532,7 @@ class GenderSplitByParty(BaseReport):
         qs = self.get_qs()
         report_list = []
         headers = ["Gender", "Gender Count", "Party Name"]
+        report_list.append(headers)
         for gender in qs:
             report_list.append(
                 [
@@ -559,6 +560,7 @@ class GenderSplitByRegion(BaseReport):
         qs = self.get_qs()
         report_list = []
         headers = ["Gender", "Gender Count", "Region"]
+        report_list.append(headers)
         for gender in qs:
             report_list.append(
                 [
@@ -587,6 +589,7 @@ class GenderSplitByElectionType(BaseReport):
         qs = self.get_qs()
         report_list = []
         headers = ["Gender", "Gender Count", "Party Name"]
+        report_list.append(headers)
         for gender in qs:
             report_list.append(
                 [

--- a/ynr/apps/candidates/management/commands/candidates_import_from_live_site.py
+++ b/ynr/apps/candidates/management/commands/candidates_import_from_live_site.py
@@ -97,8 +97,6 @@ class Command(BaseCommand):
         )
 
     def get_api_results(self, endpoint, api_version="next"):
-        page = 1
-
         if "ballots" in endpoint:
             url = "{base_url}/media/cached-api/latest/ballots-000001.json".format(
                 base_url=self.ynr_url

--- a/ynr/apps/candidates/management/commands/candidates_import_statements_of_persons_nominated.py
+++ b/ynr/apps/candidates/management/commands/candidates_import_statements_of_persons_nominated.py
@@ -85,8 +85,6 @@ class Command(BaseCommand):
                     print("Removing existing documents")
                     existing_documents.delete()
                 else:
-                    msg = "Skipping {0} since it already had documents for {1}"
-                    # print(msg.format(name, election))
                     continue
             try:
                 downloaded_filename = download_file_cached(document_url)

--- a/ynr/apps/candidates/management/commands/candidates_import_statements_of_persons_nominated.py
+++ b/ynr/apps/candidates/management/commands/candidates_import_statements_of_persons_nominated.py
@@ -60,7 +60,7 @@ class Command(BaseCommand):
         parser.add_argument("--delete-existing", action="store_true")
         parser.add_argument("url")
 
-    def handle(self, *args, **options):
+    def handle(self, *args, **options):  # noqa
 
         csv_url = options["url"]
 

--- a/ynr/apps/candidates/tests/dates.py
+++ b/ynr/apps/candidates/tests/dates.py
@@ -9,9 +9,11 @@ date_in_near_past = date.today() - timedelta(days=14)
 
 FOUR_YEARS_IN_DAYS = 1462
 
-election_date_before = lambda r: {"DATE_TODAY": date.today()}
-election_date_on_election_day = lambda r: {"DATE_TODAY": date_in_near_future}
-election_date_after = lambda r: {
+election_date_before = lambda r: {"DATE_TODAY": date.today()}  # noqa
+election_date_on_election_day = lambda r: {  # noqa
+    "DATE_TODAY": date_in_near_future
+}
+election_date_after = lambda r: {  # noqa
     "DATE_TODAY": date.today() + timedelta(days=28)
 }
 

--- a/ynr/apps/duplicates/tests/test_merge_helpers.py
+++ b/ynr/apps/duplicates/tests/test_merge_helpers.py
@@ -15,12 +15,12 @@ class TestMergeHelper(TestUserMixin, TestCase):
         p1, p2, p3 = PersonFactory.create_batch(3)
 
         # suggest they're the same
-        ds = DuplicateSuggestion.objects.create(
+        DuplicateSuggestion.objects.create(
             person=p2, other_person=p1, user=self.user
         )
 
         # suggest someone else is the same
-        ds = DuplicateSuggestion.objects.create(
+        DuplicateSuggestion.objects.create(
             person=p1, other_person=p3, user=self.user
         )
 

--- a/ynr/apps/elections/filters.py
+++ b/ynr/apps/elections/filters.py
@@ -96,7 +96,7 @@ class DSLinkWidget(LinkWidget):
             self.data = {}
         if value is None:
             value = ""
-        final_attrs = self.build_attrs(self.attrs, extra_attrs=attrs)
+        self.build_attrs(self.attrs, extra_attrs=attrs)
         output = []
         options = self.render_options(choices, [value], name)
         if options:

--- a/ynr/apps/elections/migrations/0014_cleanup_for_post_role.py
+++ b/ynr/apps/elections/migrations/0014_cleanup_for_post_role.py
@@ -19,7 +19,6 @@ ROLES_BY_TYPE = {
 def update_for_post_role(apps, schema_editor):
     Election = apps.get_model("elections", "Election")
     for election_type, text in ROLES_BY_TYPE.items():
-        match_str = "{}.".format(election_type)
         Election.objects.filter(slug__startswith=election_type).update(
             for_post_role=text
         )

--- a/ynr/apps/elections/mixins.py
+++ b/ynr/apps/elections/mixins.py
@@ -22,7 +22,7 @@ class ElectionMixin(object):
             self.election_data = self.ballot.election
             self.election = self.ballot.election.slug
         else:
-            self.election = election = self.kwargs["election"]
+            self.election = self.kwargs["election"]
             self.election_data = self.get_election()
         return super().dispatch(request, *args, **kwargs)
 

--- a/ynr/apps/elections/tests/data_timeline_helper.py
+++ b/ynr/apps/elections/tests/data_timeline_helper.py
@@ -49,7 +49,7 @@ class DataTimelineHTMLAssertions(WebTest):
             <div class="timeline_item">
                 <h4>Candidates verified and lock suggested</h4>
                 <div class="status_not_started">
-                    <strong>No lock suggestions</strong> 
+                    <strong>No lock suggestions</strong>
                     Upload a document before suggesting locking
                 </div>
             </div>

--- a/ynr/apps/elections/uk/management/commands/uk_create_joint_pseudo_parties.py
+++ b/ynr/apps/elections/uk/management/commands/uk_create_joint_pseudo_parties.py
@@ -15,7 +15,7 @@ def fix_joint_party_name(joint_party_name):
 
 
 def extract_number_from_id(party_id):
-    m = re.search("\d+", party_id)
+    m = re.search(r"\d+", party_id)
     if m:
         return int(m.group(0), 10)
     return -1

--- a/ynr/apps/elections/uk/management/commands/uk_update_parties_from_ec_data.py
+++ b/ynr/apps/elections/uk/management/commands/uk_update_parties_from_ec_data.py
@@ -19,8 +19,8 @@ base_emblem_url = (
 )
 
 
-def find_index(l, predicate):
-    for i, e in enumerate(l):
+def find_index(list, predicate):
+    for i, e in enumerate(list):
         if predicate(e):
             return i
     return -1
@@ -154,7 +154,7 @@ class Command(BaseCommand):
 
     def clean_name(self, name):
         name = name.strip()
-        if not "de-registered" in name.lower():
+        if "de-registered" not in name.lower():
             return name, "9999-12-31"
 
         match = re.match(r"(.+)\[De-registered ([0-9]+/[0-9]+/[0-9]+)\]", name)

--- a/ynr/apps/elections/uk/management/commands/uk_update_parties_from_ec_data.py
+++ b/ynr/apps/elections/uk/management/commands/uk_update_parties_from_ec_data.py
@@ -19,13 +19,6 @@ base_emblem_url = (
 )
 
 
-def find_index(list, predicate):
-    for i, e in enumerate(list):
-        if predicate(e):
-            return i
-    return -1
-
-
 def get_descriptions(party):
     return [
         {"description": d["Description"], "translation": d["Translation"]}

--- a/ynr/apps/elections/uk/migrations/0001_migrate_area_ids.py
+++ b/ynr/apps/elections/uk/migrations/0001_migrate_area_ids.py
@@ -28,7 +28,7 @@ def mapit_ids_to_gss(apps, schema_editor):
         old_id = area.identifier
         try:
             mapit_area = mapit_data[area.identifier]
-            new_id = mapit.format_code_from_area(mapit_area)
+            new_id = mapit.format_code_from_area(mapit_area)  # noqa
 
             if old_id != new_id:
                 area.identifier = new_id

--- a/ynr/apps/elections/uk/tests/ee_postcode_results.py
+++ b/ynr/apps/elections/uk/tests/ee_postcode_results.py
@@ -21,7 +21,6 @@ ee_sw1a1aa_result = {
                     "notes": "This is just for testing.",
                     "end_date": "2025-05-03",
                 },
-                "official_identifier": "test:9",
                 "seats_total": None,
                 "slug": "9",
             },

--- a/ynr/apps/elections/uk/tests/test_hompage_tags.py
+++ b/ynr/apps/elections/uk/tests/test_hompage_tags.py
@@ -8,7 +8,6 @@ from elections.uk.templatetags.home_page_tags import results_progress_by_value
 
 class TestResultsProgress(BallotsWithResultsMixin, TestCase):
     def test_for_regions(self):
-        values = ["tags__NUTS1__key", "tags__NUTS1__value"]
         # create 10 ballots for each region without any results
         for code, label in region_choices():
             tags = {"NUTS1": {"key": code, "value": label}}

--- a/ynr/apps/moderation_queue/tests/test_set_ministers_liable_to_vandalism.py
+++ b/ynr/apps/moderation_queue/tests/test_set_ministers_liable_to_vandalism.py
@@ -33,7 +33,7 @@ class TestPersonUpdate(TestCase):
         )
         person.save()
 
-        cmd = call_command("moderation_queue_set_ministers_liable_to_vandalism")
+        call_command("moderation_queue_set_ministers_liable_to_vandalism")
         person.refresh_from_db()
         self.assertEqual(
             person.edit_limitations, EditLimitationStatuses.NEEDS_REVIEW.name

--- a/ynr/apps/official_documents/management/commands/official_documents_create_candidate_csv.py
+++ b/ynr/apps/official_documents/management/commands/official_documents_create_candidate_csv.py
@@ -9,9 +9,6 @@ class Command(BaseCommand):
     help = "Create a CSV with candidate info form the SOPNs"
 
     def handle(self, *args, **options):
-        import time
-
-        start_time = time.time()
         fieldnames = (
             "election_id",
             "division_id",

--- a/ynr/apps/parties/importer.py
+++ b/ynr/apps/parties/importer.py
@@ -33,7 +33,7 @@ def make_slug(party_id):
 
 
 def extract_number_from_id(party_id):
-    m = re.search("\d+", party_id)
+    m = re.search(r"\d+", party_id)
     if m:
         return int(m.group(0), 10)
 
@@ -199,7 +199,7 @@ class ECParty(dict):
         self.created = False
         required_fields = ("RegulatedEntityName", "ECRef", "RegisterName")
         for field in required_fields:
-            if not field in self:
+            if field not in self:
                 raise ValueError("{} missing".format(field))
 
     def save(self):
@@ -252,11 +252,11 @@ class ECParty(dict):
 
         # Remove [De-registered] tag in name
         # (the date is parsed in `date_deregistered`)
-        matcher = re.compile("[\[\(]de(-?)registered .*", flags=re.I)
+        matcher = re.compile(r"[\[\(]de(-?)registered .*", flags=re.I)
         name = matcher.split(name)[0].strip()
 
         # Do some general cleaning
-        name = re.sub("\s+", " ", name)
+        name = re.sub(r"\s+", " ", name)
         return name
 
     @property

--- a/ynr/apps/parties/management/commands/parties_import_from_ec.py
+++ b/ynr/apps/parties/management/commands/parties_import_from_ec.py
@@ -9,14 +9,11 @@ from utils.slack import SlackHelper
 
 class Command(BaseCommand):
     help = """
-    Import policital parties that can stand candidates from The Electoral 
+    Import policital parties that can stand candidates from The Electoral
     Commission's API in to the Parties app.
-    
-    
     This command creates 3 types of object: parties, descriptions and emblems.
-    
-    It also creates joint parties. That is, a psudo-party that allows us to 
-    mark candidates as standing for 2 parties.  
+    It also creates joint parties. That is, a psudo-party that allows us to
+    mark candidates as standing for 2 parties.
     """
 
     def add_arguments(self, parser):

--- a/ynr/apps/parties/management/commands/parties_update_current_candidates.py
+++ b/ynr/apps/parties/management/commands/parties_update_current_candidates.py
@@ -6,7 +6,6 @@ from parties.models import Party
 class Command(BaseCommand):
     help = """
     Update the current and total candidates field on the `Party` model
-    
     Designed to be run on a cron daily.
     """
 

--- a/ynr/apps/people/migrations/0009_copy_popolo_fields_to_person_identifiers.py
+++ b/ynr/apps/people/migrations/0009_copy_popolo_fields_to_person_identifiers.py
@@ -46,7 +46,7 @@ def populate_person_identifier_from_popolo_models(apps, schema_editor):
     links_to_move = []
     for link in qs:
         person_id = link.object_id
-        if not person_id in links_by_person:
+        if person_id not in links_by_person:
             links_by_person[person_id] = set()
 
         if link.url in links_by_person[person_id]:

--- a/ynr/apps/people/migrations/0021_populate_json_versions.py
+++ b/ynr/apps/people/migrations/0021_populate_json_versions.py
@@ -9,7 +9,7 @@ def populate_json_versions(apps, schema):
     for person in Person.objects.all():
         try:
             person.json_versions = json.loads(person.versions)
-        except json.decoder.JSONDecodeError as e:
+        except json.decoder.JSONDecodeError:
             person.json_versions = {}
         person.save()
 

--- a/ynr/apps/people/models.py
+++ b/ynr/apps/people/models.py
@@ -634,7 +634,6 @@ class Person(TimeStampedModel, models.Model):
         return person
 
     def dict_for_csv(self, base_url=None):
-        elected_for_csv = ""
         image_copyright = ""
         image_uploading_user = ""
         image_uploading_user_notes = ""

--- a/ynr/apps/people/tests/test_merge_view.py
+++ b/ynr/apps/people/tests/test_merge_view.py
@@ -228,9 +228,8 @@ class TestMergePeopleView(TestUserMixin, UK2015ExamplesMixin, WebTest):
         non_primary_person = Person.objects.get(pk=2007)
         self.assertEqual(Membership.objects.count(), 4)
         response = self.app.get(
-            f"/person/{primary_person.pk}/", user=self.user_who_can_merge
+            primary_person.get_absolute_url(), user=self.user_who_can_merge
         )
-
         # first submit suggestion form
         suggestion_form = response.forms[SUGGESTION_FORM_ID]
         suggestion_form["other_person"] = "2007"
@@ -240,9 +239,10 @@ class TestMergePeopleView(TestUserMixin, UK2015ExamplesMixin, WebTest):
         merge_form = response.forms[MERGE_FORM_ID]
         response = merge_form.submit()
 
+        non_primary_person.refresh_from_db()
         self.assertEqual(response.status_code, 302)
         self.assertEqual(
-            response.location, f"/person/{non_primary_person.pk}/tessa-jowell"
+            response.location, non_primary_person.get_absolute_url()
         )
 
         # Check that the redirect object has been made:

--- a/ynr/apps/people/tests/test_merge_view.py
+++ b/ynr/apps/people/tests/test_merge_view.py
@@ -227,7 +227,9 @@ class TestMergePeopleView(TestUserMixin, UK2015ExamplesMixin, WebTest):
         primary_person = Person.objects.get(pk=2009)
         non_primary_person = Person.objects.get(pk=2007)
         self.assertEqual(Membership.objects.count(), 4)
-        response = self.app.get("/person/2009/", user=self.user_who_can_merge)
+        response = self.app.get(
+            f"/person/{primary_person.pk}/", user=self.user_who_can_merge
+        )
 
         # first submit suggestion form
         suggestion_form = response.forms[SUGGESTION_FORM_ID]
@@ -239,7 +241,9 @@ class TestMergePeopleView(TestUserMixin, UK2015ExamplesMixin, WebTest):
         response = merge_form.submit()
 
         self.assertEqual(response.status_code, 302)
-        self.assertEqual(response.location, "/person/2007/tessa-jowell")
+        self.assertEqual(
+            response.location, f"/person/{non_primary_person.pk}/tessa-jowell"
+        )
 
         # Check that the redirect object has been made:
         self.assertEqual(
@@ -641,7 +645,6 @@ class TestMergeViewFullyFrontEnd(TestUserMixin, UK2015ExamplesMixin, WebTest):
         )
         form = response.forms["new-candidate-form"]
         form["name"] = "Foo Bar"
-        election_slug = self.local_ballot.election.slug
         form["party_identifier_1"] = self.labour_party.ec_id
         form["ballot_paper_id"] = self.local_ballot.ballot_paper_id
         form["source"] = "foo bar"
@@ -740,7 +743,6 @@ class TestMergeViewFullyFrontEnd(TestUserMixin, UK2015ExamplesMixin, WebTest):
         )
         form = response.forms["new-candidate-form"]
         form["name"] = "Foo Bar"
-        election_slug = self.earlier_election.slug
         form["party_identifier_1"] = self.labour_party.ec_id
         form[
             "ballot_paper_id"

--- a/ynr/apps/people/tests/test_new_person_view.py
+++ b/ynr/apps/people/tests/test_new_person_view.py
@@ -147,7 +147,7 @@ class TestNewPersonView(TestUserMixin, UK2015ExamplesMixin, WebTest):
         form["source"] = "Testing adding a new person to a post"
         submission_response = form.submit()
         self.assertEqual(submission_response.status_code, 302)
-        person = Person.objects.get(name="Elizabeth Bennet")
+        self.assertTrue(Person.objects.get(name="Elizabeth Bennet"))
 
     def test_party_identifier_has_choices(self):
         url = reverse(

--- a/ynr/apps/people/tests/test_revert.py
+++ b/ynr/apps/people/tests/test_revert.py
@@ -237,9 +237,13 @@ class TestRevertPersonView(TestUserMixin, UK2015ExamplesMixin, WebTest):
         # Now get the person from the database and check if the
         # details are the same as the earlier version:
         person = Person.objects.get(id=2009)
-        self.assertTrue(Membership.objects.filter(person_id=2009).count(), 2)
         self.assertTrue(
-            CandidateResult.objects.filter(membership__person_id=2009).exists()
+            Membership.objects.filter(person_id=person.pk).count(), 2
+        )
+        self.assertTrue(
+            CandidateResult.objects.filter(
+                membership__person_id=person.pk
+            ).exists()
         )
 
     def test_revert_with_memberships(self):
@@ -249,12 +253,12 @@ class TestRevertPersonView(TestUserMixin, UK2015ExamplesMixin, WebTest):
         self.dulwich_post_ballot_earlier.candidates_locked = True
         self.dulwich_post_ballot_earlier.save()
 
-        response = self.app.get("/person/2009/update", user=self.user)
+        response = self.app.get(f"/person/{person.pk}/update", user=self.user)
         form = response.forms[1]
         form["source"] = "made up"
         form.submit()
 
-        response = self.app.get("/person/2009/update", user=self.user)
+        response = self.app.get(f"/person/{person.pk}/update", user=self.user)
         revert_form = response.forms["revert-form-5469de7db0cbd155"]
         revert_form[
             "source"

--- a/ynr/apps/people/tests/test_revert.py
+++ b/ynr/apps/people/tests/test_revert.py
@@ -253,12 +253,12 @@ class TestRevertPersonView(TestUserMixin, UK2015ExamplesMixin, WebTest):
         self.dulwich_post_ballot_earlier.candidates_locked = True
         self.dulwich_post_ballot_earlier.save()
 
-        response = self.app.get(f"/person/{person.pk}/update", user=self.user)
+        response = self.app.get(person.get_edit_url(), user=self.user)
         form = response.forms[1]
         form["source"] = "made up"
         form.submit()
 
-        response = self.app.get(f"/person/{person.pk}/update", user=self.user)
+        response = self.app.get(person.get_edit_url(), user=self.user)
         revert_form = response.forms["revert-form-5469de7db0cbd155"]
         revert_form[
             "source"

--- a/ynr/apps/popolo/behaviors/tests/test_behaviors.py
+++ b/ynr/apps/popolo/behaviors/tests/test_behaviors.py
@@ -61,7 +61,8 @@ class DateframeableTests(BehaviorTestCaseMixin):
 
     def test_querysets_filters(self):
         """Test current, past and future querysets"""
-        past_obj = self.create_instance(
+        # past_obj
+        self.create_instance(
             start_date=datetime.strftime(
                 datetime.now() - timedelta(days=10), "%Y-%m-%d"
             ),
@@ -69,7 +70,8 @@ class DateframeableTests(BehaviorTestCaseMixin):
                 datetime.now() - timedelta(days=5), "%Y-%m-%d"
             ),
         )
-        current_obj = self.create_instance(
+        # current_obj
+        self.create_instance(
             start_date=datetime.strftime(
                 datetime.now() - timedelta(days=5), "%Y-%m-%d"
             ),
@@ -77,7 +79,8 @@ class DateframeableTests(BehaviorTestCaseMixin):
                 datetime.now() + timedelta(days=5), "%Y-%m-%d"
             ),
         )
-        future_obj = self.create_instance(
+        # future_obj
+        self.create_instance(
             start_date=datetime.strftime(
                 datetime.now() + timedelta(days=5), "%Y-%m-%d"
             ),

--- a/ynr/apps/popolo/migrations/0012_move_post_extra_data_to_base.py
+++ b/ynr/apps/popolo/migrations/0012_move_post_extra_data_to_base.py
@@ -7,7 +7,6 @@ from django.db import migrations
 
 def add_extra_fields_to_base(apps, schema_editor):
     Post = apps.get_model("popolo", "Post")
-    PostExtra = apps.get_model("candidates", "PostExtra")
 
     # First, delete any Post objects with no extra
     Post.objects.filter(extra=None).delete()

--- a/ynr/apps/popolo/migrations/0015_move_organization_to_parties.py
+++ b/ynr/apps/popolo/migrations/0015_move_organization_to_parties.py
@@ -53,7 +53,6 @@ def copy_org_to_party(apps, schema_editor):
 
     #  Set up the maps we'll need
     ORG_PK_TO_EC_IDS = {}
-    ORG_PK_TO_OTHER_IDS = {}
     ORG_OBJ_TO_PARTY_OBJ = {}
 
     # Get all the IDs used for Organizations

--- a/ynr/apps/resultsbot/matchers/candidate.py
+++ b/ynr/apps/resultsbot/matchers/candidate.py
@@ -45,7 +45,6 @@ class CandidateMatcher(object):
         return self._memberships
 
     def pick_from_map(self):
-        candidates_for_party = self.get_memberships()
         try:
             key = "{}--{}".format(
                 self.ballot_paper.local_area.ballot_paper_id,

--- a/ynr/apps/resultsbot/matchers/party.py
+++ b/ynr/apps/resultsbot/matchers/party.py
@@ -44,7 +44,7 @@ class PartyMatacher(object):
     def match_party_description(self, cleaned_name):
         try:
             PartyDescription.objects.get(name__iexact=cleaned_name)
-        except Exception as e:
+        except Exception:
             return None
 
     def divison_options(self):

--- a/ynr/apps/sopn_parsing/management/commands/sopn_parsing_extract_tables.py
+++ b/ynr/apps/sopn_parsing/management/commands/sopn_parsing_extract_tables.py
@@ -6,7 +6,6 @@ from sopn_parsing.helpers.text_helpers import NoTextInDocumentError
 class Command(BaseSOPNParsingCommand):
     help = """
     Parse tables out of PDFs in to ParsedSOPN models for later parsing.
-    
     """
 
     def handle(self, *args, **options):

--- a/ynr/settings/testing.py
+++ b/ynr/settings/testing.py
@@ -6,8 +6,8 @@ from .base import *  # noqa
 DATABASES["default"]["CONN_MAX_AGE"] = 0  # noqa
 SITE_NAME = "example.com"
 if os.environ.get("CIRCLECI"):
-    DATABASES["default"]["NAME"] = "ynr"
-    DATABASES["default"]["USER"] = "ynr"
+    DATABASES["default"]["NAME"] = "ynr"  # noqa
+    DATABASES["default"]["USER"] = "ynr"  # noqa
 
 
 class DisableMigrations(object):


### PR DESCRIPTION
I want to get more out of my linter and discovered that part of the problem was that a number of flake8 errors are being excluded. The ones that seemed most glaring/useful were the unused import and unused variable warnings. So I have enabled these and fixed up the errors that already existed in the project.

Split in to two commits - the first to warnings from the unchanged flake8 config file. In a few cases here I have ignored the warning as I didn't want to commit to a bigger refactor. The second commit enables checking for newly enabled error codes. These were all very minor and simple fixes e.g. deleting the unused variable.

I think with these errors now checked it will help improve code quality going forward.