### PR TITLE
Party description importer

### DIFF
--- a/ynr/apps/candidates/management/commands/candidates_import_from_live_site.py
+++ b/ynr/apps/candidates/management/commands/candidates_import_from_live_site.py
@@ -7,6 +7,7 @@ from django.conf import settings
 from django.core.files.storage import FileSystemStorage
 from django.core.management import call_command
 from django.core.management.base import BaseCommand
+from parties.importer import YNRPartyDescriptionImporter
 
 import people.models
 from candidates.models import Ballot
@@ -160,6 +161,10 @@ class Command(BaseCommand):
                 else:
                     raise ValueError(serializer.errors)
 
+    def import_party_descriptions(self):
+        importer = YNRPartyDescriptionImporter()
+        importer.do_import()
+
     def import_people(self):
         for person_data in self.get_api_results("people"):
             with show_data_on_error("person_data", person_data):
@@ -261,5 +266,7 @@ class Command(BaseCommand):
         self.import_organizations()
         self.stdout.write("Importing People")
         self.import_people()
+        self.stdout.write("Importing PartyDescriptions")
+        self.import_party_descriptions()
 
         return

--- a/ynr/apps/sopn_parsing/helpers/extract_pages.py
+++ b/ynr/apps/sopn_parsing/helpers/extract_pages.py
@@ -1,5 +1,4 @@
 from pdfminer.pdfparser import PDFSyntaxError
-from official_documents.models import OfficialDocument
 from sopn_parsing.helpers.pdf_helpers import SOPNDocument
 from sopn_parsing.helpers.text_helpers import NoTextInDocumentError
 
@@ -19,35 +18,19 @@ def extract_pages_for_ballot(ballot, manual_upload=False):
     :type ballot: candidates.models.Ballot
 
     """
-    # check if this is the only document with this source url and if so attempt
-    # some optimisations before we try and parse the page numbers
-    try:
-        document = OfficialDocument.objects.get(
-            source_url=ballot.sopn.source_url
-        )
-        # if this isn't a manual upload we assume all pages relate to the ballot
-        # and can return early
-        if not manual_upload:
-            document.relevant_pages = "all"
-            return document.save()
-    except OfficialDocument.MultipleObjectsReturned:
-        document = ballot.sopn
-
-    # otherwise parse as if we had multiple sources as the SOPN may cover
-    # multiple ballots, but this is the first time parsing it
     try:
         sopn = SOPNDocument(
-            file=document.uploaded_file, source_url=document.source_url
+            file=ballot.sopn.uploaded_file, source_url=ballot.sopn.source_url
         )
         return sopn.match_all_pages()
     except (NoTextInDocumentError):
         raise NoTextInDocumentError(
-            f"Failed to extract pages for {document.uploaded_file.path} as a NoTextInDocumentError was raised"
+            f"Failed to extract pages for {ballot.sopn.uploaded_file.path} as a NoTextInDocumentError was raised"
         )
     except PDFSyntaxError:
         print(
             f"{ballot.ballot_paper_id} failed to parse as a PDFSyntaxError was raised"
         )
         raise PDFSyntaxError(
-            f"Failed to extract pages for {document.uploaded_file.path} as a PDFSyntaxError was raised"
+            f"Failed to extract pages for {ballot.sopn.uploaded_file.path} as a PDFSyntaxError was raised"
         )

--- a/ynr/apps/sopn_parsing/helpers/parse_tables.py
+++ b/ynr/apps/sopn_parsing/helpers/parse_tables.py
@@ -188,7 +188,8 @@ def get_party(description_model, description, sopn):
         party_obj = None
 
     if not party_obj:
-        raise ValueError(f"Couldn't find party for {party_name}")
+        return print(f"Couldn't find party for {party_name}")
+
     return party_obj
 
 
@@ -219,6 +220,8 @@ def parse_table(sopn, data):
         name = clean_name(name)
         description = get_description(row[description_field], sopn)
         party = get_party(description, row[description_field], sopn)
+        if not party:
+            continue
         data = {"name": name, "party_id": party.ec_id}
         if description:
             data["description_id"] = description.pk

--- a/ynr/apps/sopn_parsing/management/commands/sopn_tooling_compare_raw_people.py
+++ b/ynr/apps/sopn_parsing/management/commands/sopn_tooling_compare_raw_people.py
@@ -202,7 +202,7 @@ class Command(BaseSOPNParsingCommand):
             # sometimes we incorrectly parse extra people - often independents
             # due to an empty row
             extras = parsed - expected
-            total = sum(expected.values())
+            total = sum(extras.values())
             self.stderr.write(
                 f"{total} EXTRA parties for {ballot.ballot_paper_id}\n{extras}"
             )

--- a/ynr/apps/sopn_parsing/management/commands/sopn_tooling_compare_raw_people.py
+++ b/ynr/apps/sopn_parsing/management/commands/sopn_tooling_compare_raw_people.py
@@ -6,8 +6,10 @@ from django.core.management import call_command
 
 from bulk_adding.models import RawPeople
 from candidates.models import Ballot
+from official_documents.models import OfficialDocument
 from popolo.models import Membership
 from sopn_parsing.helpers.command_helpers import BaseSOPNParsingCommand
+from sopn_parsing.models import ParsedSOPN
 
 
 class Command(BaseSOPNParsingCommand):
@@ -47,8 +49,11 @@ class Command(BaseSOPNParsingCommand):
 
         options.update({"testing": True})
 
+        OfficialDocument.objects.update(relevant_pages="")
         call_command("sopn_parsing_extract_page_numbers", *args, **options)
+        ParsedSOPN.objects.all().delete()
         call_command("sopn_parsing_extract_tables", *args, **options)
+        RawPeople.objects.all().delete()
         call_command("sopn_parsing_parse_tables", *args, **options)
 
         with open(raw_people_file) as file:


### PR DESCRIPTION
This PR adds a few things:

- An importer to create all `PartyDescriptions` locally from the YNR live site.
- Removes an old optimisation around page matching that I don't think is relevant now that we have refactored the page matching
- Change the way that the comparison works when we run `make test-sopns` so that before the parsing commands are run, all old data is cleared from our local DB. I have done this because I was finding examples where I would make some changes to parsing tables, trying them out, and then removing them. However the old `RawPeople` or `ParsedSOPN` objects would sometimes still hang around. By clearing out the old data before each run, I feel that it gives more accurate results.
- Changes to matching Party/PartyDescription by normalising the search text we use to match with