### PR TITLE
Get cancelled

### DIFF
--- a/ynr/apps/candidates/models/popolo_extra.py
+++ b/ynr/apps/candidates/models/popolo_extra.py
@@ -361,7 +361,7 @@ class Ballot(EEModifiedMixin, models.Model):
             return True
         return False
 
-    def mark_uncontested_winners(self, request, ip_address, user, log=True):
+    def mark_uncontested_winners(self, ip_address=None, user=None):
         """
         If the election is uncontested mark all candidates as elected
         """
@@ -375,10 +375,11 @@ class Ballot(EEModifiedMixin, models.Model):
                 ip_address=ip_address,
                 user=user,
                 ballot=self,
+                person=winner.person,
                 source="Ballot was uncontested",
             )
 
-    def unmark_uncontested_winners(self, request, ip_address, user, log=True):
+    def unmark_uncontested_winners(self, ip_address=None, user=None):
         if self.uncontested:
             return
         self.membership_set.update(elected=False)
@@ -389,6 +390,7 @@ class Ballot(EEModifiedMixin, models.Model):
                 ip_address=ip_address,
                 user=user,
                 ballot=self,
+                person=candidate.person,
                 source="Ballot was previously marked uncontested, but may now have been unlocked. Check the ballot for more details.",
             )
 

--- a/ynr/apps/candidates/tests/test_models.py
+++ b/ynr/apps/candidates/tests/test_models.py
@@ -101,32 +101,25 @@ class TestBallotMethods(TestCase, SingleBallotStatesMixin):
         self.create_memberships(self.ballot, parties)
         self.assertFalse(self.ballot.uncontested)
 
-    def test_mark_uncontested_winners(self, log=True):
-        request = self.factory.get("/test")
-        request.user = self.user
+    def test_mark_uncontested_winners(self):
         parties = self.create_parties(2)
 
         self.create_memberships(self.ballot, parties)
         self.assertTrue(self.ballot.uncontested)
         self.ballot.mark_uncontested_winners(
-            request, ip_address="111.11.1111", user=request.user, log=True
+            ip_address="111.11.1111", user=self.user
         )
         self.assertTrue(
             self.ballot.membership_set.filter(elected=True).count(), 2
         )
         self.assertEqual(LoggedAction.objects.count(), 2)
 
-    def test_unmark_uncontested_winners(self, log=True):
-        request = self.factory.get("/test")
-        request.user = self.user
+    def test_unmark_uncontested_winners(self):
         parties = self.create_parties(3)
         self.create_memberships(self.ballot, parties)
         self.assertFalse(self.ballot.uncontested)
         self.ballot.unmark_uncontested_winners(
-            request=request,
-            ip_address="111.11.1111",
-            user=request.user,
-            log=True,
+            ip_address="111.11.1111", user=self.user
         )
         self.assertTrue(
             self.ballot.membership_set.filter(elected=False).count(), 2

--- a/ynr/apps/elections/api/next/serializers.py
+++ b/ynr/apps/elections/api/next/serializers.py
@@ -133,6 +133,7 @@ class BallotSerializer(serializers.HyperlinkedModelSerializer):
         lookup_url_kwarg="ballot_paper_id",
     )
     last_updated = serializers.SerializerMethodField()
+    cancelled = serializers.SerializerMethodField()
 
     def get_last_updated(self, instance):
         """
@@ -171,3 +172,13 @@ class BallotSerializer(serializers.HyperlinkedModelSerializer):
         return CandidacyOnBallotSerializer(
             qs, many=True, context=self.context
         ).data
+
+    def get_cancelled(self, instance):
+        """
+        If the ballot is marked as cancelled, return True. Otherwise check if
+        it was uncontested, as we may know this before it has been marked as
+        cancelled in EE.
+        """
+        if instance.cancelled:
+            return True
+        return instance.uncontested

--- a/ynr/apps/elections/tests/test_serializers.py
+++ b/ynr/apps/elections/tests/test_serializers.py
@@ -1,0 +1,45 @@
+from unittest.mock import PropertyMock, patch
+from django.test import TestCase
+from candidates.tests.factories import BallotPaperFactory
+
+from elections.api.next.serializers import BallotSerializer
+
+
+class TestBallotSerializerGetCancelled(TestCase):
+    def test_when_cancelled(self):
+        ballot = BallotPaperFactory(cancelled=True)
+        self.assertFalse(ballot.uncontested)
+        serializer = BallotSerializer(instance=ballot)
+        cancelled = serializer.get_cancelled(instance=ballot)
+        self.assertTrue(cancelled)
+
+    def test_when_not_cancelled(self):
+        ballot = BallotPaperFactory(cancelled=False)
+        self.assertFalse(ballot.uncontested)
+        serializer = BallotSerializer(instance=ballot)
+        cancelled = serializer.get_cancelled(instance=ballot)
+        self.assertFalse(cancelled)
+
+    def test_when_uncontested_not_cancelled(self):
+        ballot = BallotPaperFactory(cancelled=False)
+        with patch(
+            "candidates.models.Ballot.uncontested",
+            new_callable=PropertyMock,
+            return_value=True,
+        ):
+            self.assertTrue(ballot.uncontested)
+            serializer = BallotSerializer(instance=ballot)
+            cancelled = serializer.get_cancelled(instance=ballot)
+            self.assertTrue(cancelled)
+
+    def test_when_uncontested_and_cancelled(self):
+        ballot = BallotPaperFactory(cancelled=True)
+        with patch(
+            "candidates.models.Ballot.uncontested",
+            new_callable=PropertyMock,
+            return_value=True,
+        ):
+            self.assertTrue(ballot.uncontested)
+            serializer = BallotSerializer(instance=ballot)
+            cancelled = serializer.get_cancelled(instance=ballot)
+            self.assertTrue(cancelled)

--- a/ynr/apps/elections/views.py
+++ b/ynr/apps/elections/views.py
@@ -262,13 +262,13 @@ class LockBallotView(GroupRequiredMixin, UpdateView):
                 # can be deleted
                 ballot.suggestedpostlock_set.all().delete()
                 ballot.mark_uncontested_winners(
-                    request, ip_address, user=request.user
+                    ip_address=ip_address, user=request.user
                 )
             else:
                 action_type = ActionType.CONSTITUENCY_UNLOCK
                 pp = "Unlocked"
                 ballot.unmark_uncontested_winners(
-                    request, ip_address, user=request.user
+                    ip_address=ip_address, user=request.user
                 )
             message = pp + " ballot {} ({})".format(
                 post_name, ballot.ballot_paper_id

--- a/ynr/apps/uk_results/management/commands/uk_results_mark_uncontested.py
+++ b/ynr/apps/uk_results/management/commands/uk_results_mark_uncontested.py
@@ -11,4 +11,4 @@ class Command(BaseCommand):
     def handle(self, *args):
         qs = Ballot.objects.uncontested()
         for ballot in qs:
-            ballot.mark_uncontested_winners(log=False)
+            ballot.mark_uncontested_winners()


### PR DESCRIPTION
Changes the API response for a Ballot so that if it is not yet marked as `cancelled` (because EE hasn't been updated) but is `uncontested`, then in the API response `cancelled` will be True.

Intented to help with https://github.com/DemocracyClub/WhoCanIVoteFor/pull/970 so that logic around text to display when a ballot is uncontested can be moved to the cancelled election template