### PR TITLE
Say results not supported for non FPTP ballots

### DIFF
--- a/ynr/apps/candidates/models/popolo_extra.py
+++ b/ynr/apps/candidates/models/popolo_extra.py
@@ -306,6 +306,17 @@ class Ballot(EEModifiedMixin, models.Model):
         """
         return self.voting_system in [self.VOTING_SYSTEM_FPTP]
 
+    @property
+    def nice_voting_system(self):
+        voting_systems = {
+            "STV": "Single Transferable Vote",
+            "FPTP": "First Past The Post",
+            "SV": "Supplementary Vote",
+            "AMS": "Additional Member System",
+        }
+        voting_system_slug = self.voting_system.upper()
+        return voting_systems.get(voting_system_slug, voting_system_slug)
+
     def safe_delete(self):
         collector = NestedObjects(using=connection.cursor().db.alias)
         collector.collect([self])

--- a/ynr/apps/candidates/tests/test_models.py
+++ b/ynr/apps/candidates/tests/test_models.py
@@ -260,6 +260,21 @@ class TestBallotMethods(TestCase, SingleBallotStatesMixin):
             with self.subTest(msg=str(ballot)):
                 self.assertTrue(ballot.is_welsh_run)
 
+    def test_nice_voting_system(self):
+        ballots = [
+            ("Single Transferable Vote", Ballot(voting_system="STV")),
+            ("Supplementary Vote", Ballot(voting_system="sv")),
+            ("First Past The Post", Ballot(voting_system="FPTP")),
+            ("Additional Member System", Ballot(voting_system="AMS")),
+        ]
+        for ballot in ballots:
+            with self.subTest(msg=ballot[0]):
+                self.assertEqual(ballot[1].nice_voting_system, ballot[0])
+
+        # test ballot with unknown voting system slug
+        ballot = Ballot(voting_system="PR")
+        self.assertEqual(ballot.nice_voting_system, "PR")
+
 
 class BallotsWithResultsMixin(SingleBallotStatesMixin):
     """

--- a/ynr/apps/elections/tests/test_ballot_view.py
+++ b/ynr/apps/elections/tests/test_ballot_view.py
@@ -300,7 +300,9 @@ class TestBallotView(
 
         response = self.app.get(self.past_ballot.get_absolute_url())
         response.mustcontain("Winner(s) unknown")
-        response.mustcontain("Help by marking the elected candidates!")
+        response.mustcontain(
+            "At present we do not support results for Single Transferable Vote ballots, but you can still help by marking the elected candidates!"
+        )
         response.mustcontain(no="Tell us who won")
 
     def test_constituency_with_winner_record_results_user(self):

--- a/ynr/apps/elections/uk/templates/uk/data_timeline.html
+++ b/ynr/apps/elections/uk/templates/uk/data_timeline.html
@@ -83,33 +83,33 @@
       </div>
       {% else %}
           {% if ballot.has_results %}
-          <div class="status_done">
-              <strong>Winner(s) recorded</strong>
-              {% if ballot.can_enter_votes_cast %}
-                <p>
-                  <a href="{% url "ballot_paper_results_form" ballot.ballot_paper_id %}">
-                    Edit the results
-                  </a>
-                </p>
-              {% endif %}
-          </div>
+            <div class="status_done">
+                <strong>Winner(s) recorded</strong>
+                {% if ballot.can_enter_votes_cast %}
+                  <p>
+                    <a href="{% url "ballot_paper_results_form" ballot.ballot_paper_id %}">
+                      Edit the results
+                    </a>
+                  </p>
+                {% endif %}
+            </div>
           {% elif ballot.uncontested %}
-          <div class="status_done">
-              <strong>Winner(s) recorded</strong>
-              <i>Uncontested Ballot</i>
-          </div> 
+            <div class="status_done">
+                <strong>Winner(s) recorded</strong>
+                <i>Uncontested Ballot</i>
+            </div>
           {% elif ballot.can_enter_votes_cast %}
-          <div class="status_in_progress">
-              <strong>Winner(s) unknown</strong>:
-              <a href="{% url "ballot_paper_results_form" ballot.ballot_paper_id %}">
-                Tell us who won!
-              </a>
-          </div>
+            <div class="status_in_progress">
+                <strong>Winner(s) unknown</strong>:
+                <a href="{% url "ballot_paper_results_form" ballot.ballot_paper_id %}">
+                  Tell us who won!
+                </a>
+            </div>
           {% else %}
-          <div class="status_in_progress">
-              <strong>Winner(s) unknown</strong>:
-              <p>Help by marking the elected candidates!</p>
-          </div>
+            <div class="status_in_progress">
+                <strong>Winner(s) unknown</strong>:
+                <p>At present we do not support results for {{ ballot.nice_voting_system }} ballots, but you can still help by marking the elected candidates!</p>
+            </div>
           {% endif %}
       {% endif %}
     {% endif %}


### PR DESCRIPTION
Currently only FPTP is supported for results. This displays a message
to the user to explain that results are not supported for the voting
system, and asks them to mark candidates elected instead.
![Screenshot 2022-04-28 at 14 29 38](https://user-images.githubusercontent.com/15347726/165763409-9dc7f473-386d-44de-980b-32b1e7e75dde.png)
