### PR TITLE
Add spellcheck false to name form field

### DIFF
--- a/ynr/apps/bulk_adding/forms.py
+++ b/ynr/apps/bulk_adding/forms.py
@@ -206,7 +206,9 @@ class NameOnlyPersonForm(forms.Form):
     name = forms.CharField(
         label="Name (style: Ali Smith, not SMITH Ali)",
         required=True,
-        widget=forms.TextInput(attrs={"class": "person_name"}),
+        widget=forms.TextInput(
+            attrs={"class": "person_name", "spellcheck": "false"}
+        ),
     )
     ballot = ValidBallotField(
         widget=BallotInputWidget(attrs={"type": "hidden"})


### PR DESCRIPTION
> Having spellcheck="false" as an attribute to the names fields would make life a lot easier on modern apple machines.  not sure where it should be defined, but names autocorrecting is unhelpful (edited) 