### PR TITLE
Add button to bulk add form to delete RawPeople

### DIFF
--- a/ynr/apps/bulk_adding/forms.py
+++ b/ynr/apps/bulk_adding/forms.py
@@ -389,3 +389,8 @@ class SelectPartyForm(forms.Form):
 class AddByPartyForm(forms.Form):
 
     source = forms.CharField(required=True)
+
+
+class DeleteRawPeopleForm(forms.Form):
+
+    ballot_paper_id = forms.CharField(required=True, widget=forms.HiddenInput)

--- a/ynr/apps/bulk_adding/models.py
+++ b/ynr/apps/bulk_adding/models.py
@@ -83,3 +83,7 @@ class RawPeople(TimeStampedModel):
     @property
     def is_trusted(self):
         return self.source_type in self.TRUSTED_SOURCES
+
+    @property
+    def is_parsed_from_pdf(self):
+        return self.source_type == self.SOURCE_PARSED_PDF

--- a/ynr/apps/bulk_adding/templates/bulk_add/sopns/_delete_parsed_people.html
+++ b/ynr/apps/bulk_adding/templates/bulk_add/sopns/_delete_parsed_people.html
@@ -1,0 +1,11 @@
+{% if ballot.rawpeople and ballot.rawpeople.is_parsed_from_pdf %}
+  <a class="button js-show-delete-parsed-people-confirm">🤖 Delete all people parsed by our bot 🤖</a>
+  <div class="delete-parsed-people-confirm">
+    <form id="delete-parsed-people" method="post" action="{% url 'delete_raw_people' %}">
+      {% csrf_token %}
+      <input type="hidden" name="ballot_paper_id" value="{{ ballot.ballot_paper_id }}" />
+      <input type="submit" class="button primary small" value="Confirm delete" />
+      <a class="button secondary small hide-delete-parsed-people">Cancel</a>
+    </form>
+  </div>
+{% endif %}

--- a/ynr/apps/bulk_adding/templates/bulk_add/sopns/add_form.html
+++ b/ynr/apps/bulk_adding/templates/bulk_add/sopns/add_form.html
@@ -40,7 +40,7 @@
   </ol>
   </details>
 
-  {% if ballot.rawpeople and ballot.rawpeople.source_type == "parsed_pdf"%}
+  {% if ballot.rawpeople and ballot.rawpeople.is_parsed_from_pdf %}
     <div class="panel callout">
       <details open>
         <summary>
@@ -68,10 +68,11 @@
     </div>
   {% endif %}
 
-{% include "bulk_add/sopns/_known-people.html" %}
+  {% include "bulk_add/sopns/_known-people.html" %}
 
   <form method=POST id="bulk_add_form">
     <button type=submit>Review</button>
+    <a href="{{ official_document.get_absolute_url }}" target="sopn_view" class="button">Nomination paper (SoPN)</a>
   {% csrf_token %}
   {{ formset.management_form }}
   {% if formset.non_form_errors %}
@@ -137,6 +138,8 @@
     </table>
   <button type=submit>Review</button>
 </form>
+
+{% include "bulk_add/sopns/_delete_parsed_people.html" %}
 
 {% else %}
 <p>

--- a/ynr/apps/bulk_adding/templates/bulk_add/sopns/add_review_form.html
+++ b/ynr/apps/bulk_adding/templates/bulk_add/sopns/add_review_form.html
@@ -88,12 +88,7 @@
     {% endif %}
   {% endfor %}
 
-  <p style="clear:left; padding-top:1em">
-    <input type="checkbox" name="suggest_locking" id="suggest_locking" checked>
-    <label for="suggest_locking">Suggest locking this area – check this box if you
-      are confident that this area is complete as per an official document</label>
-  </p>
-  <button type=submit>Next</button>
+  <button type=submit>Submit lock suggestion</button>
 </form>
 
   <script>

--- a/ynr/apps/bulk_adding/urls.py
+++ b/ynr/apps/bulk_adding/urls.py
@@ -1,8 +1,13 @@
-from django.urls import re_path
+from django.urls import re_path, path
 
 from . import views
 
 urlpatterns = [
+    path(
+        "delete-raw-people/",
+        views.DeleteRawPeople.as_view(),
+        name="delete_raw_people",
+    ),
     re_path(
         r"^(?!.*party|sopn)(?P<ballot_paper_id>[^/]+)/$",
         views.BulkAddSOPNRedirectView.as_view(),

--- a/ynr/apps/bulk_adding/views/sopns.py
+++ b/ynr/apps/bulk_adding/views/sopns.py
@@ -254,23 +254,22 @@ class BulkAddSOPNReviewView(BaseSOPNBulkAddView):
             ballot = context["ballot"]
             ballot.delete_outdated_suggested_locks()
 
-            if self.request.POST.get("suggest_locking") == "on":
-                SuggestedPostLock.objects.create(
-                    user=self.request.user, ballot=ballot
-                )
+            SuggestedPostLock.objects.create(
+                user=self.request.user, ballot=ballot
+            )
 
-                LoggedAction.objects.create(
-                    user=self.request.user,
-                    action_type=ActionType.SUGGEST_BALLOT_LOCK,
-                    ip_address=get_client_ip(self.request),
-                    ballot=ballot,
-                    source="Suggested after bulk adding",
-                    edit_type=EditType.BULK_ADD.name,
-                )
+            LoggedAction.objects.create(
+                user=self.request.user,
+                action_type=ActionType.SUGGEST_BALLOT_LOCK,
+                ip_address=get_client_ip(self.request),
+                ballot=ballot,
+                source="Suggested after bulk adding",
+                edit_type=EditType.BULK_ADD.name,
+            )
 
-                if hasattr(ballot, "rawpeople"):
-                    # Delete the raw import, as it's no longer useful
-                    ballot.rawpeople.delete()
+            if hasattr(ballot, "rawpeople"):
+                # Delete the raw import, as it's no longer useful
+                ballot.rawpeople.delete()
 
         messages.add_message(
             self.request,

--- a/ynr/apps/candidates/models/db.py
+++ b/ynr/apps/candidates/models/db.py
@@ -89,6 +89,10 @@ class ActionType(models.TextChoices):
         "suspended-twitter-account",
         "Suspended Twitter account",
     )
+    DELETED_PARSED_RAW_PEOPLE = (
+        "deleted-parsed-raw-people",
+        "Deleted parsed RawPeople",
+    )
 
     def get_action_type_display():
         return ActionType.choices

--- a/ynr/apps/candidates/static/js/ballot.js
+++ b/ynr/apps/candidates/static/js/ballot.js
@@ -11,6 +11,7 @@ $(function() {
   $('.source-confirmation-not-standing').hide();
   $('.source-confirmation-delete-other-name').hide()
   $('.candidates__new').hide();
+  $('.delete-parsed-people-confirm').hide();
 
   function getNewCandidateDiv(element) {
     return $('.candidates__new');
@@ -52,6 +53,18 @@ $(function() {
         return;
       }
     }
+  });
+
+  $('.js-show-delete-parsed-people-confirm').on('click', function(event){
+    event.preventDefault()
+    confirmation = $('.delete-parsed-people-confirm')
+    confirmation.show();
+  });
+
+  $('.hide-delete-parsed-people').on('click', function(event){
+    event.preventDefault()
+    confirmation = $('.delete-parsed-people-confirm')
+    confirmation.hide();
   });
 
   $('.winner-confirm').submit(function(e) {


### PR DESCRIPTION
Adds a new button to allow users to delete the parsed people preloaded on the bulk add form. Used JS to toggle a confirm/cancel button, on confirmation the `RawPeople` object is deleted via a FormView and user is redirected to the bulk add page.

Welcome to suggestions/help about better placement of the buttons - I had to keep them outside of the bulk add formset, which is why they are sat slightly above rather than inline with the other buttons.

![Screenshot 2022-03-28 at 18 00 16](https://user-images.githubusercontent.com/15347726/160449720-9a70500d-1a1e-41c6-88e3-5d913bf2ac12.png)
![Screenshot 2022-03-28 at 18 00 19](https://user-images.githubusercontent.com/15347726/160449726-004bb796-73bb-4cf8-a5ab-e6212d57e8e3.png)

