### PR TITLE
Hotfix/Add contested

### DIFF
--- a/ynr/apps/api/next/filters.py
+++ b/ynr/apps/api/next/filters.py
@@ -16,3 +16,20 @@ class LastUpdatedMixin(filterset.FilterSet):
         """
         name = f"{name}__gt"
         return queryset.filter(**{name: value})
+
+
+class UncontestedMixin(filterset.FilterSet):
+    uncontested = filters.BooleanFilter(
+        field_name="uncontested",
+        lookup_expr="gt",
+        label="Uncontested",
+        help_text="Uncontested ballots",
+        method="filter_uncontested",
+    )
+
+    def filter_uncontested(self, queryset, name, value):
+        """
+        Default method that can be overided to check additional fields in subclass
+        """
+        name = f"{name}__gt"
+        return queryset.filter(**{name: value})

--- a/ynr/apps/api/tests/test_filters.py
+++ b/ynr/apps/api/tests/test_filters.py
@@ -1,6 +1,6 @@
 from mock import MagicMock
 
-from api.next.filters import LastUpdatedMixin
+from api.next.filters import LastUpdatedMixin, UncontestedMixin
 
 
 class TestLastUpdatedMixin:
@@ -17,3 +17,15 @@ class TestLastUpdatedMixin:
             queryset=queryset, name=fieldname, value=timestamp
         )
         queryset.filter.assert_called_once_with(modified__gt=timestamp)
+
+
+class TestUncontestedMixin:
+    def test_filter_uncontested(self):
+        """
+        Test that the queryset is filtered using the correct fieldname
+        and expression
+        """
+        queryset = MagicMock()
+        filter_obj = UncontestedMixin(queryset=queryset)
+        fieldname = "uncontested"
+        filter_obj.filter_uncontested(queryset=queryset, name=fieldname)

--- a/ynr/apps/candidates/models/popolo_extra.py
+++ b/ynr/apps/candidates/models/popolo_extra.py
@@ -211,16 +211,6 @@ class BallotQueryset(models.QuerySet):
             .filter(candidates_locked=True)
         )
 
-    def contested(self):
-        """
-        Return a QuerySet of ballots that are contested
-        """
-        return (
-            self.annotate(memberships_count=Count("membership"))
-            .filter(winner_count__gte=F("memberships_count"))
-            .filter(candidates_locked=True)
-        )
-
 
 class Ballot(EEModifiedMixin, models.Model):
 

--- a/ynr/apps/candidates/models/popolo_extra.py
+++ b/ynr/apps/candidates/models/popolo_extra.py
@@ -211,6 +211,16 @@ class BallotQueryset(models.QuerySet):
             .filter(candidates_locked=True)
         )
 
+    def contested(self):
+        """
+        Return a QuerySet of ballots that are contested
+        """
+        return (
+            self.annotate(memberships_count=Count("membership"))
+            .filter(winner_count__gte=F("memberships_count"))
+            .filter(candidates_locked=True)
+        )
+
 
 class Ballot(EEModifiedMixin, models.Model):
 
@@ -358,6 +368,14 @@ class Ballot(EEModifiedMixin, models.Model):
         if not self.candidates_locked:
             return False
         if self.get_winner_count == self.membership_set.count():
+            return True
+        return False
+
+    @property
+    def contested(self):
+        if not self.candidates_locked:
+            return False
+        if self.get_winner_count != self.membership_set.count():
             return True
         return False
 

--- a/ynr/apps/candidates/models/popolo_extra.py
+++ b/ynr/apps/candidates/models/popolo_extra.py
@@ -211,6 +211,16 @@ class BallotQueryset(models.QuerySet):
             .filter(candidates_locked=True)
         )
 
+    def contested(self):
+        """
+        Return a QuerySet of ballots that are contested
+        """
+        return (
+            self.annotate(memberships_count=Count("membership"))
+            .filter(winner_count__gte=F("memberships_count"))
+            .filter(candidates_locked=True)
+        )
+
 
 class Ballot(EEModifiedMixin, models.Model):
 

--- a/ynr/apps/candidates/tests/test_models.py
+++ b/ynr/apps/candidates/tests/test_models.py
@@ -68,12 +68,12 @@ class TestBallotMethods(TestCase, SingleBallotStatesMixin):
             username="jacob", email="jacob@…", password="top_secret"
         )
 
-        election = self.create_election("Sheffield Local Election")
-        post = self.create_post(post_label="Ecclesall")
+        self.election = self.create_election("Sheffield Local Election")
+        self.post = self.create_post(post_label="Ecclesall")
         self.ballot = self.create_ballot(
             ballot_paper_id="local.sheffield.ecclesall.2021-05-06",
-            election=election,
-            post=post,
+            election=self.election,
+            post=self.post,
             winner_count=2,
             candidates_locked=True,
         )
@@ -132,6 +132,13 @@ class TestBallotMethods(TestCase, SingleBallotStatesMixin):
             self.ballot.membership_set.filter(elected=False).count(), 2
         )
         self.assertEqual(LoggedAction.objects.count(), 3)
+
+    def test_contested(self):
+        ballot = self.ballot
+        parties = self.create_parties(3)
+        self.create_memberships(ballot, parties)
+        contested_ballots = Ballot.objects.contested()
+        self.assertNotIn(ballot, contested_ballots)
 
 
 class BallotsWithResultsMixin(SingleBallotStatesMixin):

--- a/ynr/apps/elections/filters.py
+++ b/ynr/apps/elections/filters.py
@@ -294,6 +294,10 @@ This may change depending on the elections. Used to determine if
         Only First Past The Post ballots have results at the moment.""",
     )
 
+    uncontested = django_filters.BooleanFilter(
+        label="Uncontested", widget=AnyBooleanWidget, help_text="""Boolean. ."""
+    )
+
     def filter_last_updated(self, queryset, name, value):
         """
         Method for the last_updated filter. Uses the last_updated QuerysetMethod
@@ -340,6 +344,7 @@ def filter_shortcuts(request):
                 "review_required": ["unlocked"],
                 "has_sopn": ["1"],
                 "is_cancelled": ["0"],
+                "uncontested": ["0"],
             },
         },
         {
@@ -349,6 +354,7 @@ def filter_shortcuts(request):
                 "has_results": ["0"],
                 "review_required": ["locked"],
                 "is_cancelled": ["0"],
+                "uncontested": ["0"],
             },
         },
     ]


### PR DESCRIPTION
Following on from https://github.com/DemocracyClub/yournextrepresentative/pull/1486, this work adds a method to call and query contested ballots.

This also adds an `uncontested` boolean to the `/ballots` endpoint. 