### PR TITLE
Catch base PDFException when extracting pages

### DIFF
--- a/ynr/apps/sopn_parsing/helpers/extract_pages.py
+++ b/ynr/apps/sopn_parsing/helpers/extract_pages.py
@@ -1,4 +1,4 @@
-from pdfminer.pdfparser import PDFSyntaxError
+from pdfminer.pdftypes import PDFException
 from sopn_parsing.helpers.pdf_helpers import SOPNDocument
 from sopn_parsing.helpers.text_helpers import NoTextInDocumentError
 
@@ -23,10 +23,10 @@ def extract_pages_for_ballot(ballot):
         raise NoTextInDocumentError(
             f"Failed to extract pages for {ballot.sopn.uploaded_file.path} as a NoTextInDocumentError was raised"
         )
-    except PDFSyntaxError:
+    except PDFException:
         print(
             f"{ballot.ballot_paper_id} failed to parse as a PDFSyntaxError was raised"
         )
-        raise PDFSyntaxError(
+        raise PDFException(
             f"Failed to extract pages for {ballot.sopn.uploaded_file.path} as a PDFSyntaxError was raised"
         )

--- a/ynr/apps/sopn_parsing/management/commands/sopn_parsing_extract_page_numbers.py
+++ b/ynr/apps/sopn_parsing/management/commands/sopn_parsing_extract_page_numbers.py
@@ -1,4 +1,4 @@
-from pdfminer.pdfparser import PDFSyntaxError
+from pdfminer.pdftypes import PDFException
 from sopn_parsing.helpers.command_helpers import BaseSOPNParsingCommand
 from sopn_parsing.helpers.extract_pages import extract_pages_for_ballot
 from sopn_parsing.helpers.text_helpers import NoTextInDocumentError
@@ -26,5 +26,5 @@ class Command(BaseSOPNParsingCommand):
         for ballot in qs:
             try:
                 extract_pages_for_ballot(ballot)
-            except (ValueError, NoTextInDocumentError, PDFSyntaxError) as e:
+            except (ValueError, NoTextInDocumentError, PDFException) as e:
                 self.stderr.write(e.args[0])


### PR DESCRIPTION
When testing some of the docs from Scotland locally, one of the .docx files that we failed to convert raised a encryption error that we were not explicitly catching. This shouldn't happen now that the conversion method has been updated, but it made we wonder if rather than catching a `PDFSyntax` exception, should we catch the base `PDFException` to guard against the management command to import SOPN's being killed by some other exception we have not yet seen?