### PR TITLE
Previous party interface

### DIFF
--- a/ynr/apps/bulk_adding/static/bulk_adding/css/bulk.scss
+++ b/ynr/apps/bulk_adding/static/bulk_adding/css/bulk.scss
@@ -20,6 +20,10 @@
             margin:0
         }
     }
+    ul {
+        font-size: 0.875rem;
+        line-height: 1rem; 
+    }
 
     .other-names {
         margin: 0;

--- a/ynr/apps/bulk_adding/templates/bulk_add/parties/add_review_form.html
+++ b/ynr/apps/bulk_adding/templates/bulk_add/parties/add_review_form.html
@@ -72,17 +72,4 @@
   });
   </script>
 
-
-
-
-
-
-
-
-
-
-
-
-
-
 {% endblock content %}

--- a/ynr/apps/bulk_adding/templates/bulk_add/sopns/_known-people.html
+++ b/ynr/apps/bulk_adding/templates/bulk_add/sopns/_known-people.html
@@ -12,6 +12,9 @@
           <th class="name">Name</th>
           <th>Also known as</th>
           <th>Party</th>
+          {% if ballot.is_welsh_run %}
+            <th>Previous party affiliations</th>
+          {% endif %}
           <th>Actions</th>
         </tr>
       </thead>
@@ -33,31 +36,47 @@
             <td>
               {{ person.party.name }}
             </td>
-            <td><a class="button tiny js-toggle-source-confirmation not-standing">
-              Not actually standing?
-            </a>
+            {% if ballot.is_welsh_run %} 
+              <td>
+              {% if person.previous_party_affiliations %}
+                {% for party in person.previous_party_affiliations.all %}
+                  {% if person.previous_party_affiliations.all.count > 1 %}
+                    <ul class="previous-party>">
+                      <li>{{ party.name }}</li>
+                    </ul>
+                  {% else %}
+                    {{ party.name }}
+                  {% endif %}
+                {% endfor %} 
+              {% endif %}
+              </td>
+            {% endif %} 
+            <td>
+              <a class="button tiny js-toggle-source-confirmation not-standing">
+                Not actually standing?
+              </a>
               {% include 'candidates/_source_confirmation.html' with standing='not-standing' action='candidacy-delete' person_id=person.id source=official_document.source_url %}
             </td>
           </tr>
           <tr>
-            <td></td>
-            <td colspan=2 class="actions">
-              {% if person.edits_allowed %}
-                <a href="{% url 'person-update' person.pk %}" target="_blank" class="button secondary tiny">
-                  Edit candidate
-                </a>
-                <a href="{% url 'person-other-name-create' person.pk %}"
-                   class="button secondary tiny js-bulk-known-person-alternate-name">
-                  Nomination paper shows different name variant
-                </a>
-                <a data-person-id="{{ person.pk }}" data-post-id="{{ post.slug }}"
-                   href="{% url 'candidacy-delete' election=election %}"
-                   class="button secondary tiny js-bulk-known-person-not-standing">
-                  Not standing
-                </a>
-              {% endif %}
-            </td>
-            <td></td>
+            {% if person.edits_allowed %} 
+              <td colspan=2 class="actions">
+                
+                  <a href="{% url 'person-update' person.pk %}" target="_blank" class="button secondary tiny">
+                    Edit candidate
+                  </a>
+                  <a href="{% url 'person-other-name-create' person.pk %}"
+                    class="button secondary tiny js-bulk-known-person-alternate-name">
+                    Nomination paper shows different name variant
+                  </a>
+                  <a data-person-id="{{ person.pk }}" data-post-id="{{ post.slug }}"
+                    href="{% url 'candidacy-delete' election=election %}"
+                    class="button secondary tiny js-bulk-known-person-not-standing">
+                    Not standing
+                  </a>
+              </td>
+            {% endif %}
+            
             <script type="text/html" class="js-bulk-known-person-alternate-name-form">
               <tr>
                 <td colspan="3" class="js-row">

--- a/ynr/apps/bulk_adding/templates/bulk_add/sopns/add_form.html
+++ b/ynr/apps/bulk_adding/templates/bulk_add/sopns/add_form.html
@@ -10,6 +10,7 @@
 
 {% block extra_js %}
 {% javascript 'bulk_adding' %}
+
 {% endblock %}
 
 {% block content %}
@@ -100,34 +101,41 @@
         <th>
           {{ form.party.errors }}
           <label for="{{ form.party.id_for_label }}">{{ form.party.label }}</label>
-        </th>
+        </th> 
         {% if form.name.initial %}
           <th class="delete_column">
           <abbr title="Select if this person is listed already">Duplicate?</abbr>
           </th>
         {% endif %}
-
       </tr>
-        <tr>
+      <tr>
         <td>{{ form.name }}</td>
         <td {% if not form.name.initial %}colspan="2"{% endif %}>
           {{ form.party }}<br>
           If the party is blank on the SOPN, enter "Independent"
         </td>
+        
         {% if form.name.initial %}
         <td class="delete_column">
         {{ form.DELETE }}
         </td>
         {% endif %}
-      
-        {% if ballot.is_welsh_run %}
-          <tr>
-            <td>{{ form.previous_party_affiliations }}</td>
-          </tr>
-        {% endif %}
-
       </tr>
-      </tbody>
+
+      {% if ballot.is_welsh_run %}
+      <tr class="previous-party-affiliation">
+        <th>
+          <details>
+            <summary type="button" class="button btn tiny secondary">
+                Add Previous Party Affilations
+            </summary>
+            <p class="previous-party-input" colspan=3 >
+              {{ form.previous_party_affiliations }}
+            </p> 
+          </details> 
+        </th> 
+      </tr> 
+      {% endif %} 
     {% endfor %}
     </table>
   <button type=submit>Review</button>

--- a/ynr/apps/bulk_adding/templates/bulk_add/sopns/add_review_form.html
+++ b/ynr/apps/bulk_adding/templates/bulk_add/sopns/add_review_form.html
@@ -74,7 +74,6 @@
                   {% for candidacy in choice.choice_label.previous_candidacies %}
                     <li>{{ candidacy }}</li>
                   {% endfor %}
-
                 </td>
               </tr>
             {% endfor %}

--- a/ynr/apps/bulk_adding/views/sopns.py
+++ b/ynr/apps/bulk_adding/views/sopns.py
@@ -72,6 +72,9 @@ class BaseSOPNBulkAddView(LoginRequiredMixin, TemplateView):
         for membership in context["ballot"].membership_set.all():
             person = membership.person
             person.party = membership.party
+            person.previous_party_affiliations = (
+                membership.previous_party_affiliations.all()
+            )
 
             people_set.add(person)
 

--- a/ynr/apps/candidates/static/candidates/_people.scss
+++ b/ynr/apps/candidates/static/candidates/_people.scss
@@ -108,6 +108,12 @@
   }
 }
 
+.previous-party {
+  color: $muted-text-color;
+  font-size: 0.875rem;
+  margin-bottom: 0;
+ }
+ 
 .candidates-list__person.hover-highlighting {
 
   padding-top: 0.8em;

--- a/ynr/apps/candidates/static/candidates/_person_edit.scss
+++ b/ynr/apps/candidates/static/candidates/_person_edit.scss
@@ -16,12 +16,9 @@ li.select2-search {
   font-size:0.875rem;
   padding: 3px;
 }
-.select2-container--default .select2-selection--multiple .select2-selection__rendered li {
-  font-size: 0.875rem;
-}
 
 ul.select2-results__option, .select2-results__option--highlighted, .select2-selection-choice{
-    line-height: 1.2em;
+  line-height: 1.2em;
 }
 
 li.input.select2-search_field {
@@ -30,6 +27,9 @@ li.input.select2-search_field {
 
 .select2-container--default .select2-search--inline .select2-search__field {
   font-size: .875rem;
+}
+.select2-container--default .select2-selection--multiple .select2-selection__rendered li {
+  font-size: .875rem !important; 
 }
 
 .select2-container--default.select2-container--focus .select2-selection--multiple {

--- a/ynr/apps/candidates/static/candidates/_person_edit.scss
+++ b/ynr/apps/candidates/static/candidates/_person_edit.scss
@@ -1,3 +1,43 @@
 .person-edit-separate-form {
   margin-bottom: 1em;
 }
+
+input.select2-search__field{
+  width: 100% !important;
+  height:1.2rem; 
+}
+
+li.select2-search {
+  width: 100% !important;
+  line-height: 1.2em;
+} 
+
+.select2-results__option {
+  font-size:0.875rem;
+  padding: 3px;
+}
+.select2-container--default .select2-selection--multiple .select2-selection__rendered li {
+  font-size: 0.875rem;
+}
+
+ul.select2-results__option, .select2-results__option--highlighted, .select2-selection-choice{
+    line-height: 1.2em;
+}
+
+li.input.select2-search_field {
+  width: 100% !important;
+}
+
+.select2-container--default .select2-search--inline .select2-search__field {
+  font-size: .875rem;
+}
+
+.select2-container--default.select2-container--focus .select2-selection--multiple {
+  border: solid #444 1px;
+}
+
+.select2-container--default .select2-selection--multiple {
+  margin-bottom: 1rem;
+}
+
+

--- a/ynr/apps/candidates/static/js/person_form.js
+++ b/ynr/apps/candidates/static/js/person_form.js
@@ -168,30 +168,22 @@ var populate_party_selects = function() {
   allPartySelects.each(setup_single_party_select);
 };
 
-var populate_prev_party_selects = function() {
+var setup_multiple_party_select = function(i, partySelect) {
   var allPrevPartySelects = $(PREVIOUS_PARTY_AFFILIATIONS_SELECT_CLASS);
   allPrevPartySelects.attr("disabled", false);
   $(PREVIOUS_PARTY_AFFILIATIONS_SELECT_CLASS).hide();
   $(PREVIOUS_PARTY_AFFILIATIONS_SELECT_CLASS).select2({
-    width: '95%',
+    width: '100%',
     placeholder: 'Select previous party affiliations',
     allowClear: true,
     closeOnSelect: true,
-    minimumInputLength: 0,
     multiple: true,
-    // ajax: { 
-    // instead of writing the function to execute the request we use Select2's convenient helper
-    //   url: '/ajax/parties/parties_for_select.json',
-    //   dataType: 'json',
-    //   delay: 250,
-    //   data: function (params) {
-    //     return {
-    //       q: params.term,
-    //       page: params.page
-    //     };
-    //   }
   })
-  allPartySelects.each(setup_single_party_select);
+} 
+
+var populate_prev_party_selects = function() {
+  var allPrevPartySelects = $(PREVIOUS_PARTY_AFFILIATIONS_SELECT_CLASS);
+  allPrevPartySelects.each(setup_multiple_party_select);
 };
 
 

--- a/ynr/apps/candidates/static/js/person_form.js
+++ b/ynr/apps/candidates/static/js/person_form.js
@@ -6,6 +6,7 @@ var PARTY_LIST_POSITION_INPUT_CLASS = "input.party-list-position";
 var BALLOT_GROUP_CLASS = ".ballot_group";
 var PREVIOUS_PARTY_AFFILIATIONS_SELECT_CLASS = "select.previous-party-affiliations";
 
+
 var setup_ballot_select2 = function(ballots) {
   $(BALLOT_INPUT_CLASS).each(function(el) {
     var BallotInput = $(this);
@@ -165,19 +166,42 @@ var populate_party_selects = function() {
   allPartySelects.attr("disabled", false);
   $(PARTY_WIDGET_INPUT_CLASS).hide();
   allPartySelects.each(setup_single_party_select);
-
-  $(PREVIOUS_PARTY_AFFILIATIONS_SELECT_CLASS).select2({
-    width: '100%',
-    placeholder: 'Select previous party affiliations',
-    allowClear: true
-  })
 };
 
-$(document).ready(function() {
+var populate_prev_party_selects = function() {
+  var allPrevPartySelects = $(PREVIOUS_PARTY_AFFILIATIONS_SELECT_CLASS);
+  allPrevPartySelects.attr("disabled", false);
+  $(PREVIOUS_PARTY_AFFILIATIONS_SELECT_CLASS).hide();
+  $(PREVIOUS_PARTY_AFFILIATIONS_SELECT_CLASS).select2({
+    width: '95%',
+    placeholder: 'Select previous party affiliations',
+    allowClear: true,
+    closeOnSelect: true,
+    minimumInputLength: 0,
+    multiple: true,
+    // ajax: { 
+    // instead of writing the function to execute the request we use Select2's convenient helper
+    //   url: '/ajax/parties/parties_for_select.json',
+    //   dataType: 'json',
+    //   delay: 250,
+    //   data: function (params) {
+    //     return {
+    //       q: params.term,
+    //       page: params.page
+    //     };
+    //   }
+  })
+  allPartySelects.each(setup_single_party_select);
+};
+
+
+$(document).ready(function() { 
   populate_ballot_selects();
-  populate_party_selects()
-  addTitleCaseButton()
+  populate_party_selects();
+  populate_prev_party_selects();
+  addTitleCaseButton(); 
 });
+
 
 
 /* This title-casing function should uppercase any letter after a word
@@ -208,5 +232,18 @@ function addTitleCaseButton() {
       let name = name_fields[i].value;
       name_fields[i].value = compressWhitespace(toTitleCase(name));
     })
-  } 
+  }
+}
+
+function addPreviousParty(){
+  var prev_party_btns = document.querySelectorAll('.previous-party-btn');
+  var prev_party_label = document.querySelectorAll('.previous-party-label');
+  var input_fields = document.querySelectorAll('.previous-party-input');
+  for (let i = 0; i < prev_party_btns.length; i++) {
+    prev_party_btns[i].addEventListener('click', function() {
+      prev_party_btns[i].style.display = 'none';
+      prev_party_label[i].style.display = 'inline'; 
+      input_fields[i].style.display = 'inline';
+    })
+  }
 }

--- a/ynr/apps/candidates/templatetags/standing.py
+++ b/ynr/apps/candidates/templatetags/standing.py
@@ -2,7 +2,6 @@ from django import template
 from django.conf import settings
 from django.db.models import Prefetch
 from django.utils.safestring import mark_safe
-
 from popolo.models import Membership
 from uk_results.models import CandidateResult
 
@@ -70,7 +69,7 @@ def post_in_election(person, election):
         result = prefix + result + suffix
         if candidacy.previous_party_affiliations.exists():
             for party in candidacy.previous_party_affiliations.all():
-                result += '<br><span class="">Previous party affiliation: {}</span>'.format(
+                result += '<ul class="previous-party"><li>Previous party affiliation: {}</li></ul>'.format(
                     party.name
                 )
 

--- a/ynr/apps/candidates/templatetags/standing.py
+++ b/ynr/apps/candidates/templatetags/standing.py
@@ -68,6 +68,12 @@ def post_in_election(person, election):
             )
         prefix, suffix = get_known_candidacy_prefix_and_suffix(candidacy)
         result = prefix + result + suffix
+        if candidacy.previous_party_affiliations.exists():
+            for party in candidacy.previous_party_affiliations.all():
+                result += '<br><span class="">Previous party affiliation: {}</span>'.format(
+                    party.name
+                )
+
     else:
         if election in person.not_standing.all():
             if not election.in_past:

--- a/ynr/apps/elections/templates/elections/ballot_view.html
+++ b/ynr/apps/elections/templates/elections/ballot_view.html
@@ -71,6 +71,9 @@
           <tr>
             <th>Name</th>
             <th>Party</th>
+            {% if ballot.is_welsh_run %}
+            <th>Previous Party Affiliations</th>
+            {% endif %}
             {% if ballot.has_results %}
             <th>Results</th>
             {% endif %}
@@ -90,46 +93,56 @@
                 {% if candidate.elected %}</strong>{% endif %}
               </a>
             </td>
-            <td>{{ candidate.party.name }}</td>
+            <td>
+              {{ candidate.party.name }}
+            </td> 
+            
+            {% if ballot.is_welsh_run %}
+              <td>
+                <ul class="previous-party">
+                {% for party in candidate.previous_party_affiliations.all %}
+                  <li>{{ party.name }}</li>
+                {% endfor %}
+                </ul>
+              </td>  
+            {% endif %}  
+
             {% if ballot.has_results %}
             <td>
               {{ candidate.result.num_ballots }}
               {% if candidate.elected %} (elected){% endif %}
             </td>
             {% endif %}
+            {% if user.is_authenticated %}
             <td>
-              {% if user.is_authenticated %}
+              {% if membership_edits_allowed %}
+                <a class="button tiny js-toggle-source-confirmation not-standing">
+                  Not actually standing?
+                </a>
+                {% include 'candidates/_source_confirmation.html' with standing='not-standing' action='candidacy-delete' person_id=candidate.person_id %}
+              {% endif %}
 
-                {% if membership_edits_allowed %}
-                  <a class="button tiny js-toggle-source-confirmation not-standing">
-                    Not actually standing?
-                  </a>
-                  {% include 'candidates/_source_confirmation.html' with standing='not-standing' action='candidacy-delete' person_id=candidate.person_id %}
-                {% endif %}
-
-                {% if ballot.polls_closed %}
-                  {% if user_can_record_results %}
-                    {% if not ballot.can_enter_votes_cast %}
-                      {% if not has_all_winners %}
-                        <form class="winner-confirm" id="winner-confirm_{{ candidate.person_id }}" action="{% url 'record-winner' ballot_paper_id=ballot.ballot_paper_id %}" method="post">
-                          {% csrf_token %}
-                          <input type="hidden" name="person_id" value="{{ candidate.person_id }}">
-                          <input type="hidden" name="source" value="[Quick update from the constituency page]">
-                          <input type="submit" class="button success" value="Mark candidate as elected">
-                        </form>
-                      {% endif %}
+              {% if ballot.polls_closed %}
+                {% if user_can_record_results %}
+                  {% if not ballot.can_enter_votes_cast %}
+                    {% if not has_all_winners %}
+                      <form class="winner-confirm" id="winner-confirm_{{ candidate.person_id }}" action="{% url 'record-winner' ballot_paper_id=ballot.ballot_paper_id %}" method="post">
+                        {% csrf_token %}
+                        <input type="hidden" name="person_id" value="{{ candidate.person_id }}">
+                        <input type="hidden" name="source" value="[Quick update from the constituency page]">
+                        <input type="submit" class="button success" value="Mark candidate as elected">
+                      </form>
                     {% endif %}
                   {% endif %}
                 {% endif %}
-
-                  <a href="{% url 'person-update' person_id=candidate.person.pk %}" class="button tiny secondary">
-                    Edit
-                  </a>
               {% endif %}
+              <a href="{% url 'person-update' person_id=candidate.person.pk %}" class="button tiny secondary">
+                Edit
+              </a> 
             </td>
+            {% endif %}
           </tr>
           {% endfor %}
-
         </tbody>
       </table>
 

--- a/ynr/apps/elections/tests/test_ballot_view.py
+++ b/ynr/apps/elections/tests/test_ballot_view.py
@@ -161,6 +161,33 @@ class TestBallotView(
             self.assertContains(response, escape(membership.person.name))
             self.assertContains(response, membership.party.name)
 
+    def test_previous_party_affiliations(self):
+        new_candidate = PersonFactory.create(name="John Doe")
+        ballot = BallotPaperFactory.create(
+            election=self.election,
+            post=self.post,
+            ballot_paper_id="senedd.foo.bar.2022-05-05",
+            winner_count=2,
+        )
+        party = PartyFactory()
+        self.old_party = PartyFactory()
+        self.membership = Membership.objects.create(
+            person=new_candidate, party=party, post=ballot.post, ballot=ballot
+        )
+
+        self.assertEqual(ballot.is_welsh_run, True)
+        response = self.app.get(ballot.get_absolute_url())
+        self.assertNotContains(response, self.old_party.name)
+        self.membership.previous_party_affiliations.add(self.old_party)
+        self.assertEqual(
+            self.old_party.name,
+            self.membership.previous_party_affiliations.all()[0].name,
+        )
+        response = self.app.get(ballot.get_absolute_url())
+        self.assertContains(
+            response, self.membership.previous_party_affiliations.all()[0].name
+        )
+
     def test_person_photo_shown(self):
         self.create_memberships(self.ballot, self.parties)
         person = self.ballot.membership_set.first().person

--- a/ynr/apps/elections/uk/templates/candidates/_person_form.html
+++ b/ynr/apps/elections/uk/templates/candidates/_person_form.html
@@ -95,14 +95,21 @@
       <thead>
         <th>Ballot</th>
         <th>Party</th>
-        <th>Previous Party</th> 
       </thead>
       <tbody>
       {% for membership in current_locked_ballots %}
         <tr>
           <td>{{ membership.ballot.ballot_paper_id }}</td>
-          <td>{{ membership.party.name }}</td>
-          <td>{{ membership.previous_party_affiliations.name }}</td>
+          <td>{{ membership.party.name }}<br>
+          <i class="previous-party">Previous Party Affiliations:</i>  
+            <ul class="previous-party">
+            {% for party in membership.previous_party_affiliations.all %}
+              
+              <li>{{ party.name }}</li>
+              
+            {% endfor %}
+          </ul>
+          </td>
         </tr>
       {% endfor %}
       </tbody>

--- a/ynr/apps/elections/uk/templates/candidates/_person_form.html
+++ b/ynr/apps/elections/uk/templates/candidates/_person_form.html
@@ -95,12 +95,14 @@
       <thead>
         <th>Ballot</th>
         <th>Party</th>
+        <th>Previous Party</th> 
       </thead>
       <tbody>
       {% for membership in current_locked_ballots %}
         <tr>
           <td>{{ membership.ballot.ballot_paper_id }}</td>
           <td>{{ membership.party.name }}</td>
+          <td>{{ membership.previous_party_affiliations.name }}</td>
         </tr>
       {% endfor %}
       </tbody>

--- a/ynr/apps/elections/uk/templates/candidates/person-view.html
+++ b/ynr/apps/elections/uk/templates/candidates/person-view.html
@@ -123,12 +123,12 @@
       <dt>Party</dt>
       <dd>{{ last_candidacy.party.name }}</dd>
     {% endif %}
+    
     {% if person.biography %}
       <dt>Statement to voters</dt>
       <dd class="person_biography">{{ person.biography|linebreaks }}</dd>
     {% endif %}
   </dl>
-
   <h2>Candidacies:</h2>
   <dl>
     {% for election in person.current_elections_standing_down %}
@@ -143,11 +143,12 @@
            Contesting the {{ election_data.name }} ({{ election_data.election_date }})
         {% endif %}</dt>
       <dd>{{ person|post_in_election:election_data }}</dd>
+
     {% empty %}
       <p>No candidacies known at the moment.</p>
     {% endfor %}
   </dl>
-
+ 
   <h2>Links and social media:</h2>
 
   <dl>


### PR DESCRIPTION
Closes https://github.com/DemocracyClub/yournextrepresentative/issues/1768

- [x] Add the input in the HTML but hide it with JS and add a button to add the data inline (showing the input when clicked).
- [x] Add another party select drop down, excluding party descriptions, and filtering on parties that were active in the 12 months before the election date.
- [x] Show the data on the bulk add review screen, so people locking ballots can verify the data.
- [x] Edit prev party affiliation 
- [x] Update tests