### PR TITLE
Exclude other content types from name search trigger

### DIFF
--- a/ynr/apps/people/managers.py
+++ b/ynr/apps/people/managers.py
@@ -59,6 +59,11 @@ POPULATE_NAME_SEARCH_COLUMN_SQL = """
         FROM people_person pp
         LEFT JOIN popolo_othername ppon
         ON pp.id = ppon.object_id
+        WHERE ppon.content_type_id = (
+            select id
+            from django_content_type
+            where app_label='people'
+              and model='person')
         GROUP BY pp.id, pp.name
     ) as sq
     where sq.id = people_person.id
@@ -75,6 +80,11 @@ NAME_SEARCH_TRIGGER_SQL = """
                                        select po.name
                                        from popolo_othername po
                                        where po.object_id = new.id
+                                       and po.content_type_id = (
+                                        select id
+                                        from django_content_type
+                                        where app_label='people'
+                                          and model='person')
                                    ), ','
                            ) as other_names
             )

--- a/ynr/apps/people/managers.py
+++ b/ynr/apps/people/managers.py
@@ -46,16 +46,16 @@ POPULATE_NAME_SEARCH_COLUMN_SQL = """
         SELECT pp.id as id,
             ---- First and last names are weight A
             --- First Name
-            setweight(to_tsvector('simple', split_part(pp.name, ' ', 1)), 'A')
+            setweight(to_tsvector('simple', split_part(pp.name, ' ', 1)), 'B')
             ||
             --- Last Name
             setweight(to_tsvector('simple', regexp_replace(pp.name, '^.* ', '')), 'A')
             ||
             --- Full name is weight B, further boosting first and last names, adding middle names
-            setweight(to_tsvector('simple', coalesce(pp.name, '')), 'B')
+            setweight(to_tsvector('simple', coalesce(pp.name, '')), 'C')
             ||
             --- Other names are weight C
-            setweight(to_tsvector('simple', coalesce(string_agg(ppon.name, ' '), '')), 'C') as terms
+            setweight(to_tsvector('simple', coalesce(string_agg(ppon.name, ' '), '')), 'D') as terms
         FROM people_person pp
         LEFT JOIN popolo_othername ppon
         ON pp.id = ppon.object_id
@@ -89,16 +89,16 @@ NAME_SEARCH_TRIGGER_SQL = """
                            ) as other_names
             )
             SELECT
-            setweight(to_tsvector('simple', split_part(new.name, ' ', 1)), 'A')
+            setweight(to_tsvector('simple', split_part(new.name, ' ', 1)), 'B')
             ||
             --- Last Name
             setweight(to_tsvector('simple', regexp_replace(new.name, '^.* ', '')), 'A')
             ||
             --- Full name is weight B, further boosting first and last names, adding middle names
-            setweight(to_tsvector('simple', coalesce(new.name, '')), 'B')
+            setweight(to_tsvector('simple', coalesce(new.name, '')), 'C')
             ||
             --- Other names are weight C
-            setweight(to_tsvector('simple', coalesce(string_agg(po_names.other_names, ' '), '')), 'C') as terms
+            setweight(to_tsvector('simple', coalesce(string_agg(po_names.other_names, ' '), '')), 'D') as terms
             FROM po_names
         );
       return new;


### PR DESCRIPTION
The OtherName model is a Django generic relatable, meaning we have a single table with content that relates to >1 model.

Previous to this change, we were getting other names by joining on the object_id of the OtherName model, however it was possible for content form other models to be included in this.

For example, we used to use OtherName for parties (no longer, but the data is still in the table on Prod), so we could have:

Person 1 -> OtherName = "John Smith"
Party 1 -> OtherName = "Cornish Independents"

The resulting name vector field would contain "john cornish smith independents". Therefore a search for "John Cornish" would return "John Smith", even though that person has nothing to do with "Cornish" (apart form enjoying a pasty from time to time).

This change filters on the content type of people.person, meaning we'll only ever get actual other names for the person, not random objects.

```[tasklist]
### PR Checklist
<!-- Not all the items in this list will be relevant for every repo -->
<!-- When creating a Pull Request please delete items as necessary, leaving those that are relevant.  -->

Check off items once the PR addresses them.

- [x] References a specific issue or if not, describes the bug or feature in detail
- [x] Have I rebased with the latest version of master?
- [x] Added PR labels
```
