### PR TITLE
Save initial name to other names list

### DIFF
--- a/ynr/apps/moderation_queue/templates/moderation_queue/person_name_review.html
+++ b/ynr/apps/moderation_queue/templates/moderation_queue/person_name_review.html
@@ -4,7 +4,8 @@
 {% block content %}
 <h2>Review person name suggestions</h2>
 <p>This step is to prevent the few cases of vandalism on Person names.</p>
-<p>You can either set the person's primary name, keep the other name but don't set it as primary, or delete the other name.</p>
+<p>You can either use the suggestion as the person's primary name (this will retain the original name as an alternative),
+    keep the suggested name as an alternative (this doesn't set it as the primary name), or delete the suggested name.</p>
 <p>Only delete the other name if it's clearly not the person's name (e.g it's vandalism).</p>
 
 <table class="table">

--- a/ynr/apps/moderation_queue/views.py
+++ b/ynr/apps/moderation_queue/views.py
@@ -474,10 +474,25 @@ class PersonNameEditReviewListView(GroupRequiredMixin, ListView):
         return HttpResponseRedirect(reverse("person-name-review"))
 
     def approve_name_change(self, other_name):
+        # initial_name = other_name.content_object.name
+        # suggested_name = other_name.name
+
+        # this doesn't save edits to the person object since it was designed for the context of form instance edits
+        # other_name.content_object.edit_name(initial_name=initial_name, suggested_name=suggested_name, user=self.request.user)
+
+        # save the initial name to a list of other names on the person object
+        other_name.content_object.other_names.get_or_create(
+            name=other_name.content_object.name
+        )
+        # set the person object name to the suggested name
         other_name.content_object.name = other_name.name
         other_name.content_object.save()
         other_name.needs_review = False
         other_name.save()
+        # if the current name is already in the list of other names, remove it
+        other_name.content_object.other_names.filter(
+            name=other_name.name
+        ).delete()
 
     def delete_name_change(self, other_name):
         other_name.delete()

--- a/ynr/apps/moderation_queue/views.py
+++ b/ynr/apps/moderation_queue/views.py
@@ -474,25 +474,9 @@ class PersonNameEditReviewListView(GroupRequiredMixin, ListView):
         return HttpResponseRedirect(reverse("person-name-review"))
 
     def approve_name_change(self, other_name):
-        # initial_name = other_name.content_object.name
-        # suggested_name = other_name.name
-
-        # this doesn't save edits to the person object since it was designed for the context of form instance edits
-        # other_name.content_object.edit_name(initial_name=initial_name, suggested_name=suggested_name, user=self.request.user)
-
-        # save the initial name to a list of other names on the person object
-        other_name.content_object.other_names.get_or_create(
-            name=other_name.content_object.name
-        )
-        # set the person object name to the suggested name
-        other_name.content_object.name = other_name.name
-        other_name.content_object.save()
-        other_name.needs_review = False
-        other_name.save()
-        # if the current name is already in the list of other names, remove it
-        other_name.content_object.other_names.filter(
-            name=other_name.name
-        ).delete()
+        person = other_name.content_object
+        person.edit_name(other_name.name, person.name, user=self.request.user)
+        person.save()
 
     def delete_name_change(self, other_name):
         other_name.delete()

--- a/ynr/apps/people/forms/forms.py
+++ b/ynr/apps/people/forms/forms.py
@@ -359,6 +359,7 @@ class BasePersonForm(forms.ModelForm):
                 initial_name=initial_name,
                 user=user,
             )
+
         return super().save(commit)
 
 

--- a/ynr/apps/people/tests/test_person_update.py
+++ b/ynr/apps/people/tests/test_person_update.py
@@ -232,7 +232,7 @@ class TestPersonUpdate(PersonViewSharedTestsMixin):
         self.person.refresh_from_db()
         # check that the name has not been changed
         self.assertEqual(self.person.name, "Tessa Palmer")
-        # check an other names has been created
+        # check an other_names has been created
         self.assertEqual(len(self.person.other_names.all()), 1)
         self.assertEqual(self.person.other_names.first().needs_review, False)
 


### PR DESCRIPTION
When we make a name edit, save the suggested name to the other names list. When the suggestion is approved, update the person primary name, add the initial name to the other names list  and remove the suggested
name from the other names list.
