### PR TITLE
Prevent adding candidates on ballot if we have a SOPN

### DIFF
--- a/ynr/apps/candidates/tests/test_candidacy_add_and_remove.py
+++ b/ynr/apps/candidates/tests/test_candidacy_add_and_remove.py
@@ -5,6 +5,7 @@ from people.tests.factories import PersonFactory
 from .auth import TestUserMixin
 from .factories import MembershipFactory
 from .uk_examples import UK2015ExamplesMixin
+from ..models import Ballot
 
 
 class TestCandidacyCreateView(TestUserMixin, UK2015ExamplesMixin, WebTest):
@@ -52,3 +53,22 @@ class TestCandidacyDeleteView(TestUserMixin, UK2015ExamplesMixin, WebTest):
         form["source"] = "Tests"
         form.submit()
         self.assertEqual(self.person.memberships.count(), 0)
+
+
+class TestEditButtonsShown(TestUserMixin, UK2015ExamplesMixin, WebTest):
+    def test_can_see_add_button_with_no_sopn(self):
+        ballot: Ballot = self.dulwich_post_ballot
+        response = self.app.get(
+            ballot.get_absolute_url(),
+            user=self.user,
+        )
+        self.assertContains(response, "Add a new candidate")
+        ballot.officialdocument_set.create(
+            document_type=ballot.officialdocument_set.model.NOMINATION_PAPER
+        )
+        ballot.refresh_from_db()
+        response = self.app.get(
+            ballot.get_absolute_url(),
+            user=self.user,
+        )
+        self.assertNotContains(response, "Add a new candidate")


### PR DESCRIPTION
This is to prevent the case where well meaning users add all the candidates to a ballot via the "add candidate form" rather than the bulk adding process. This isn't helpful as we need users to de-duplicate and suggest locking.

Users who can lock ballots are able to edit candidates still. This is because sometimes it's useful to be able to manually correct bulk adding errors this way.

To test: add a SOPN to a ballot and look at the ballot page with a user that has normal permissions.

```[tasklist]
### PR Checklist
<!-- Not all the items in this list will be relevant for every repo -->
<!-- When creating a Pull Request please delete items as necessary, leaving those that are relevant.  -->

Check off items once the PR addresses them.

- [x] References a specific issue or if not, describes the bug or feature in detail
- [x] Instructions for how reviewers can test the code locally
- [x] Tests have been added and/or updated
- [x] Did I use the clear and concise names for variables and functions?
- [x] Have I rebased with the latest version of master?
- [x] Added PR labels
```
