### PR TITLE
Fix bug where initial party choices not loaded

### DIFF
--- a/ynr/apps/bulk_adding/forms.py
+++ b/ynr/apps/bulk_adding/forms.py
@@ -54,12 +54,21 @@ class BulkAddFormSet(BaseBulkAddFormSet):
         super().__init__(*args, **kwargs)
         self.parties = Party.objects.register(
             self.ballot.post.party_set.slug.upper()
-        ).default_party_choices()
+        ).default_party_choices(extra_party_ids=self.initial_party_ids)
 
     def get_form_kwargs(self, index):
         kwargs = super().get_form_kwargs(index)
         kwargs["party_choices"] = self.parties
         return kwargs
+
+    @property
+    def initial_party_ids(self):
+        """
+        Returns a list of any party ID's that are included in initial data
+        """
+        if self.initial is None:
+            return []
+        return [d.get("party")[0].split("__")[0] for d in self.initial]
 
 
 class BaseBulkAddReviewFormSet(BaseBulkAddFormSet):

--- a/ynr/apps/parties/managers.py
+++ b/ynr/apps/parties/managers.py
@@ -129,7 +129,7 @@ class PartyQuerySet(models.QuerySet):
             result.append(party_names)
         return result
 
-    def default_party_choices(self, register=None):
+    def default_party_choices(self, register=None, extra_party_ids=None):
         qs = self
         if register:
             qs = qs.register(register)
@@ -138,5 +138,6 @@ class PartyQuerySet(models.QuerySet):
             include_non_current=False,
             exclude_deregistered=True,
             include_description_ids=True,
+            extra_party_ids=extra_party_ids,
         )
         return choices


### PR DESCRIPTION
Closes https://github.com/DemocracyClub/yournextrepresentative/issues/1367

- If initial data e.g. from a RawPeople object that has been parsed
contains a party that is not included in the default party choices,
the bulk add form was not preselecting the party.
- This fixes that by extending extra_party_ids kwarg to the method
that loads the default party choices, and adds method to extract just
the party ids from initial data if it exists