### PR TITLE
Only link to resultsform for FPTP ballots

### DIFF
--- a/ynr/apps/elections/tests/test_ballot_view.py
+++ b/ynr/apps/elections/tests/test_ballot_view.py
@@ -93,6 +93,7 @@ class TestBallotView(
                 date_in_near_past.isoformat()
             ),
             winner_count=2,
+            voting_system="FPTP",
         )
 
         self.parties = self.create_parties(3)
@@ -260,6 +261,16 @@ class TestBallotView(
         response.mustcontain(no="Waiting for election to happen")
         response.mustcontain(no="Unset the current winners")
         # TODO: Test winners in table
+
+    def test_ballot_non_fptp(self):
+        self.past_ballot.voting_system = "stv"
+        self.past_ballot.save()
+        self.create_memberships(self.past_ballot, self.parties)
+
+        response = self.app.get(self.past_ballot.get_absolute_url())
+        response.mustcontain("Winner(s) unknown")
+        response.mustcontain("Help by marking the elected candidates!")
+        response.mustcontain(no="Tell us who won")
 
     def test_constituency_with_winner_record_results_user(self):
         self.ballot.election.election_date = "2015-05-07"

--- a/ynr/apps/elections/uk/templates/uk/data_timeline.html
+++ b/ynr/apps/elections/uk/templates/uk/data_timeline.html
@@ -98,12 +98,17 @@
               <strong>Winner(s) recorded</strong>
               <i>Uncontested Ballot</i>
           </div> 
-          {% else %}
+          {% elif ballot.can_enter_votes_cast %}
           <div class="status_in_progress">
               <strong>Winner(s) unknown</strong>:
               <a href="{% url "ballot_paper_results_form" ballot.ballot_paper_id %}">
                 Tell us who won!
               </a>
+          </div>
+          {% else %}
+          <div class="status_in_progress">
+              <strong>Winner(s) unknown</strong>:
+              <p>Help by marking the elected candidates!</p>
           </div>
           {% endif %}
       {% endif %}


### PR DESCRIPTION
When removing the the ResultSet for https://candidates.democracyclub.org.uk/elections/mayor.sheffield-city-ca.2018-05-03/ I noticed that we would still display a link to user to enter results. This would then return a 404 as we only accept results for FPTP ballots currently.

This change removes that link, and asks users to mark elected candidates instead.