### PR TITLE
Use election_date when looking up OfficialDocuments with same source

### DIFF
--- a/ynr/apps/sopn_parsing/helpers/extract_pages.py
+++ b/ynr/apps/sopn_parsing/helpers/extract_pages.py
@@ -16,7 +16,9 @@ def extract_pages_for_ballot(ballot):
     """
     try:
         sopn = SOPNDocument(
-            file=ballot.sopn.uploaded_file, source_url=ballot.sopn.source_url
+            file=ballot.sopn.uploaded_file,
+            source_url=ballot.sopn.source_url,
+            election_date=ballot.election.election_date,
         )
         return sopn.match_all_pages()
     except (NoTextInDocumentError):

--- a/ynr/apps/sopn_parsing/helpers/pdf_helpers.py
+++ b/ynr/apps/sopn_parsing/helpers/pdf_helpers.py
@@ -22,12 +22,13 @@ CONTINUATION_THRESHOLD = 0.5
 
 
 class SOPNDocument:
-    def __init__(self, file, source_url, strict=False):
+    def __init__(self, file, source_url, election_date, strict=False):
         """
         Represents a collection of pages from a single PDF file.
         """
         self.file = file
         self.source_url = source_url
+        self.election_date = election_date
         self.strict = strict
         self.unmatched_documents = list(
             self.all_official_documents_with_source()
@@ -94,7 +95,10 @@ class SOPNDocument:
         ward name "Foo"
         """
         return (
-            OfficialDocument.objects.filter(source_url=self.source_url)
+            OfficialDocument.objects.filter(
+                source_url=self.source_url,
+                ballot__election__election_date=self.election_date,
+            )
             .select_related("ballot", "ballot__post")
             .order_by(-Length("ballot__post__label"), "ballot__post__label")
         )

--- a/ynr/apps/sopn_parsing/tests/test_sopn_helpers.py
+++ b/ynr/apps/sopn_parsing/tests/test_sopn_helpers.py
@@ -29,7 +29,9 @@ class TestSOPNHelpers(TestCase):
             join(dirname(__file__), "data/sopn-berkeley-vale.pdf")
         )
         doc = SOPNDocument(
-            file=open(example_doc_path, "rb"), source_url="http://example.com"
+            file=open(example_doc_path, "rb"),
+            source_url="http://example.com",
+            election_date="2019-02-28",
         )
         doc.heading = {"reason", "2019", "a", "election", "the", "labour"}
         self.assertEqual(len(doc.pages), 1)
@@ -42,7 +44,9 @@ class TestSOPNHelpers(TestCase):
             join(dirname(__file__), "data/sopn-berkeley-vale.pdf")
         )
         doc = SOPNDocument(
-            open(example_doc_path, "rb"), source_url="http://example.com"
+            open(example_doc_path, "rb"),
+            source_url="http://example.com",
+            election_date="2022-02-28",
         )
         self.assertSetEqual(
             doc.document_heading_set,
@@ -116,7 +120,9 @@ class TestSOPNHelpers(TestCase):
         self.assertEqual(official_document.relevant_pages, "")
 
         document_obj = SOPNDocument(
-            file=sopn_file, source_url="http://example.com/strensall"
+            file=sopn_file,
+            source_url="http://example.com/strensall",
+            election_date=ballot.election.election_date,
         )
         self.assertEqual(len(document_obj.pages), 1)
 
@@ -135,7 +141,9 @@ class TestSOPNHelpers(TestCase):
         example_doc_path = abspath(
             join(dirname(__file__), "data/NI-Assembly-Election-2016.pdf")
         )
-        election = ElectionFactory(slug="nia.2016-05-05")
+        election = ElectionFactory(
+            slug="nia.2016-05-05", election_date="2016-05-05"
+        )
         organization = OrganizationFactory(slug="nia:nia")
         mid_ulster = BallotPaperFactory(
             ballot_paper_id="nia.mid-ulster.2016-05-05",
@@ -165,7 +173,9 @@ class TestSOPNHelpers(TestCase):
             self.assertEqual(official_document.relevant_pages, "")
 
         document_obj = SOPNDocument(
-            file=sopn_file, source_url="http://example.com"
+            file=sopn_file,
+            source_url="http://example.com",
+            election_date=election.election_date,
         )
         self.assertEqual(len(document_obj.pages), 9)
         document_obj.match_all_pages()
@@ -198,7 +208,9 @@ class TestSOPNHelpers(TestCase):
         self.assertEqual(official_document.relevant_pages, "")
 
         document_obj = SOPNDocument(
-            file=sopn_file, source_url="http://example.com/strensall"
+            file=sopn_file,
+            source_url="http://example.com/strensall",
+            election_date=strensall.election.election_date,
         )
         self.assertEqual(len(document_obj.pages), 2)
 


### PR DESCRIPTION
- Fixes bug that occurs when councils publish SOPN's on same source
url as previous election. This was resulting in old SOPN's being
reparsed unnecessarily