### PR TITLE
Bugfix/results 2022

### DIFF
--- a/ynr/apps/resultsbot/management/commands/resultsbot_import_from_mg_csv.py
+++ b/ynr/apps/resultsbot/management/commands/resultsbot_import_from_mg_csv.py
@@ -54,15 +54,27 @@ class Command(BaseCommand):
                     continue
 
                 candidates = list(importer.candidates(div))
-                all_candidates += candidates
-                has_any_votes = any([c.votes for c in candidates])
-
-                if has_any_votes:
-                    print("Adding results for {}".format(div.title))
-                    bot = ResultsBot()
-                    bot.add_results(
-                        division=div,
-                        candidate_list=candidates,
-                        source=importer.api_url_to_web_url(url),
+                candidates_len = len(candidates)
+                if candidates_len != div.local_area.membership_set.count():
+                    print(
+                        f"Only found {candidates_len} candidates for {div.local_area.ballot_paper_id}, skipping"
                     )
+                    continue
+
+                # avoids storing a partial result
+                has_all_votes = all([c.votes for c in candidates])
+                if not has_all_votes:
+                    print(
+                        f"Couldn't find a vote count for every candidate, skipping {div.local_area.ballot_paper_id}"
+                    )
+                    continue
+
+                all_candidates += candidates
+                print("Adding results for {}".format(div.title))
+                bot = ResultsBot()
+                bot.add_results(
+                    division=div,
+                    candidate_list=candidates,
+                    source=importer.api_url_to_web_url(url),
+                )
         print(len(all_candidates))

--- a/ynr/apps/uk_results/templates/uk_results/home.html
+++ b/ynr/apps/uk_results/templates/uk_results/home.html
@@ -3,7 +3,7 @@
 {% block results_content %}
 <h2>Entering results</h2>
 <ol>
-  <li>Find <a href="{% url "current-elections-with-no-resuts" %}">an area without results yet</a></li>
+  <li>Find <a href="{{ elections_without_results_url }}">an area without results yet</a></li>
   <li>Click "add results"</li>
   <li>Find the results on the council website</li>
 </ol>

--- a/ynr/apps/uk_results/tests/test_smoke_test_views.py
+++ b/ynr/apps/uk_results/tests/test_smoke_test_views.py
@@ -12,6 +12,7 @@ from candidates.tests.factories import (
 )
 from candidates.tests.uk_examples import UK2015ExamplesMixin
 from people.tests.factories import PersonFactory
+from popolo.models import Membership
 from uk_results.models import CandidateResult, ResultSet
 
 
@@ -21,14 +22,6 @@ class TestUKResults(TestUserMixin, UK2015ExamplesMixin, WebTest, TestCase):
         self.ballot = self.local_post.ballot_set.get()
         self.ballot.voting_system = Ballot.VOTING_SYSTEM_FPTP
         self.ballot.save()
-        self.result_set = ResultSet.objects.create(
-            ballot=self.ballot,
-            num_turnout_reported=10000,
-            num_spoilt_ballots=30,
-            user=self.user,
-            ip_address="127.0.0.1",
-            source="Example ResultSet for testing",
-        )
         # Create three people:
         self.people = [
             PersonFactory.create(id=13, name="Alice"),
@@ -38,25 +31,16 @@ class TestUKResults(TestUserMixin, UK2015ExamplesMixin, WebTest, TestCase):
 
         parties = [self.labour_party, self.conservative_party, self.ld_party]
         # Create their candidacies:
-        candidacies = [
+
+        for person, party in zip(self.people, parties):
             MembershipFactory.create(
                 ballot=self.ballot,
                 person=person,
                 post=self.local_post,
                 party=party,
             )
-            for person, party in zip(self.people, parties)
-        ]
-        # Create their CandidateResult objects:
-        votes = [2000, 5000, 3000]
-        self.candidate_results = [
-            CandidateResult.objects.create(
-                result_set=self.result_set, membership=c, num_ballots=v
-            )
-            for c, v in zip(candidacies, votes)
-        ]
 
-    def test_form_view(self):
+    def test_form_view_creates_result(self):
         url = reverse(
             "ballot_paper_results_form",
             kwargs={
@@ -66,8 +50,55 @@ class TestUKResults(TestUserMixin, UK2015ExamplesMixin, WebTest, TestCase):
         resp = self.app.get(url, user=self.user_who_can_record_results)
         self.assertEqual(resp.status_code, 200)
         form = resp.forms[1]
-        form["memberships_13"] = 345
+        form["memberships_13"] = 1000
+        form["memberships_14"] = 2000
+        form["memberships_15"] = 3000
+        form["source"] = "Example ResultSet for testing"
         form.submit()
+        self.assertEqual(CandidateResult.objects.count(), 3)
+        self.assertEqual(ResultSet.objects.count(), 1)
+        winner = Membership.objects.get(person_id=15)
+        self.assertTrue(winner.elected)
+
+    def test_partial_result_not_saved(self):
+        url = reverse(
+            "ballot_paper_results_form",
+            kwargs={
+                "ballot_paper_id": "local.maidstone.DIW:E05005004.2016-05-05"
+            },
+        )
+        resp = self.app.get(url, user=self.user_who_can_record_results)
+        self.assertEqual(resp.status_code, 200)
+        form = resp.forms[1]
+        form["memberships_13"] = 1000
+        form["memberships_14"] = 2000
+        form["memberships_15"] = ""
+        form["source"] = "Partial ResultSet for testing"
+        form.submit()
+        self.assertEqual(CandidateResult.objects.count(), 0)
+        self.assertEqual(ResultSet.objects.count(), 0)
+        winner = Membership.objects.get(person_id=15)
+        self.assertFalse(winner.elected)
+
+    def test_result_without_source_not_saved(self):
+        url = reverse(
+            "ballot_paper_results_form",
+            kwargs={
+                "ballot_paper_id": "local.maidstone.DIW:E05005004.2016-05-05"
+            },
+        )
+        resp = self.app.get(url, user=self.user_who_can_record_results)
+        self.assertEqual(resp.status_code, 200)
+        form = resp.forms[1]
+        form["memberships_13"] = 1000
+        form["memberships_14"] = 2000
+        form["memberships_15"] = 3000
+        form["source"] = ""
+        form.submit()
+        self.assertEqual(CandidateResult.objects.count(), 0)
+        self.assertEqual(ResultSet.objects.count(), 0)
+        winner = Membership.objects.get(person_id=15)
+        self.assertFalse(winner.elected)
 
     def test_form_view_cancelled_election(self):
         url = reverse(

--- a/ynr/apps/uk_results/tests/test_smoke_test_views.py
+++ b/ynr/apps/uk_results/tests/test_smoke_test_views.py
@@ -124,3 +124,10 @@ class TestUKResults(TestUserMixin, UK2015ExamplesMixin, WebTest, TestCase):
             url, user=self.user_who_can_record_results, expect_errors=True
         )
         self.assertEqual(resp.status_code, 200)
+
+    def test_results_home_view(self):
+        response = self.app.get(reverse("results-home"))
+        self.assertContains(
+            response,
+            'Find <a href="/elections/?has_results=0&amp;is_cancelled=0">an area without results yet</a>',
+        )

--- a/ynr/apps/uk_results/tests/test_smoke_test_views.py
+++ b/ynr/apps/uk_results/tests/test_smoke_test_views.py
@@ -1,10 +1,15 @@
 from django.test import TestCase
 from django.urls import reverse
 from django_webtest import WebTest
+from freezegun import freeze_time
 from candidates.models.popolo_extra import Ballot
 
 from candidates.tests.auth import TestUserMixin
-from candidates.tests.factories import MembershipFactory
+from candidates.tests.factories import (
+    BallotPaperFactory,
+    ElectionFactory,
+    MembershipFactory,
+)
 from candidates.tests.uk_examples import UK2015ExamplesMixin
 from people.tests.factories import PersonFactory
 from uk_results.models import CandidateResult, ResultSet
@@ -77,3 +82,45 @@ class TestUKResults(TestUserMixin, UK2015ExamplesMixin, WebTest, TestCase):
             url, user=self.user_who_can_record_results, expect_errors=True
         )
         self.assertEqual(resp.status_code, 404)
+
+    @freeze_time("2022-05-05 10:00:00")
+    def test_form_view_polls_open(self):
+        election = ElectionFactory(
+            election_date="2022-05-05",
+            slug="local.sheffield.2022-05-05",
+            current=False,
+        )
+        ballot = BallotPaperFactory(
+            election=election,
+            ballot_paper_id="local.sheffield.2022-05-05",
+            voting_system="FPTP",
+        )
+        url = reverse(
+            "ballot_paper_results_form",
+            kwargs={"ballot_paper_id": ballot.ballot_paper_id},
+        )
+        resp = self.app.get(
+            url, user=self.user_who_can_record_results, expect_errors=True
+        )
+        self.assertEqual(resp.status_code, 404)
+
+    @freeze_time("2022-05-05 22:00:00")
+    def test_form_view_polls_closed(self):
+        election = ElectionFactory(
+            election_date="2022-05-05",
+            slug="local.sheffield.2022-05-05",
+            current=False,
+        )
+        ballot = BallotPaperFactory(
+            election=election,
+            ballot_paper_id="local.sheffield.2022-05-05",
+            voting_system="FPTP",
+        )
+        url = reverse(
+            "ballot_paper_results_form",
+            kwargs={"ballot_paper_id": ballot.ballot_paper_id},
+        )
+        resp = self.app.get(
+            url, user=self.user_who_can_record_results, expect_errors=True
+        )
+        self.assertEqual(resp.status_code, 200)

--- a/ynr/apps/uk_results/views/base_views.py
+++ b/ynr/apps/uk_results/views/base_views.py
@@ -4,6 +4,7 @@ from datetime import date
 from braces.views import LoginRequiredMixin
 from django.http import Http404, HttpResponse
 from django.shortcuts import get_object_or_404
+from django.urls import reverse
 from django.views.generic import FormView, TemplateView
 
 from candidates.models import Ballot
@@ -18,6 +19,10 @@ class ResultsHomeView(TemplateView):
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
 
+        elections_list = reverse("election_list_view")
+        context[
+            "elections_without_results_url"
+        ] = f"{elections_list}?has_results=0&is_cancelled=0"
         return context
 
     def test_func(self, user):

--- a/ynr/apps/uk_results/views/base_views.py
+++ b/ynr/apps/uk_results/views/base_views.py
@@ -2,7 +2,7 @@ import csv
 from datetime import date
 
 from braces.views import LoginRequiredMixin
-from django.http import HttpResponse
+from django.http import Http404, HttpResponse
 from django.shortcuts import get_object_or_404
 from django.views.generic import FormView, TemplateView
 
@@ -37,6 +37,12 @@ class BallotPaperResultsUpdateView(LoginRequiredMixin, FormView):
             voting_system=Ballot.VOTING_SYSTEM_FPTP,
             ballot_paper_id=self.kwargs["ballot_paper_id"],
         )
+
+        if not self.ballot.polls_closed:
+            raise Http404(
+                f"Polls are still open for {self.ballot.ballot_paper_id}. Please check back after polls close at 10pm."
+            )
+
         try:
             kwargs["instance"] = self.ballot.resultset
         except:


### PR DESCRIPTION
- Stops the results form being accessed via URL if polls are not closed
- Adds some extra tests to confirm results form submits as expected
- Update the link to ballots without results from the results homepage (re #1494). However, I am not sure including this, as I have noticed that currently if I try to hit https://candidates.democracyclub.org.uk/elections/?has_results=0&is_cancelled=0 I am getting a timeout error. This led me to spend time trying to optimise the queries with various combinations of adjustments to `annotate`, `prefetch_related`, `SubQuery` etc. But I cannot improve the SQL speed, and the number of queries on the page currently is actually only 6. So I think that rather than the queries being the issue, it is simply the volume of ballots (and memberships) that is the issue. For example, if you limit the ballots to a particular region, and then choose to filter by no results, it will load fine. So I am unsure how to solve this without limiting the number of ballots on the page or moving to paginations.

