### PR TITLE
Another name field

### DIFF
--- a/ynr/apps/sopn_parsing/helpers/parse_tables.py
+++ b/ynr/apps/sopn_parsing/helpers/parse_tables.py
@@ -40,6 +40,7 @@ NAME_FIELDS = (
         "names of candidate",
         "candidate name",
         "surname other names",
+        "surname other names in full",
     ]
     + WELSH_NAME_FIELDS
 )

--- a/ynr/apps/sopn_parsing/helpers/parse_tables.py
+++ b/ynr/apps/sopn_parsing/helpers/parse_tables.py
@@ -31,7 +31,7 @@ LAST_NAME_FIELDS = [
     "last name",
     "surname / cyfenw",
 ]
-WELSH_NAME_FIELDS = ["enwr ymgeisydd"]
+WELSH_NAME_FIELDS = ["enwr ymgeisydd", "enwr ymgeisydd candidate name"]
 NAME_FIELDS = (
     FIRST_NAME_FIELDS
     + LAST_NAME_FIELDS
@@ -48,7 +48,10 @@ NAME_FIELDS = (
 
 INDEPENDENT_VALUES = ["Independent", "", "Annibynnol"]
 
-WELSH_DESCRIPTION_VALUES = ["disgrifiad or ymgeisydd"]
+WELSH_DESCRIPTION_VALUES = [
+    "disgrifiad or ymgeisydd",
+    "disgrifiad or ymgeisydd description of candidate",
+]
 DESCRIPTION_VALUES = [
     "description of candidate",
     "description",


### PR DESCRIPTION
Fixes https://github.com/DemocracyClub/yournextrepresentative/issues/1727#issuecomment-1089253992

Parses the parties but the names are a mess - not sure if it better not to parse?

```
local.watford.central.2022-05-05 increased from 0 to 4 parsed people.
Check the SOPN at https://candidates.democracyclub.org.uk/elections/local.watford.central.2022-05-05/sopn/.
{'name': 'emetriou-Jones Sophia D', 'party_id': 'PP53'}
{'name': 'evonish Marilyn D', 'party_id': 'PP90', 'description_id': 1742}
{'name': 'arker Cole James P', 'party_id': 'PP52', 'description_id': 1727}
{'name': 'harton Dennis Alfred W', 'party_id': 'ynmp-party:2'}
We dont have candidates for local.watford.central.2022-05-05. Try updating with the live site first?
```