### PR TITLE
Fix 500 error on bulk add by party form

### DIFF
--- a/ynr/apps/bulk_adding/forms.py
+++ b/ynr/apps/bulk_adding/forms.py
@@ -236,7 +236,8 @@ class BaseBulkAddByPartyFormset(forms.BaseFormSet):
     def __init__(self, *args, **kwargs):
         self.ballot = kwargs["ballot"]
         kwargs["prefix"] = self.ballot.pk
-        self.extra = self.ballot.winner_count
+        if self.ballot.winner_count:
+            self.extra = self.ballot.winner_count
         del kwargs["ballot"]
 
         super().__init__(*args, **kwargs)
@@ -260,7 +261,7 @@ class BaseBulkAddByPartyFormset(forms.BaseFormSet):
 
 BulkAddByPartyFormset = forms.formset_factory(
     NameOnlyPersonForm,
-    extra=15,
+    extra=6,
     formset=BaseBulkAddByPartyFormset,
     can_delete=False,
 )


### PR DESCRIPTION
- If winner_count is set, use that to set number of rows on teh bulk
add by party form. Otherwise use a default of 6
- Closes https://github.com/DemocracyClub/yournextrepresentative/issues/1733