### PR TITLE
Make it clearer how undercontested is calculated

### DIFF
--- a/ynr/apps/cached_counts/report_helpers.py
+++ b/ynr/apps/cached_counts/report_helpers.py
@@ -371,9 +371,15 @@ class NcandidatesPerSeat(BaseReport):
                 continue
 
             parties = Counter(parties)
-            will_win, will_win_seats = parties.most_common(1)[0]
-            parties[will_win] -= ballot.winner_count
-            will_win_seats -= sum(parties.values())
+            will_win, _ = parties.most_common(1)[0]
+            # remove the candidates of the party we know will
+            # definitely win some seats
+            del parties[will_win]
+            # subtract the total number of candidates from other
+            # parties from the number of seats up. The result is the
+            # minimum number of seats the winning party will win
+            will_win_seats = ballot.winner_count - sum(parties.values())
+
             for membership in ballot.membership_set.all():
                 is_a_winner = False
                 if membership.party.name == will_win and will_win_seats:


### PR DESCRIPTION
Subtract total number of other candidates that could win from the
winner count. This is the minimum number of seats that the 'winning'
party will win.

- Count up which party has the most candidates, remove them from the
candidate total
- Count up the remaining number of candidates from other parties, and
subtract this from the number of seats up
- That number represents the minimum number of seats the party with
most candidates will win:
So e.g:
5 candidates in total
3 seats up
3 Labour
1 Conservative
1 Green

5 (candidate total) - 3 (labour total) = 2 (or 1 con + 1 green)
3 (seats up) - 2 (other candidates, assuming they won) = 1 (Has to go to Labour)