### PR TITLE
Add SOPN debug template

### DIFF
--- a/ynr/apps/elections/templates/elections/includes/_sopn_debug.html
+++ b/ynr/apps/elections/templates/elections/includes/_sopn_debug.html
@@ -1,0 +1,33 @@
+<div class="container">
+  <details class="panel">
+  <summary><strong>Debug Info (click to expand)</strong></summary>
+    <br/>
+    <h3>Parsing Status</h3>
+    <ul>
+      <li>Pages matched: {% if object.sopn.get_pages %}Yes (matched pages: {{ object.sopn.get_pages|join:", " }}){% else %}No{% endif %}</li>
+      <li>Tables extracted: {% if object.sopn.parsedsopn %}Yes{% else %}No{% endif %}</li>
+      <li>Raw Person Data: {% if object.sopn.ballot.raw_people %}Yes{% else %}No{% endif %}</li>
+    </ul>
+    <br/>
+    <h3>Table Data</h3>
+    {% if object.sopn.parsedsopn.data_as_html %}
+      {{ object.sopn.parsedsopn.data_as_html|safe }}
+    {% else %}
+      N/A
+    {% endif %}
+    <br/>
+    <h3>Raw Data</h3>
+    {% if object.sopn.parsedsopn.raw_data %}
+      <pre>{{ object.sopn.parsedsopn.as_pandas.to_dict|pprint }}</pre>
+    {% else %}
+      N/A
+    {% endif %}
+    <br/>
+    <h3>Parsed SOPN form</h3>
+    {% if object.rawpeople %}
+      <pre>{{ object.rawpeople.data|pprint }}</pre>
+    {% else %}
+      N/A
+    {% endif %}
+  </details>
+</div>

--- a/ynr/apps/elections/templates/elections/sopn_for_ballot.html
+++ b/ynr/apps/elections/templates/elections/sopn_for_ballot.html
@@ -40,9 +40,11 @@
       </p>
     {% endif %}
 
+    {% if request.user.is_authenticated %}
+        {% include "elections/includes/_sopn_debug.html" %}
+    {% endif %}
 
     <div id="sopn-{{ object.ballot_paper_id }}" class="pdf_container"></div>
-
 
   {% else %}
     No SOPN uploaded for this ballot paper yet.


### PR DESCRIPTION
Added a debug section to help pinpoint the cause of some SOPNs not being parsed correctly. This is to save a bit of time on debugging. 
Spec [here](https://docs.google.com/document/d/14oMTLPedLFCCu83HfBcY9-CgeWvRv97nSyhU97z09vA/edit#).


<img width="996" alt="Screenshot 2023-04-06 at 14 23 16" src="https://user-images.githubusercontent.com/9531063/230391609-4b656b0c-3a66-460c-89fc-1dbd9b5e14be.png">
<img width="977" alt="Screenshot 2023-04-06 at 13 37 50" src="https://user-images.githubusercontent.com/9531063/230380979-f080f345-4a30-4b57-b2a5-53a71ce1ef22.png">
<img width="668" alt="Screenshot 2023-04-06 at 14 26 03" src="https://user-images.githubusercontent.com/9531063/230392187-55da2649-0bf6-47cf-9f33-48b19a731ffa.png">
<img width="708" alt="Screenshot 2023-04-06 at 14 26 40" src="https://user-images.githubusercontent.com/9531063/230392261-330aef7e-3ab7-4b7c-acbd-7082f4cf78f4.png">


To test locally:
- Upload a SOPN
- Go to the SOPN page for that ballot on your localhost (e.g. /elections/local.amber-valley.alfreton.2023-05-04/sopn/)
- Check out the debug in all its glory
- If no SOPN exists for the ballot, the debug < details > should not be shown on page.
You might want to try this with SOPNs in various states of repair. I used this [SOPN](https://info.ambervalley.gov.uk/docarc/docviewer.aspx?docguid=b9b80a2ddf7243549f75858f0d16827e) from last year which doesn't import properly.


```[tasklist]
### PR Checklist

- [x] References a specific issue or if not, describes the bug or feature in detail
- [x] Instructions for how reviewers can test the code locally
- [x] Screenshot of the feature/bug fix (if applicable)
```
