### PR TITLE
Fix SOPN progress stats for displaying numbers double checked

### DIFF
--- a/ynr/apps/elections/uk/templatetags/home_page_tags.py
+++ b/ynr/apps/elections/uk/templatetags/home_page_tags.py
@@ -1,16 +1,6 @@
 from django import template
 from django.conf import settings
-from django.db.models import (
-    Sum,
-    IntegerField,
-    Count,
-    Func,
-    F,
-    Value,
-    TextField,
-    Q,
-)
-from django.db.models.functions import Cast
+from django.db.models import Sum, Count, Func, F, Value, TextField, Q
 
 from candidates.models import Ballot
 from elections.filters import filter_shortcuts
@@ -70,8 +60,10 @@ def sopn_progress_by_value(base_qs, lookup_value, label_field=None):
         has_sopn_count=Count(
             "pk", filter=Q(officialdocument__isnull=False), distinct=True
         ),
-        locked_count=Sum(Cast("candidates_locked", IntegerField())),
-        locksuggested_count=Count("suggestedpostlock"),
+        locked_count=Count(
+            "pk", filter=Q(candidates_locked=True), distinct=True
+        ),
+        locksuggested_count=Count("suggestedpostlock", distinct=True),
         count=Count("ballot_paper_id", distinct=True),
     ).order_by(lookup_value)
     values_dict = {}


### PR DESCRIPTION
Tested on the server:
```
In [9]: ballot_qs = Ballot.objects.filter( 
   ...:     election__election_date="2022-05-05" 
   ...: )                                                                       

In [10]: b = ballot_qs.filter(tags__NUTS1__key="UKM")                           

In [11]: b = b.values("election__election_date")                                

In [12]: b = b.annotate( 
    ...:         has_sopn_count=Count( 
    ...:             "pk", filter=Q(officialdocument__isnull=False), distinct=Tr
    ...: ue 
    ...:         ), 
    ...:         locked_count=Count("pk", filter=Q(candidates_locked=True), dist
    ...: inct=True), 
    ...:         locksuggested_count=Count("suggestedpostlock", distinct=True), 
    ...:         count=Count("ballot_paper_id", distinct=True), 
    ...:     )                                                                  

In [13]: b                                                                      
Out[13]: <BallotQueryset [{'election__election_date': datetime.date(2022, 5, 5), 'has_sopn_count': 355, 'locked_count': 355, 'locksuggested_count': 0, 'count': 355}]>

```