### PR TITLE
Add default emblem for Mansfield Independents

### DIFF
--- a/ynr/apps/parties/constants.py
+++ b/ynr/apps/parties/constants.py
@@ -56,6 +56,8 @@ DEFAULT_EMBLEMS = {
     "PP79": 7395,
     # Conservative and Unionist Party
     "PP52": 7730,
+    # Mansfield Independents
+    "PP504": 8345,
 }
 
 JOINT_DESCRIPTION_REGEX = r"^(.*?) \(joint descriptions? with\s?(.*)\)"


### PR DESCRIPTION
Closes #1970 

We still have some old emblems for the Mansfield Independents which means the correct emblem is not being assigned as default. 

_This change may take a little time to propagate through as our importers run on a 24h schedule_

Screenie:

<img width="996" alt="Screenshot 2023-04-26 at 16 11 22" src="https://user-images.githubusercontent.com/9531063/234621154-636dcf28-160a-44ee-b7aa-d4b1eabc4b3a.png">

To test:
- Run `python manage.py parties_import_from_ec` (this will reset the default emblem for the party)
- Run the project
- Find somebody who is a Mansfield Independents candidate (I used this chap `person/23782/`)
- They should have the emblem with the deer on it, as in the screenshot above


```[tasklist]
### PR Checklist

- [x] References a specific issue or if not, describes the bug or feature in detail
- [x] Instructions for how reviewers can test the code locally
```
