### PR TITLE
Set default emblem for Conservatives

### DIFF
--- a/ynr/apps/parties/constants.py
+++ b/ynr/apps/parties/constants.py
@@ -54,6 +54,8 @@ DEFAULT_EMBLEMS = {
     "PP12759": 7833,
     # Christian Peoples Alliance
     "PP79": 7395,
+    # Conservative and Unionist Party
+    "PP52": 7730,
 }
 
 JOINT_DESCRIPTION_REGEX = r"^(.*?) \(joint descriptions? with\s?(.*)\)"


### PR DESCRIPTION
Peter correctly pointed out that Conservative party candidates are being shown alongside an old emblem for the party which is no longer used. You can see this in action [here](https://candidates.democracyclub.org.uk/person/4546/boris-johnson).
<img width="374" alt="Screenshot 2023-04-21 at 16 39 34" src="https://user-images.githubusercontent.com/9531063/233677981-0c2f87f5-dfd3-48e2-b9a9-960966846083.png">


The way we currently set a default emblem is by selecting the one with the lowest emblem id (assigned by the EC), unless the party appears in the manual override list. For the Conservatives, we still have their old emblems in the database which have lower IDs and so the old emblem is set as default. Of the emblems currently registered with the EC, the Scottish Conservative variant has the lowest ID so removing old emblems wouldn't quite fit the bill either.

To test locally:
- `python manage.py parties_import_from_ec` - this will force a db level reset of their default emblem
- Go to any conservative MP's page - you should see this emblem instead
<img width="364" alt="Screenshot 2023-04-21 at 16 39 54" src="https://user-images.githubusercontent.com/9531063/233678047-462d53dd-0cad-41a3-87c0-71606bd28042.png">

I have no idea why coveralls says that coverage has gone down 6% but here we are 🙃 

```[tasklist]
### PR Checklist

- [x] References a specific issue or if not, describes the bug or feature in detail
- [x] Instructions for how reviewers can test the code locally
- [x] Screenshot of the feature/bug fix (if applicable)
```
