### PR TITLE
Filter people/ballots last_updated with gte

### DIFF
--- a/ynr/apps/api/next/filters.py
+++ b/ynr/apps/api/next/filters.py
@@ -4,7 +4,7 @@ from django_filters import filterset, filters
 class LastUpdatedMixin(filterset.FilterSet):
     last_updated = filters.IsoDateTimeFilter(
         field_name="modified",
-        lookup_expr="gt",
+        lookup_expr="gte",
         label="Last updated",
         help_text="An ISO datetime",
         method="filter_last_updated",

--- a/ynr/apps/candidates/models/popolo_extra.py
+++ b/ynr/apps/candidates/models/popolo_extra.py
@@ -196,7 +196,7 @@ class BallotQueryset(models.QuerySet):
         """
         Filter on the last_updated timestamp
         """
-        return self.with_last_updated().filter(last_updated__gt=datetime)
+        return self.with_last_updated().filter(last_updated__gte=datetime)
 
     def ordered_by_latest_ee_modified(self):
         """

--- a/ynr/apps/candidates/tests/test_models.py
+++ b/ynr/apps/candidates/tests/test_models.py
@@ -336,7 +336,7 @@ class TestHasResultsOrNoResults(BallotsWithResultsMixin, TestCase):
         Ballot.objects.last_updated(datetime=datetime_obj)
         mock_with_last_updated.assert_called_once()
         mock_with_last_updated.return_value.filter.assert_called_once_with(
-            last_updated__gt=datetime_obj
+            last_updated__gte=datetime_obj
         )
 
     @patch("candidates.models.popolo_extra.BallotQueryset.annotate")


### PR DESCRIPTION
Avoids a potential situation where multiple objects have the same
last_updated timestamp, leading to updates being missed when
importing from YNR to WCIVF. This could be a problem particularly if
instances are updated in bulk. We have also seen some photo updates
being missed recently in WCIVF which may or may not be related.