### PR TITLE
Fixes bug where Welsh description assigned for 'The Green Party'

### DIFF
--- a/ynr/apps/sopn_parsing/helpers/parse_tables.py
+++ b/ynr/apps/sopn_parsing/helpers/parse_tables.py
@@ -137,6 +137,10 @@ def clean_description(description):
     # change dash to hyphen to match how they are stored in our DB
     description = description.replace("\u2013", "\u002d")
     description = re.sub(r"\s+", " ", description)
+    # handle edgecases for the green party to stop incorrectly matching against
+    # Welsh descriptions
+    if description.lower() in ["the green party", "the green party candidate"]:
+        description = "Green Party"
     return description
 
 


### PR DESCRIPTION
Special case when Green Party candidates appear on SOPN under
'The Green Party'. There is no matching PartyDescription for this but
previously it was incorrectly matched with a Welsh party description
that startswith 'The Green Party'. This meant that wombles would have
to change the party manually to simply 'The Green Party'.
So this change removes the 'The' only when the description is exactly
'The Green Party' appears. This makes sure that if the welsh
description (or other) should be matched, it will be.

Example pre-this change for https://candidates.democracyclub.org.uk/elections/local.derbyshire.wirksworth.2021-05-06/sopn/:
![Screenshot 2022-02-01 at 15 22 56](https://user-images.githubusercontent.com/15347726/151997090-8a9c8d78-9553-44b1-88e9-4c8d6560ecc7.png)

After this change and reparsing, the bulk add form displays:
![Screenshot 2022-02-01 at 15 25 52](https://user-images.githubusercontent.com/15347726/151997514-c91037bb-f541-41a4-8a9c-9e7a24c1b353.png)


