### PR TITLE
Fix docx to PDF conversion

### DIFF
--- a/ynr/apps/candidates/management/commands/candidates_import_statements_of_persons_nominated.py
+++ b/ynr/apps/candidates/management/commands/candidates_import_statements_of_persons_nominated.py
@@ -13,7 +13,7 @@ from django.core.management.base import BaseCommand
 
 from candidates.models import Ballot
 from official_documents.models import OfficialDocument
-from sopn_parsing.helpers.convert_pdf import PandocConversionError
+from ynr.apps.sopn_parsing.helpers.convert_pdf import PandocConversionError
 from sopn_parsing.tasks import extract_and_parse_tables_for_ballot
 
 allowed_mime_types = {

--- a/ynr/apps/candidates/management/commands/candidates_import_statements_of_persons_nominated.py
+++ b/ynr/apps/candidates/management/commands/candidates_import_statements_of_persons_nominated.py
@@ -13,7 +13,10 @@ from django.core.management.base import BaseCommand
 
 from candidates.models import Ballot
 from official_documents.models import OfficialDocument
-from ynr.apps.sopn_parsing.helpers.convert_pdf import PandocConversionError
+from sopn_parsing.helpers.convert_pdf import (
+    PandocConversionError,
+    convert_sopn_to_pdf,
+)
 from sopn_parsing.tasks import extract_and_parse_tables_for_ballot
 
 allowed_mime_types = {
@@ -161,18 +164,28 @@ class Command(BaseCommand):
             with open(downloaded_filename, "rb") as f:
                 storage_filename = storage.save(filename, f)
 
-            try:
-                OfficialDocument.objects.create(
-                    document_type=OfficialDocument.NOMINATION_PAPER,
-                    uploaded_file=storage_filename,
-                    ballot=ballot,
-                    source_url=document_url,
-                )
-            except PandocConversionError:
-                self.stderr.write(
-                    f"Error attempting to convert {document_url} to a PDF, skipping this row"
-                )
-                continue
+            # create with the original file
+            official_document = OfficialDocument.objects.create(
+                document_type=OfficialDocument.NOMINATION_PAPER,
+                uploaded_file=storage_filename,
+                ballot=ballot,
+                source_url=document_url,
+            )
+
+            if extension != ".pdf":
+                try:
+                    new_file = convert_sopn_to_pdf(
+                        official_document.uploaded_file.file
+                    )
+                    official_document.uploaded_file.save(
+                        storage_filename.replace(extension, ".pdf"),
+                        new_file.file,
+                    )
+                except PandocConversionError:
+                    self.stderr.write(
+                        f"Error attempting to convert {document_url} to a PDF, skipping this row"
+                    )
+                    continue
 
             message = (
                 "Successfully added the Statement of Persons Nominated for {0}"

--- a/ynr/apps/official_documents/forms.py
+++ b/ynr/apps/official_documents/forms.py
@@ -28,7 +28,9 @@ class UploadDocumentForm(forms.ModelForm):
         uploaded_file = self.cleaned_data["uploaded_file"]
         # try and convert
         try:
-            uploaded_file = convert_sopn_to_pdf(uploaded_file)
+            self.cleaned_data["uploaded_file"] = convert_sopn_to_pdf(
+                uploaded_file
+            )
         except PandocConversionError:
             raise forms.ValidationError(
                 "File is invalid. Please convert to a PDF and retry"

--- a/ynr/apps/official_documents/forms.py
+++ b/ynr/apps/official_documents/forms.py
@@ -17,9 +17,7 @@ class UploadDocumentForm(forms.ModelForm):
         widgets = {"ballot": forms.HiddenInput()}
 
     uploaded_file = forms.FileField(
-        validators=[
-            FileExtensionValidator(allowed_extensions=["pdf", "docx", "html"])
-        ]
+        validators=[FileExtensionValidator(allowed_extensions=["pdf", "docx"])]
     )
 
     document_type = forms.CharField(widget=forms.HiddenInput())

--- a/ynr/apps/official_documents/models.py
+++ b/ynr/apps/official_documents/models.py
@@ -1,10 +1,9 @@
 import os
 
+from django.core.validators import FileExtensionValidator
 from django.db import models
 from django.urls import reverse
 from django_extensions.db.models import TimeStampedModel
-
-from ynr.apps.sopn_parsing.helpers.convert_pdf import convert_sopn_to_pdf
 
 DOCUMENT_UPLOADERS_GROUP_NAME = "Document Uploaders"
 
@@ -28,7 +27,11 @@ class OfficialDocument(TimeStampedModel):
         max_length=100,
     )
     uploaded_file = models.FileField(
-        upload_to=document_file_name, max_length=800
+        upload_to=document_file_name,
+        max_length=800,
+        validators=[
+            FileExtensionValidator(allowed_extensions=["pdf", "docx", "html"])
+        ],
     )
     ballot = models.ForeignKey(
         "candidates.Ballot", null=False, on_delete=models.CASCADE
@@ -41,11 +44,6 @@ class OfficialDocument(TimeStampedModel):
         max_length=50,
         default="",
     )
-
-    def save(self, *args, **kwargs):
-        if self.uploaded_file:
-            self.uploaded_file = convert_sopn_to_pdf(self.uploaded_file)
-        super().save(*args, **kwargs)
 
     class Meta:
         get_latest_by = "modified"

--- a/ynr/apps/official_documents/models.py
+++ b/ynr/apps/official_documents/models.py
@@ -29,9 +29,7 @@ class OfficialDocument(TimeStampedModel):
     uploaded_file = models.FileField(
         upload_to=document_file_name,
         max_length=800,
-        validators=[
-            FileExtensionValidator(allowed_extensions=["pdf", "docx", "html"])
-        ],
+        validators=[FileExtensionValidator(allowed_extensions=["pdf", "docx"])],
     )
     ballot = models.ForeignKey(
         "candidates.Ballot", null=False, on_delete=models.CASCADE

--- a/ynr/apps/official_documents/tests/test_upload.py
+++ b/ynr/apps/official_documents/tests/test_upload.py
@@ -196,9 +196,12 @@ class TestModels(TestUserMixin, WebTest):
         with open(self.example_html_filename, "rb") as f:
             form["uploaded_file"] = Upload("pilot.html", f.read())
         response = form.submit()
-        self.assertEqual(response.status_code, 302)
-        self.assertEqual(OfficialDocument.objects.count(), 1)
-        self.assertEqual(response.location, self.ballot.get_sopn_url())
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(OfficialDocument.objects.count(), 0)
+        self.assertInHTML(
+            "File extension “html” is not allowed. Allowed extensions are: pdf, docx.",
+            response.text,
+        )
 
     @skipIf(
         should_skip_conversion_tests(), "Required conversion libs not installed"
@@ -227,6 +230,6 @@ class TestModels(TestUserMixin, WebTest):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(OfficialDocument.objects.count(), 0)
         self.assertInHTML(
-            "File extension “jpg” is not allowed. Allowed extensions are: pdf, docx, html.",
+            "File extension “jpg” is not allowed. Allowed extensions are: pdf, docx.",
             response.text,
         )

--- a/ynr/apps/sopn_parsing/helpers/convert_pdf.py
+++ b/ynr/apps/sopn_parsing/helpers/convert_pdf.py
@@ -17,7 +17,7 @@ def convert_sopn_to_pdf(uploaded_file):
     """
     filetype = uploaded_file.name.split(".")[-1]
     if filetype not in ACCEPTED_FILE_TYPES:
-        raise ValueError(f"Cannot convert {filetype} files")
+        raise PandocConversionError(f"Cannot convert {filetype} files")
 
     if filetype == "pdf":
         return uploaded_file

--- a/ynr/apps/sopn_parsing/helpers/convert_pdf.py
+++ b/ynr/apps/sopn_parsing/helpers/convert_pdf.py
@@ -13,7 +13,8 @@ class PandocConversionError(Exception):
 
 def convert_sopn_to_pdf(uploaded_file):
     """
-    Convert a SOPN to a PDF.
+    Takes a File-like object, attempts to convert it to a PDF, and returns the
+    new file that can then be used to store against an OfficialDocument
     """
     filetype = uploaded_file.name.split(".")[-1]
     if filetype not in ACCEPTED_FILE_TYPES:
@@ -41,6 +42,4 @@ def convert_sopn_to_pdf(uploaded_file):
 
         # return with converted file object and updated name
         pdf_file_name = uploaded_file.name.replace(f".{filetype}", ".pdf")
-        uploaded_file.file = ContentFile(content=temp_file.file.read())
-        uploaded_file.name = pdf_file_name
-        return uploaded_file
+        return ContentFile(content=temp_file.file.read(), name=pdf_file_name)

--- a/ynr/apps/sopn_parsing/helpers/convert_pdf.py
+++ b/ynr/apps/sopn_parsing/helpers/convert_pdf.py
@@ -4,7 +4,7 @@ import pypandoc
 from django.core.files.base import ContentFile
 from raven.contrib.django.raven_compat.models import client
 
-ACCEPTED_FILE_TYPES = ["docx", "html", "pdf"]
+ACCEPTED_FILE_TYPES = ["docx", "pdf"]
 
 
 class PandocConversionError(Exception):

--- a/ynr/apps/sopn_parsing/tests/test_pdf_conversion.py
+++ b/ynr/apps/sopn_parsing/tests/test_pdf_conversion.py
@@ -10,6 +10,7 @@ from official_documents.tests.paths import (
     EXAMPLE_HTML_FILENAME,
 )
 from moderation_queue.tests.paths import EXAMPLE_IMAGE_FILENAME
+from ynr.apps.sopn_parsing.helpers.convert_pdf import PandocConversionError
 from sopn_parsing.helpers.convert_pdf import convert_sopn_to_pdf
 from sopn_parsing.tests import should_skip_conversion_tests
 
@@ -54,7 +55,7 @@ class TestSOPNHelpers(UK2015ExamplesMixin, TestCase):
 
     def test_convert_other_file_to_SOPN(self):
         # when file types are not accepted, raise an error
-        with self.assertRaises(ValueError):
+        with self.assertRaises(PandocConversionError):
             OfficialDocument.objects.create(
                 ballot=self.dulwich_post_ballot,
                 document_type=OfficialDocument.NOMINATION_PAPER,

--- a/ynr/apps/sopn_parsing/tests/test_pdf_conversion.py
+++ b/ynr/apps/sopn_parsing/tests/test_pdf_conversion.py
@@ -49,8 +49,8 @@ class TestSOPNHelpers(UK2015ExamplesMixin, TestCase):
             ),
             source_url="example.com",
         )
-        new_file = convert_sopn_to_pdf(doc.uploaded_file)
-        self.assertTrue(new_file.name.endswith(".pdf"))
+        with self.assertRaises(PandocConversionError):
+            convert_sopn_to_pdf(doc.uploaded_file)
 
     def test_convert_other_file_to_SOPN(self):
         # when file types are not accepted, raise an error


### PR DESCRIPTION
- Previously there was a bug that meant that the file was being
converted but not stored. This updates the convert method to expect
a file object, and return a new file object that is then used by the
OfficialDocument.uploaded_file.save method to ensure that it is stored

I have tested this locally by adding some .docx SOPN's to https://docs.google.com/spreadsheets/d/1T4If0-1u4yDbjkmtCJ2r-TxURvuFFDUEotpEWTNEwSg/edit#gid=0 and then using the management command to attempt to import them:
```
python manage.py candidates_import_statements_of_persons_nominated "https://docs.google.com/spreadsheets/d/e/2PACX-1vRzSzHXiYHTK0bDgoDkstM8gmaMC4IPUXsXhvDGXGj08B8v40A9cgLTJgtngndmuLLRqlNNv0hKzPuc/pub?gid=0&single=true&output=csv"
```