### PR TITLE
Bugfix/sopn parsing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ node_modules/
 .vscode/
 /test-env
 /ynr/apps/sopn_parsing/tests/data/sopn_baseline.json
+/ynr/apps/sopn_parsing/tests/data/sopn_baseline_copy.json

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,14 @@
 export DJANGO_SETTINGS_MODULE?=ynr.settings.sopn_testing
 
+
+.PHONY: sopn-runserver
+sopn-runserver:
+	python manage.py runserver
+
+.PHONY: sopn-shell
+sopn-shell:
+	python manage.py shell_plus
+
 .PHONY: migrate-db
 migrate-db:
 	python manage.py migrate
@@ -25,3 +34,7 @@ delete-test-sopns:
 .PHONY: create-baseline-file
 create-baseline-file:
 	python manage.py sopn_tooling_write_baseline
+
+.PHONY: copy-baseline-file
+copy-baseline-file:
+	cp ynr/apps/sopn_parsing/tests/data/sopn_baseline.json ynr/apps/sopn_parsing/tests/data/sopn_baseline_copy.json

--- a/ynr/apps/sopn_parsing/helpers/parse_tables.py
+++ b/ynr/apps/sopn_parsing/helpers/parse_tables.py
@@ -21,6 +21,7 @@ FIRST_NAME_FIELDS = [
     "other names",
     "candidate forename",
     "candidates other names",
+    "other names in full",
 ]
 LAST_NAME_FIELDS = [
     "surname",

--- a/ynr/apps/sopn_parsing/helpers/pdf_helpers.py
+++ b/ynr/apps/sopn_parsing/helpers/pdf_helpers.py
@@ -74,11 +74,14 @@ class SOPNDocument:
         return [page for page in self.pages.values() if not page.matched]
 
     @property
-    def has_single_page_and_single_document(self) -> bool:
+    def guess_all_pages(self) -> bool:
         """
-        Return if there is only one page and one related OfficialDocument
+        Return if there is only one page or one related OfficialDocument
         """
-        return len(self.pages) == 1 and len(self.unmatched_documents) == 1
+        if len(self.pages) == 1:
+            return True
+
+        return len(self.pages) < 4 and len(self.unmatched_documents) == 1
 
     def all_official_documents_with_source(self):
         """
@@ -221,7 +224,7 @@ class SOPNDocument:
         match its associated Ballot with pages in the PDF file. If matches are
         found, the OfficialDocument's relevant_pages field is updated.
         """
-        if self.has_single_page_and_single_document:
+        if self.guess_all_pages:
             document = self.unmatched_documents.pop()
             document.relevant_pages = "all"
             return document.save()

--- a/ynr/apps/sopn_parsing/helpers/text_helpers.py
+++ b/ynr/apps/sopn_parsing/helpers/text_helpers.py
@@ -34,6 +34,7 @@ def _clean_text(text, recheck=True, split_braces=True):
     text = re.sub(r"(^[a-z])\s([a-z][a-z]+)", r"\1\2", text)
     text = re.sub(r"(^[0-9])\s", r"", text)
     text = text.replace("*", "")
+    text = " ".join(char for char in text.split() if not char.isdigit())
     if split_braces:
         text = text.split("(")[0].strip()
     if recheck:

--- a/ynr/apps/sopn_parsing/management/commands/sopn_tooling_write_baseline.py
+++ b/ynr/apps/sopn_parsing/management/commands/sopn_tooling_write_baseline.py
@@ -40,7 +40,10 @@ class Command(BaseCommand):
                 except RawPeople.DoesNotExist:
                     raw_people = []
 
-                json_data[ballot.ballot_paper_id] = raw_people
+                json_data[ballot.ballot_paper_id] = {
+                    "raw_people": raw_people,
+                    "relevant_pages": ballot.sopn.relevant_pages,
+                }
 
         file_path = os.path.join(
             os.getcwd(), "ynr/apps/sopn_parsing/tests/data/sopn_baseline.json"

--- a/ynr/apps/sopn_parsing/tests/test_sopn_helpers.py
+++ b/ynr/apps/sopn_parsing/tests/test_sopn_helpers.py
@@ -62,8 +62,6 @@ class TestSOPNHelpers(TestCase):
                 "on",
                 "thursday",
                 "february",
-                "28",
-                "2019",
                 # table headers
                 "candidate",
                 "name",

--- a/ynr/apps/sopn_parsing/tests/test_sopn_helpers.py
+++ b/ynr/apps/sopn_parsing/tests/test_sopn_helpers.py
@@ -205,4 +205,4 @@ class TestSOPNHelpers(TestCase):
         self.assertEqual(len(document_obj.pages), 2)
 
         document_obj.match_all_pages()
-        self.assertEqual(strensall.sopn.relevant_pages, "1,2")
+        self.assertEqual(strensall.sopn.relevant_pages, "all")


### PR DESCRIPTION
After a lot of failed attempts to debug and come up with solutions for the problem with the [City of London SOPN's](https://candidates.democracyclub.org.uk/elections/local.city-of-london.2022-03-24/) I have settled on these changes for as a best option for now. With this, the city of London SOPN's are parsed correctly, whilst also not causing the number of previously tested SOPN's to go down. Extract from test output:
```
Old total 'people' parsed WAS 1610
New total 'people' parsed IS 1751
Old RawPeople count: 282
New total RawPeople count: 306
261 ballots parsed correct_exactly
6 ballots parsed num_correct_some_parties_missing
39 ballots parsed num_incorrect
224 ballots parsed zero_candidates
```
