### PR TITLE
Use simple dict, not English

### DIFF
--- a/ynr/apps/people/managers.py
+++ b/ynr/apps/people/managers.py
@@ -43,9 +43,9 @@ POPULATE_NAME_SEARCH_COLUMN_SQL = """
     UPDATE people_person
     SET name_search_vector = sq.terms
     FROM (
-        SELECT pp.id as id, setweight(to_tsvector(coalesce(pp.name, '')), 'A')
+        SELECT pp.id as id, setweight(to_tsvector('simple', coalesce(pp.name, '')), 'A')
                ||
-           setweight(to_tsvector(coalesce(string_agg(ppon.name, ' '), '')), 'B') as terms
+           setweight(to_tsvector('simple', coalesce(string_agg(ppon.name, ' '), '')), 'B') as terms
         FROM people_person pp
         LEFT JOIN popolo_othername ppon
         ON pp.id = ppon.object_id
@@ -68,8 +68,8 @@ NAME_SEARCH_TRIGGER_SQL = """
                                    ), ','
                            ) as other_names
             )
-            SELECT setweight(to_tsvector('pg_catalog.english', coalesce(new.name, '')), 'A') ||
-                   setweight(to_tsvector(coalesce(po_names.other_names, '')), 'D')
+            SELECT setweight(to_tsvector('simple', coalesce(new.name, '')), 'A') ||
+                   setweight(to_tsvector('simple', coalesce(po_names.other_names, '')), 'D')
             FROM po_names
         );
       return new;

--- a/ynr/apps/people/managers.py
+++ b/ynr/apps/people/managers.py
@@ -43,9 +43,19 @@ POPULATE_NAME_SEARCH_COLUMN_SQL = """
     UPDATE people_person
     SET name_search_vector = sq.terms
     FROM (
-        SELECT pp.id as id, setweight(to_tsvector('simple', coalesce(pp.name, '')), 'A')
-               ||
-           setweight(to_tsvector('simple', coalesce(string_agg(ppon.name, ' '), '')), 'B') as terms
+        SELECT pp.id as id,
+            ---- First and last names are weight A
+            --- First Name
+            setweight(to_tsvector('simple', split_part(pp.name, ' ', 1)), 'A')
+            ||
+            --- Last Name
+            setweight(to_tsvector('simple', regexp_replace(pp.name, '^.* ', '')), 'A')
+            ||
+            --- Full name is weight B, further boosting first and last names, adding middle names
+            setweight(to_tsvector('simple', coalesce(pp.name, '')), 'B')
+            ||
+            --- Other names are weight C
+            setweight(to_tsvector('simple', coalesce(string_agg(ppon.name, ' '), '')), 'C') as terms
         FROM people_person pp
         LEFT JOIN popolo_othername ppon
         ON pp.id = ppon.object_id
@@ -68,8 +78,17 @@ NAME_SEARCH_TRIGGER_SQL = """
                                    ), ','
                            ) as other_names
             )
-            SELECT setweight(to_tsvector('simple', coalesce(new.name, '')), 'A') ||
-                   setweight(to_tsvector('simple', coalesce(po_names.other_names, '')), 'D')
+            SELECT
+            setweight(to_tsvector('simple', split_part(new.name, ' ', 1)), 'A')
+            ||
+            --- Last Name
+            setweight(to_tsvector('simple', regexp_replace(new.name, '^.* ', '')), 'A')
+            ||
+            --- Full name is weight B, further boosting first and last names, adding middle names
+            setweight(to_tsvector('simple', coalesce(new.name, '')), 'B')
+            ||
+            --- Other names are weight C
+            setweight(to_tsvector('simple', coalesce(string_agg(po_names.other_names, ' '), '')), 'C') as terms
             FROM po_names
         );
       return new;

--- a/ynr/apps/people/models.py
+++ b/ynr/apps/people/models.py
@@ -852,17 +852,14 @@ class PersonNameSynonymLookup(Lookup):
         params = lhs_params + rhs_params
         return (
             """
-            %s @@
-                tsquery_or(
-                    %s,
-                    ts_rewrite(
+            %s @@ ts_rewrite(
                         %s,
-                        'SELECT term, synonym FROM people_personnamesynonym'
+                        'SELECT term, synonym FROM people_personnamesynonym
+                        WHERE ''%s''::tsquery @> term'
                     )
-                )
             """
-            % (lhs, rhs, rhs),
-            params + params,
+            % (lhs, rhs, params[1]),
+            params,
         )
 
 

--- a/ynr/apps/people/models.py
+++ b/ynr/apps/people/models.py
@@ -6,7 +6,7 @@ from django.conf import settings
 from django.contrib.contenttypes.fields import GenericRelation
 from django.db import transaction
 from django.db.models import JSONField
-from django.contrib.postgres.indexes import GistIndex
+from django.contrib.postgres.indexes import GinIndex
 from django.contrib.postgres.search import (
     SearchVectorField,
     SearchQuery,
@@ -301,7 +301,7 @@ class Person(TimeStampedModel, models.Model):
     class Meta:
         verbose_name_plural = "People"
         indexes = (
-            GistIndex(
+            GinIndex(
                 fields=["name_search_vector"], name="name_vector_search_index"
             ),
         )

--- a/ynr/apps/people/templates/people/search/search.html
+++ b/ynr/apps/people/templates/people/search/search.html
@@ -27,7 +27,7 @@
                 <img class="person-avatar" src="{{ result.get_display_image_url }}" height="64" width="64"/>
                 <div class="person-name-and-party">
                   <a href="{% url 'person-view' result.id result.name|slugify %}" class="candidate-name">{{ result.name }}</a>
-                  <span class="party">{{ result.last_party }}</span>
+                  <span class="party">{{ result.party_name }}</span>
                 </div>
                 <a href="{% url 'person-update' person_id=result.pk %}" class="button secondary small">Add more details</a>
             </li>

--- a/ynr/apps/people/templates/people/search/search.html
+++ b/ynr/apps/people/templates/people/search/search.html
@@ -4,55 +4,67 @@
 {% load thumbnail %}
 
 {% block content %}
-<h2>Search candidates</h2>
+  <h2>Search candidates</h2>
 
-    <form class="search" method="get" action="{% url 'person-search' %}">
-        <input type="search" placeholder="Find a candidate…" name="q" value="{{ query|default_if_none:'' }}"/>
-        <button type="submit">Search</button>
-    </form>
+  <form class="search" method="get" action="{% url 'person-search' %}">
+    <input type="search" placeholder="Find a candidate…" name="q" value="{{ query|default_if_none:'' }}"/>
+    <button type="submit">Search</button>
+  </form>
 
-    {% if looks_like_postcode %}
+  {% if looks_like_postcode %}
     <h3>Looking information in your postcode?</h3>
     <p>Try going to <a href="https://whocanivotefor.co.uk/elections/{{ query }}/">
-        'Who Can I Vote For' for information on your candidates and elections</a></p>
-    {% endif %}
+      'Who Can I Vote For' for information on your candidates and elections</a></p>
+  {% endif %}
 
-    {% if results %}
+  {% if object_list %}
     <h3>Existing candidates</h3>
 
-        <ul class="candidate-list search_results">
-        {% for result in results %}
+    <ul class="candidate-list search_results">
+      {% for result in object_list %}
 
-            <li class="candidates-list__person">
-                <img class="person-avatar" src="{{ result.get_display_image_url }}" height="64" width="64"/>
-                <div class="person-name-and-party">
-                  <a href="{% url 'person-view' result.id result.name|slugify %}" class="candidate-name">{{ result.name }}</a>
-                  <span class="party">{{ result.party_name }}</span>
-                </div>
-                <a href="{% url 'person-update' person_id=result.pk %}" class="button secondary small">Add more details</a>
-            </li>
-        {% empty %}
+        <li class="candidates-list__person">
+          <img class="person-avatar" src="{{ result.get_display_image_url }}" height="64" width="64"/>
+          <div class="person-name-and-party">
+            <a href="{% url 'person-view' result.id result.name|slugify %}" class="candidate-name">{{ result.name }}</a>
+            <span class="party">{{ result.party_name }}</span>
+          </div>
+          <a href="{% url 'person-update' person_id=result.pk %}" class="button secondary small">Add more details</a>
+        </li>
+      {% empty %}
         <p>No results found.</p>
-        {% endfor %}
-        </ul>
+      {% endfor %}
+    </ul>
 
-        {% if page.has_previous or page.has_next %}
-            <div>
-                {% if page.has_previous %}<a href="?q={{ query }}&amp;page={{ page.previous_page_number }}">{% endif %}&larr; Previous{% if page.has_previous %}</a>{% endif %}
-                |
-                {% if page.has_next %}<a href="?q={{ query }}&amp;page={{ page.next_page_number }}">{% endif %}Next &rarr;{% if page.has_next %}</a>{% endif %}
-            </div>
+
+
+    <div class="pagination">
+    <span class="step-links">
+        {% if page_obj.has_previous %}
+          <a href="?page=1&q={{ query }}">&laquo; first</a>
+          <a href="?page={{ page_obj.previous_page_number }}&q={{ query }}">previous</a>
         {% endif %}
-    {% endif %}
 
-    <h3>Add a new candidate</h3>
+      <span class="current">
+            Page {{ page_obj.number }} of {{ page_obj.paginator.num_pages }}.
+        </span>
 
-    {% url 'person-create-select-election' as select_election_view %}
-    <p>If we don't have this person in our database already, you can add them yourself.</p>
-    <p>Please check that they aren't in the results above first – you can update
-      existing candidates if they are standing in another election!</p>
-    <a href="{{ select_election_view }}?name={{ query }}" class="button">
-      Add "{{ query }}" as a new candidate</a>
+      {% if page_obj.has_next %}
+        <a href="?page={{ page_obj.next_page_number }}&q={{ query }}">next</a>
+        <a href="?page={{ page_obj.paginator.num_pages }}&q={{ query }}">last &raquo;</a>
+      {% endif %}
+    </span>
+    </div>
+  {% endif %}
+
+  <h3>Add a new candidate</h3>
+
+  {% url 'person-create-select-election' as select_election_view %}
+  <p>If we don't have this person in our database already, you can add them yourself.</p>
+  <p>Please check that they aren't in the results above first – you can update
+    existing candidates if they are standing in another election!</p>
+  <a href="{{ select_election_view }}?name={{ query }}" class="button">
+    Add "{{ query }}" as a new candidate</a>
 
 
 

--- a/ynr/apps/search/utils.py
+++ b/ynr/apps/search/utils.py
@@ -13,7 +13,7 @@ def search_person_by_name(name, synonym=True):
     and_name = " & ".join(name.split(" "))
     or_name = " | ".join(name.split(" "))
     name = f"({and_name}) | ({or_name})"
-    query = SearchQuery(name, search_type="raw", config="english")
+    query = SearchQuery(name, search_type="raw", config="simple")
 
     search_args = {}
     if synonym:

--- a/ynr/apps/search/utils.py
+++ b/ynr/apps/search/utils.py
@@ -76,7 +76,7 @@ def search_person_by_name(name: str, synonym: bool = False) -> PersonQuerySet:
                 weights=[0.1, 0.3, 0.4, 1],
             )
         )
-        .filter(rank__gt=0.2)
+        .select_related("image")
         .order_by("-rank", "membership_count")
         .defer("biography", "versions")
     )

--- a/ynr/apps/search/utils.py
+++ b/ynr/apps/search/utils.py
@@ -1,30 +1,82 @@
 import re
 
 from django.contrib.postgres.search import SearchQuery, SearchRank
-from django.db.models import Count, F
+from django.db import connection
+from django.db.models import Count, F, Max
 
+from people.managers import PersonQuerySet
 from people.models import Person
 
 
-def search_person_by_name(name, synonym=True):
+def search_person_by_name(name: str, synonym: bool = False) -> PersonQuerySet:
+    """
+    Take a string and turn it into a Django query that uses PostgresSQLs full
+    text search.
+
+    This function manages query parsing, and prevents the user passing in
+    search logic.
+
+    The complexity arises because we use a synonyms table for common name
+    synonyms. This is done using PostgresSQLs built in `ts_rewrite`, however
+    see the comment in line about a workaround for a performance bug.
+
+    """
     name = name.lower()
     name = re.sub(r"[^a-z ]", " ", name)
     name = " ".join(name.strip().split())
     and_name = " & ".join(name.split(" "))
     or_name = " | ".join(name.split(" "))
     name = f"({and_name}) | ({or_name})"
-    query = SearchQuery(name, search_type="raw", config="simple")
 
-    search_args = {}
     if synonym:
-        search_args["name_search_vector__synonym"] = query
-    else:
-        search_args["name_search_vector"] = query
+        # First perform a query that builts the final query
+        # We do this because of a bug in Postgres and `ts_rewrite`.
+        # In theory we can use `ts_rewrite` in line, however this causes the
+        # search query to take almost 10 seconds on the full database.
+        # Doing the rewrite to add synonnyms first and then passing that query
+        # in to the actual search speeds this up, with the final search taking
+        # less than 30ms
+        with connection.cursor() as cursor:
+            # This query takes the search terms and returns a query string
+            # with name synonyms attached.
+            # For example with:
+            # ```
+            # PersonNameSynonym.objects.create(term="sam", synonym="samantha")
+            # ```
+            # The search for "sam" would be transformed in to "(sam | samantha)"
+            # with `|` acting as an OR operator
+            cursor.execute(
+                """
+            SELECT ts_rewrite(
+                to_tsquery('simple'::regconfig, %s),
+                'SELECT term, synonym
+                FROM people_personnamesynonym
+                WHERE to_tsquery(''simple''::regconfig, '%s') @> term'
+            );
+            """,
+                (name, name),
+            )
+            row = cursor.fetchone()
 
+        query = SearchQuery(row[0], search_type="raw", config="simple")
+    else:
+        query = SearchQuery(name, search_type="raw", config="simple")
+
+    # Build the query
     qs = (
         Person.objects.annotate(membership_count=Count("memberships"))
-        .filter(**search_args)
-        .annotate(rank=SearchRank(F("name_search_vector"), query))
+        .filter(name_search_vector=query)
+        .annotate(vector=F("name_search_vector"))
+        .annotate(party_name=Max("memberships__party_name"))
+        .annotate(
+            rank=SearchRank(
+                F("vector"),
+                query,
+                cover_density=True,
+                weights=[0.1, 0.3, 0.4, 1],
+            )
+        )
+        .filter(rank__gt=0.2)
         .order_by("-rank", "membership_count")
         .defer("biography", "versions")
     )

--- a/ynr/apps/search/utils.py
+++ b/ynr/apps/search/utils.py
@@ -24,6 +24,8 @@ def search_person_by_name(name: str, synonym: bool = False) -> PersonQuerySet:
     name = name.lower()
     name = re.sub(r"[^a-z ]", " ", name)
     name = " ".join(name.strip().split())
+    if not name:
+        return Person.objects.none()
     and_name = " & ".join(name.split(" "))
     or_name = " | ".join(name.split(" "))
     name = f"({and_name}) | ({or_name})"

--- a/ynr/apps/search/views.py
+++ b/ynr/apps/search/views.py
@@ -1,15 +1,16 @@
 from django.http import HttpResponseRedirect
 from django.urls import reverse
-from django.views.generic import TemplateView
+from django.views.generic import ListView
 
 from search.utils import search_person_by_name
 from search.forms import PersonSearchForm
 from elections.uk.lib import is_valid_postcode
 
 
-class PersonSearch(TemplateView):
+class PersonSearch(ListView):
     template_name = "people/search/search.html"
     form_class = PersonSearchForm
+    paginate_by = 20
 
     def get(self, request, *args, **kwargs):
         ret = super().get(request, *args, **kwargs)
@@ -26,11 +27,14 @@ class PersonSearch(TemplateView):
 
         return ret
 
+    def get_queryset(self):
+        return search_person_by_name(
+            self.request.GET.get("q", ""), synonym=True
+        )
+
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         context["query"] = self.request.GET.get("q", "")
         context["looks_like_postcode"] = is_valid_postcode(context["query"])
-        if context["query"]:
-            context["results"] = search_person_by_name(context["query"])[:10]
 
         return context


### PR DESCRIPTION
Using 'english' automatically removes 'stop words' like "the" and "an".
This is normally useful when searching, but loads of English names also
contain stop words.

We've had bug reports where the name "will" isn't returned, and this is
because "will" is also a common English word.

Using 'simple' means no stop-words are removed at index time or search
time.

Refs #1227 #1860