### PR TITLE
Catch use of welsh word for Independent

### DIFF
--- a/ynr/apps/sopn_parsing/helpers/parse_tables.py
+++ b/ynr/apps/sopn_parsing/helpers/parse_tables.py
@@ -30,7 +30,7 @@ NAME_FIELDS = (
 )
 
 
-INDEPENDENT_VALUES = ("Independent", "")
+INDEPENDENT_VALUES = ("Independent", "", "Annibynnol")
 
 
 def iter_rows(data):


### PR DESCRIPTION
For the purposes of section 22(3)(a) of the Political Parties,
Elections and Referendums Act 2000(9), the description “Annibynnol”
may be given in a candidate’s nomination paper at an election of
councillors to a county council or county borough council in Wales,
instead of, or in addition to, the description “Independent”.