### PR TITLE
Fix migrations so that they run cleanly on empty DB

### DIFF
--- a/ynr/apps/moderation_queue/migrations/0014_queuedimage_person.py
+++ b/ynr/apps/moderation_queue/migrations/0014_queuedimage_person.py
@@ -15,7 +15,7 @@ class Migration(migrations.Migration):
             field=models.ForeignKey(
                 blank=True,
                 null=True,
-                to="people.Person",
+                to="popolo.Person",
                 on_delete=models.CASCADE,
             ),
             preserve_default=False,

--- a/ynr/apps/moderation_queue/migrations/0015_migrate_queuedimage_person.py
+++ b/ynr/apps/moderation_queue/migrations/0015_migrate_queuedimage_person.py
@@ -2,7 +2,7 @@ from django.db import migrations
 
 
 def popit_to_db(apps, schema_editor):
-    Person = apps.get_model("people", "Person")
+    Person = apps.get_model("popolo", "person")
     QueuedImage = apps.get_model("moderation_queue", "queuedimage")
     for qi in QueuedImage.objects.all():
         try:

--- a/ynr/apps/popolo/migrations/0026_remove_stale_models.py
+++ b/ynr/apps/popolo/migrations/0026_remove_stale_models.py
@@ -11,6 +11,7 @@ class Migration(migrations.Migration):
         ("popolo", "0025_move_person_fk_to_people_app"),
         ("uk_results", "0047_auto_20180501_1359"),
         ("results", "0026_move_person_fk_to_people_app"),
+        ("moderation_queue", "0024_move_person_fk_to_people_app"),
     ]
 
     operations = [

--- a/ynr/apps/popolo/migrations/0028_rename_post_election_to_ballot.py
+++ b/ynr/apps/popolo/migrations/0028_rename_post_election_to_ballot.py
@@ -11,6 +11,7 @@ class Migration(migrations.Migration):
         ("people", "0014_remove_person_email"),
         ("candidates", "0058_pee_to_ballot"),
         ("popolo", "0027_slug_org_unique_together"),
+        ("parties", "0011_add_initial_candidates_counts"),
     ]
 
     operations = [


### PR DESCRIPTION
- Revert changes in moderation_queue app made in previous commit that
2bcdef4#diff-08fed5bc216bd87881c23595b3f49c415b29b39ff68680f4ec405858683791ca
- Add dependencies to popolo migrations to ensure that the old Person
model still exists when other dependent migrations are run


Steps to test:
- create a new empty database e.g. `createdb ynr_new`
- update your local.py file to change your `DATABASES` dict to use the name of your new database
- run `python manage.py migrate`
- Migrations should run cleanly with no errors
- Delete the database you created and change your `local.py` settings back to use previous DB name