### PR TITLE
Remove not_standing status if adding to ballot

### DIFF
--- a/ynr/apps/candidates/tests/test_constraints.py
+++ b/ynr/apps/candidates/tests/test_constraints.py
@@ -2,30 +2,13 @@ from django.test import TestCase
 
 from candidates.models.constraints import check_no_candidancy_for_election
 from people.tests.factories import PersonFactory
-from popolo.models import Membership, Post
+from popolo.models import Post
 
 from .factories import MembershipFactory
 from .uk_examples import UK2015ExamplesMixin
 
 
 class PreventCreatingBadMemberships(UK2015ExamplesMixin, TestCase):
-    def test_prevent_creating_conflicts_with_not_standing(self):
-        new_candidate = PersonFactory.create(name="John Doe")
-        new_candidate.not_standing.add(self.election)
-
-        with self.assertRaisesRegex(
-            Exception,
-            r'Trying to add a Membership with an election "2015 '
-            r'General Election", but that\'s in John Doe '
-            r"\({}\)\'s not_standing list".format(new_candidate.id),
-        ):
-            Membership.objects.create(
-                person=new_candidate,
-                party=self.green_party,
-                post=self.camberwell_post,
-                ballot=self.camberwell_post_ballot,
-            )
-
     def test_raise_if_candidacy_exists(self):
         new_candidate = PersonFactory.create(name="John Doe")
         post = Post.objects.get(slug="14419")

--- a/ynr/apps/people/tests/test_merge_view.py
+++ b/ynr/apps/people/tests/test_merge_view.py
@@ -566,15 +566,7 @@ class TestMergePeopleView(TestUserMixin, UK2015ExamplesMixin, WebTest):
         # then directly merge
         merge_form = response.forms[MERGE_FORM_ID]
         response = merge_form.submit()
-
         self.assertEqual(response.status_code, 302)
-        self.assertEqual(
-            response.location, "/person/1/merge_conflict/2009/not_standing/"
-        )
-        response = response.follow()
-        form = response.forms[1]
-        response = form.submit()
-        response.follow()
         self.assertEqual(response.location, "/person/1/tessa-jowell")
 
     def test_merge_same_person_shows_error(self):

--- a/ynr/apps/popolo/models.py
+++ b/ynr/apps/popolo/models.py
@@ -363,18 +363,8 @@ class Membership(Dateframeable, TimeStampedModel, models.Model):
     def save(self, *args, **kwargs):
         if self.ballot and getattr(self, "check_for_broken", True):
             if self.ballot.election in self.person.not_standing.all():
-                msg = (
-                    "Trying to add a Membership with an election "
-                    '"{election}", but that\'s in {person} '
-                    "({person_id})'s not_standing list."
-                )
-                raise NotStandingValidationError(
-                    msg.format(
-                        election=self.ballot.election,
-                        person=self.person.name,
-                        person_id=self.person.id,
-                    )
-                )
+                # remove not_standing status
+                self.person.not_standing.remove(self.ballot.election)
         if not self.party_name:
             self.party_name = self.party.name
 


### PR DESCRIPTION
Issue: 

> I get a 500 when I try to return this candidate to the ballot (accidentally removed, I think) https://candidates.democracyclub.org.uk/person/96114/ 
- @pmk01 

Confirmed error: 
`Trying to add a Membership with an election "Swale local election", but that's in Lloyd Chapman (96114)'s not_standing list.`

This work removes the error message and replaces it with the functionality to remove the ballot from the person's `not_standing` list. 

To test: 
With an unlocked ballot that has a list of candidates, mark a candidate as not standing, then try to add the candidate back onto the ballot. 

```[tasklist]
### PR Checklist
<!-- Not all the items in this list will be relevant for every repo -->
<!-- When creating a Pull Request please delete items as necessary, leaving those that are relevant.  -->

Check off items once the PR addresses them.

- [ x] References a specific issue or if not, describes the bug or feature in detail
- [x] Instructions for how reviewers can test the code locally
- [x]Tests have been added and/or updated
```
