### PR TITLE
Enable 2023 leaderboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,4 +53,14 @@ Install pypandoc (or via `requirements.txt`):
 
 If `pypandoc` does not install via `pip`, visit https://pypi.org/project/pypandoc/ for further instructions. 
 
- 
+# Pre-election Tasks
+
+# Enable Candidate Leaderboard
+
+The candidate leaderboard is a way of showing the most active candidates on the site. It is a way of volunteers to add more information about candidates and elections.
+
+We take a slice of edits in YNR and assign them to a election leaderboard. 
+
+This is defined here: https://github.com/DemocracyClub/yournextrepresentative/blob/master/ynr/apps/candidates/views/mixins.py#L20
+
+We can modify the old value to reflect the current election. Change, PR, merge, [currently Sym needs to deploy]

--- a/ynr/apps/candidates/views/mixins.py
+++ b/ynr/apps/candidates/views/mixins.py
@@ -17,9 +17,9 @@ class ContributorsMixin(object):
                 timezone.now(),
             ),
             (
-                "May 2022 Elections",
-                timezone.make_aware(parse("2022-03-01")),
-                timezone.make_aware(parse("2022-05-09")),
+                "May 2023 Elections",
+                timezone.make_aware(parse("2023-03-01")),
+                timezone.make_aware(parse("2023-05-31")),
             ),
         ]
         if all_time:


### PR DESCRIPTION
Closes https://trello.com/c/n3Nj7IXk/3305-candidates-leaderboard

To test:

1. Run `localhost`, and make some person edits. 
2. Next, navigate to the bottom of the home page and click on [Democracy Heroes](http://localhost:8000/leaderboard). 
3. You should not see 2022 edits and rather see your recent edits in the format similar to the screenshot below. 

```[tasklist]
### PR Checklist
<!-- Not all the items in this list will be relevant for every repo -->
<!-- When creating a Pull Request please delete items as necessary, leaving those that are relevant.  -->

Check off items once the PR addresses them.

- [x] Note what card in Trello this work relates to
- [x] Instructions for how reviewers can test the code locally
- [x] Screenshot of the feature/bug fix (if applicable)
- [x] Have I rebased with the latest version of master?
- [x] Update any documentation
```

![Screenshot 2023-03-14 at 9 17 35 AM](https://user-images.githubusercontent.com/7017118/224953910-58d59212-7230-460f-9b8f-68c1f0c29c18.png)

