### PR TITLE
Add explicit fallback for party Slack attachments

### DIFF
--- a/ynr/apps/parties/models.py
+++ b/ynr/apps/parties/models.py
@@ -107,6 +107,7 @@ class Party(TimeStampedModel):
 
         attachment = {
             "title": self.name,
+            "fallback": self.name,
             "title_link": "http://search.electoralcommission.org.uk/English/Registrations/{}".format(
                 self.ec_id
             ),


### PR DESCRIPTION
This improves display for people using Slack over IRCCloud. Slack's fallback defaults to the image dimensions of the party emblem, which is not very useful.