### PR TITLE
Sopn more debugging

### DIFF
--- a/ynr/apps/sopn_parsing/helpers/extract_pages.py
+++ b/ynr/apps/sopn_parsing/helpers/extract_pages.py
@@ -1,3 +1,4 @@
+from pdfminer.pdfparser import PDFSyntaxError
 from official_documents.models import OfficialDocument
 from sopn_parsing.helpers.pdf_helpers import SOPNDocument
 from sopn_parsing.helpers.text_helpers import NoTextInDocumentError
@@ -42,4 +43,11 @@ def extract_pages_for_ballot(ballot, manual_upload=False):
     except (NoTextInDocumentError):
         raise NoTextInDocumentError(
             f"Failed to extract pages for {document.uploaded_file.path} as a NoTextInDocumentError was raised"
+        )
+    except PDFSyntaxError:
+        print(
+            f"{ballot.ballot_paper_id} failed to parse as a PDFSyntaxError was raised"
+        )
+        raise PDFSyntaxError(
+            f"Failed to extract pages for {document.uploaded_file.path} as a PDFSyntaxError was raised"
         )

--- a/ynr/apps/sopn_parsing/helpers/pdf_helpers.py
+++ b/ynr/apps/sopn_parsing/helpers/pdf_helpers.py
@@ -147,7 +147,15 @@ class SOPNDocument:
                 self.add_to_matched_pages(page)
 
         if not self.is_matched_page_numbers_valid():
-            raise MatchedPagesError("Page numbers are not consecutive")
+            if self.strict:
+                raise MatchedPagesError(
+                    f"Page numbers are not consecutive for {self.source_url}. Pages: {self.matched_pages}"
+                )
+            else:
+                print(
+                    f"Page numbers are not consecutive for {self.source_url}. Pages: {self.matched_pages}. Skipping."
+                )
+                return ""
 
         return ",".join(str(number) for number in self.matched_page_numbers)
 
@@ -163,10 +171,13 @@ class SOPNDocument:
         if matched_pages:
             self.unmatched_documents.remove(document)
             document.relevant_pages = matched_pages
+
             return document.save()
 
         if self.strict:
-            raise MatchedPagesError("We couldnt match any pages")
+            raise MatchedPagesError(
+                f"We couldnt match any pages for {document.ballot.ballot_paper_id}"
+            )
 
     def match_all_pages(self) -> None:
         """
@@ -185,7 +196,7 @@ class SOPNDocument:
 
         if self.strict and self.unmatched_documents:
             raise MatchedPagesError(
-                "Some OfficialDocument objects were unmatched"
+                f"Some OfficialDocument objects were unmatched for {self.source_url}"
             )
 
     def parse_pages(self):

--- a/ynr/apps/sopn_parsing/helpers/pdf_helpers.py
+++ b/ynr/apps/sopn_parsing/helpers/pdf_helpers.py
@@ -152,11 +152,11 @@ class SOPNDocument:
             )
             if self.strict:
                 raise MatchedPagesError(
-                    f"Page numbers are not consecutive for {self.source_url}. Pages: {matched_page_str}"
+                    f"Page numbers are not consecutive for {self.source_url}. Pages: {matched_page_str}. Post: {post_label}"
                 )
             else:
                 print(
-                    f"Page numbers are not consecutive for {self.source_url}. Pages: {matched_page_str}. Skipping."
+                    f"Page numbers are not consecutive for {self.source_url}. Pages: {matched_page_str}. Post: {post_label}. Skipping."
                 )
                 return ""
 

--- a/ynr/apps/sopn_parsing/management/commands/sopn_parsing_extract_page_numbers.py
+++ b/ynr/apps/sopn_parsing/management/commands/sopn_parsing_extract_page_numbers.py
@@ -1,3 +1,4 @@
+from pdfminer.pdfparser import PDFSyntaxError
 from sopn_parsing.helpers.command_helpers import BaseSOPNParsingCommand
 from sopn_parsing.helpers.extract_pages import extract_pages_for_ballot
 from sopn_parsing.helpers.text_helpers import NoTextInDocumentError
@@ -25,5 +26,5 @@ class Command(BaseSOPNParsingCommand):
         for ballot in qs:
             try:
                 extract_pages_for_ballot(ballot)
-            except (ValueError, NoTextInDocumentError) as e:
+            except (ValueError, NoTextInDocumentError, PDFSyntaxError) as e:
                 self.stderr.write(e.args[0])


### PR DESCRIPTION
While running `make test-sopns` for all 2021 SOPNs, we discovered a bug related to consecutive pages that was preventing the command from completing. 

This PR: 
- Adds more error messages and exceptions to identify where parsing fails
- Adds ballot, post, document details to errors to identify erroring SOPNs
- Identifies .docx SOPNs that can't be parsed