### PR TITLE
Hotfix/Replace '&' in party description

### DIFF
--- a/ynr/apps/sopn_parsing/helpers/parse_tables.py
+++ b/ynr/apps/sopn_parsing/helpers/parse_tables.py
@@ -125,6 +125,7 @@ def clean_last_names(names):
 
 def clean_description(description):
     description = str(description)
+    description = description.replace(" & ", " and ")
     description = description.replace("\\n", "")
     description = description.replace("\n", "")
     description = description.replace("`", "'")
@@ -201,7 +202,6 @@ def get_name(row, name_fields):
 
 
 def parse_table(sopn, data):
-
     data.columns = clean_row(data.columns)
     try:
         name_fields = get_name_fields(data.columns)

--- a/ynr/apps/sopn_parsing/tests/test_parse_tables.py
+++ b/ynr/apps/sopn_parsing/tests/test_parse_tables.py
@@ -302,6 +302,14 @@ class TestParseTablesUnitTests(TestCase):
         assert "'" in cleaned_description
         assert cleaned_description == "All People's Party"
 
+    def test_clean_description_replaces_ampersand(self):
+        cleaned_description = parse_tables.clean_description(
+            "Labour & Co-operative Party"
+        )
+        assert "&" not in cleaned_description
+        assert "and" in cleaned_description
+        assert cleaned_description == "Labour and Co-operative Party"
+
 
 class TestParseTablesFilterKwargs(TestCase):
     def setUp(self):


### PR DESCRIPTION
This bug seems to mostly affect joint parties. 

- [x] Replace '&' with 'and' in the party description. This change improves bot parsing for https://candidates.democracyclub.org.uk/bulk_adding/sopn/local.devon.whimple-blackdown.2021-05-06/ 
- [ ] Confirm the parsed party description matches one in the DB and form is pre-populated 