### PR TITLE
Hotfix/Expand blank page check

### DIFF
--- a/ynr/apps/sopn_parsing/helpers/pdf_helpers.py
+++ b/ynr/apps/sopn_parsing/helpers/pdf_helpers.py
@@ -35,8 +35,8 @@ class SOPNDocument:
         self.pages = self.parse_pages()
         self.matched_pages = []
 
-        if len(self.document_heading_set) < 10:
-            raise NoTextInDocumentError()
+        if self.blank_doc:
+            raise NoTextInDocumentError
 
     @property
     def document_heading_set(self):
@@ -45,6 +45,19 @@ class SOPNDocument:
         a set
         """
         return self.pages[1].get_page_heading_set()
+
+    @property
+    def blank_doc(self):
+        """
+        Takes the heading from the first or second page (if any) in the document and checks if empty
+        """
+        if len(self.document_heading_set) >= 10:
+            return False
+
+        return (
+            len(self.pages) > 1
+            and len(self.pages[2].get_page_heading_set()) < 10
+        )
 
     @property
     def matched_page_numbers(self) -> List[str]:

--- a/ynr/apps/sopn_parsing/tests/test_sopn_helpers.py
+++ b/ynr/apps/sopn_parsing/tests/test_sopn_helpers.py
@@ -32,6 +32,8 @@ class TestSOPNHelpers(TestCase):
             file=open(example_doc_path, "rb"), source_url="http://example.com"
         )
         doc.heading = {"reason", "2019", "a", "election", "the", "labour"}
+        self.assertEqual(len(doc.pages), 1)
+        self.assertEqual(doc.blank_doc, False)
         self.assertRaises(NoTextInDocumentError)
 
     @skipIf(should_skip_pdf_tests(), "Required PDF libs not installed")


### PR DESCRIPTION
This work addresses cases were we a SOPN has a blank/Title page (or with little text) on page 1 but has text on subsequent pages such as [`local.bradford.baildon.2021-05-06`.](https://candidates.democracyclub.org.uk/elections/local.bradford.baildon.2021-05-06/sopn/). Here, we check the 1st and second page for blank pages before raising an exception.  This change makes it possible to move along to extracting tables. 