### PR TITLE
Use inputmode="numeric" for results entry

### DIFF
--- a/ynr/apps/uk_results/forms.py
+++ b/ynr/apps/uk_results/forms.py
@@ -10,6 +10,7 @@ from candidates.models.db import ActionType
 from candidates.views.version_data import get_client_ip
 from uk_results.helpers import RecordBallotResultsHelper
 from utils.db import LastWord, NullIfBlank
+from utils.widgets import DCNumberInput
 
 from .models import CandidateResult, ResultSet
 
@@ -32,7 +33,11 @@ class ResultSetForm(forms.ModelForm):
                     "rows": 1,
                     "columns": 72,
                 }
-            )
+            ),
+            "num_turnout_reported": DCNumberInput(),
+            "turnout_percentage": DCNumberInput(),
+            "num_spoilt_ballots": DCNumberInput(),
+            "total_electorate": DCNumberInput(),
         }
 
     def __init__(self, ballot, *args, **kwargs):
@@ -76,6 +81,7 @@ class ResultSetForm(forms.ModelForm):
                 label=membership.name_and_party,
                 initial=initial.get("num_ballots"),
                 required=True,
+                widget=DCNumberInput,
             )
             fields[f"tied_vote_{name}"] = forms.BooleanField(
                 required=False,

--- a/ynr/apps/uk_results/tests/test_smoke_test_views.py
+++ b/ynr/apps/uk_results/tests/test_smoke_test_views.py
@@ -49,6 +49,8 @@ class TestUKResults(TestUserMixin, UK2015ExamplesMixin, WebTest, TestCase):
         )
         resp = self.app.get(url, user=self.user_who_can_record_results)
         self.assertEqual(resp.status_code, 200)
+        self.assertContains(resp, 'inputmode="numeric"')
+        self.assertContains(resp, r'pattern="[0-9\s\.]*"')
         form = resp.forms[1]
         form["memberships_13"] = 1000
         form["memberships_14"] = 2000

--- a/ynr/apps/utils/widgets.py
+++ b/ynr/apps/utils/widgets.py
@@ -1,7 +1,7 @@
 """
 For storing custom Django form widgets
 """
-from django.forms.widgets import Select
+from django.forms.widgets import Select, TextInput
 
 
 class SelectWithAttrs(Select):
@@ -26,3 +26,25 @@ class SelectWithAttrs(Select):
         )
         option["attrs"].update(label)
         return option
+
+
+class DCNumberInput(TextInput):
+    """
+    An input widget for entering numbers that isn't an input `type=number`.
+
+    For more on why we do this, see this GDS post:
+
+    https://technology.blog.gov.uk/2020/02/24/why-the-gov-uk-design-system-team-changed-the-input-type-for-numbers/
+
+    """
+
+    def build_attrs(self, base_attrs, extra_attrs=None):
+        attrs = super().build_attrs(base_attrs, extra_attrs)
+        attrs.update(
+            {
+                "inputmode": "numeric",
+                "pattern": r"[0-9\s\.]*",
+                "oninvalid": "this.setCustomValidity('Enter a number')",
+            }
+        )
+        return attrs


### PR DESCRIPTION
As per a request in Slack, the `type=number` input isn't useful for various reasons.

[GDS](https://technology.blog.gov.uk/2020/02/24/why-the-gov-uk-design-system-team-changed-the-input-type-for-numbers/) moved to `inputmode="numeric"` for number inputs, so that's what we'll do too.

This could be moved to DC utils at some point, however as the project doesn't currently use the design system I didn't think it was worth adding there in order to make this change.

Test by going to enter results and seeing that the input type has changed.

![image](https://github.com/DemocracyClub/yournextrepresentative/assets/242329/fe715ce4-889b-4526-8052-ecec8600d81a)


```[tasklist]
### PR Checklist
<!-- Not all the items in this list will be relevant for every repo -->
<!-- When creating a Pull Request please delete items as necessary, leaving those that are relevant.  -->

Check off items once the PR addresses them.

- [x] References a specific issue or if not, describes the bug or feature in detail
- [x] Instructions for how reviewers can test the code locally
- [x] Tests have been added and/or updated
- [x] Screenshot of the feature/bug fix (if applicable)
- [x] Did I explain all possible solutions and why I chose the one I did?
- [x] Added any comments to make new functions clearer
- [x] Have I rebased with the latest version of master?
- [x] Added PR labels
```
