### PR TITLE
Dont allow lock suggestions to be created if ballot is locked

### DIFF
--- a/ynr/apps/bulk_adding/forms.py
+++ b/ynr/apps/bulk_adding/forms.py
@@ -168,6 +168,12 @@ class BaseBulkAddReviewFormSet(BaseBulkAddFormSet):
         errors = []
         if not hasattr(self, "ballot"):
             return super().clean()
+
+        if self.ballot.candidates_locked:
+            raise ValidationError(
+                "Candidates have already been locked for this ballot"
+            )
+
         for form_data in self.cleaned_data:
 
             if (

--- a/ynr/apps/elections/templates/elections/includes/_ballot_lock_form.html
+++ b/ynr/apps/elections/templates/elections/includes/_ballot_lock_form.html
@@ -2,7 +2,10 @@
 {% if candidates.exists and user_can_lock %}
   <form method="post" action="{% url 'constituency-lock' ballot_id=ballot.ballot_paper_id %}">
     {% csrf_token %}
-    {% if ballot.has_lock_suggestion and sopn %}
+
+    {% if ballot.candidates_locked %}
+      <input type="submit" class="button small" value="Unlock candidate list">
+    {% elif ballot.has_lock_suggestion and sopn %}
       {% if current_user_suggested_lock %}
          <p>
           Locking disabled because you suggested locking this ballot.
@@ -14,8 +17,6 @@
         <input type="submit" class="button small" value="Lock candidate list">
       {% endif %}
 
-    {% elif ballot.candidates_locked %}
-      <input type="submit" class="button small" value="Unlock candidate list">
     {% endif %}
 
     {% if ballot.candidates_locked %}

--- a/ynr/apps/moderation_queue/forms.py
+++ b/ynr/apps/moderation_queue/forms.py
@@ -252,3 +252,11 @@ class SuggestedPostLockForm(forms.ModelForm):
             "ballot": forms.HiddenInput(),
             "justification": forms.Textarea(attrs={"rows": 1, "columns": 72}),
         }
+
+    def clean(self):
+        ballot = self.cleaned_data["ballot"]
+        if ballot.candidates_locked:
+            raise ValidationError(
+                "Cannot create a lock suggestion for a locked ballot"
+            )
+        return self.cleaned_data

--- a/ynr/context_processors.py
+++ b/ynr/context_processors.py
@@ -60,6 +60,7 @@ def add_notification_data(request):
         if TRUSTED_TO_LOCK_GROUP_NAME in groups:
             result["suggestions_to_lock"] = (
                 SuggestedPostLock.objects.exclude(user=request.user)
+                .exclude(ballot__candidates_locked=True)
                 .distinct("ballot")
                 .count()
             )


### PR DESCRIPTION
Fixes a bug that could occur in the following scenario:
- User A completes bulk add form to add candidates but does not
submit the final step to lock candidates
- User B also submits a lock suggestion
- User C confirms user B's lock suggestion, locking the candidates
- User A belatedly submits their lock suggestion, which would still
create a lock suggestion for the ballot and add it to the queue. But
now the "Lock ballot" button on the lock review screen would actually
unlock the ballot

These changes add additional validation to block the lock suggestion
from being created. As a safeguard, it also excludes locked ballots
from the queryset used on the lock suggestion review list.