### PR TITLE
Save as png in any case

### DIFF
--- a/ynr/apps/moderation_queue/helpers.py
+++ b/ynr/apps/moderation_queue/helpers.py
@@ -65,8 +65,8 @@ def rotate_photo(original_image):
         exif = pil_image.getexif()
         if exif and exif[274]:
             pil_image = ImageOps.exif_transpose(pil_image)
-        buffer = BytesIO()
-        pil_image.save(buffer, "PNG")
+    buffer = BytesIO()
+    pil_image.save(buffer, "PNG")
     return pil_image
 
 


### PR DESCRIPTION
This change attempts to solve the key error below related to photo rotation during the photo upload and save process. the photo in question may present related issues https://candidates.democracyclub.org.uk/moderation/photo/review/38481


```
Internal Server Error: /moderation/photo/upload/image/65623

KeyError at /moderation/photo/upload/image/65623
274

Request Method: POST
Request URL: https://candidates.democracyclub.org.uk/moderation/photo/upload/image/65623
```

