### PR TITLE
Matched pages debug

### DIFF
--- a/ynr/apps/sopn_parsing/helpers/pdf_helpers.py
+++ b/ynr/apps/sopn_parsing/helpers/pdf_helpers.py
@@ -180,7 +180,8 @@ class SOPNDocument:
         # if we are re-parsing and matched pages changed log it
         if document.relevant_pages and matched_pages != document.relevant_pages:
             print(
-                "Matched pages changed from {previously_matched} to {new_matched}".format(
+                "{ballot} matched pages changed from {previously_matched} to {new_matched}".format(
+                    ballot=document.ballot.ballot_paper_id,
                     previously_matched=document.relevant_pages,
                     new_matched=matched_pages or "0",
                 )


### PR DESCRIPTION
- If changes result in the matched pages changing, this is outputted for further investigation.
- Improves error output to display the number of "people" that have been parsed, rather than just the `RawPeople` objects
- Also removes the hard fail if numbers go down, to avoid situation where the parsed objects and the comparison json (baseline file) are out of sync
