### PR TITLE
Remove local party button

### DIFF
--- a/ynr/apps/elections/uk/templates/candidates/person-view.html
+++ b/ynr/apps/elections/uk/templates/candidates/person-view.html
@@ -248,18 +248,6 @@
     <input type="submit" class="button alert" value="Suggest duplicate">
   </form>
 
-
-
-  {% if last_candidacy %}
-  <div class="person__actions__action">
-    <h2>Add party info</h2>
-    <p>Know something about {{ person.name }}'s local party?</p>
-    <p><a class="button" href="https://docs.google.com/forms/d/e/1FAIpQLSefxjlpi4UVK38CUGKZmZM3zjJO7hJfI58wSX6VZ0ifA54GAQ/viewform?usp=pp_url&entry.166120474={{ last_candidacy.ballot.election.slug }}&entry.339427281={{ last_candidacy.party.ec_id }}">
-      Add it here
-    </a></p>
-  </div>
-  {% endif %}
-
   <div class="person__actions__action person__actions__data">
     <h2>Use this data!</h2>
     <p>Open data JSON API:</p>

--- a/ynr/apps/people/tests/test_person_view.py
+++ b/ynr/apps/people/tests/test_person_view.py
@@ -69,13 +69,13 @@ class TestPersonView(PersonViewSharedTestsMixin):
     def test_shows_no_edit_buttons_if_user_not_authenticated(self):
         response = self.app.get("/person/2009/tessa-jowell")
         edit_buttons = response.html.find_all("a", attrs={"class": "button"})
-        self.assertEqual(len(edit_buttons), 2)
+        self.assertEqual(len(edit_buttons), 1)
         self.assertEqual(edit_buttons[0].string, "Log in to edit")
 
     def test_shows_edit_buttons_if_user_authenticated(self):
         response = self.app.get("/person/2009/tessa-jowell", user=self.user)
         edit_buttons = response.html.find_all("a", attrs={"class": "button"})
-        self.assertEqual(len(edit_buttons), 3)
+        self.assertEqual(len(edit_buttons), 2)
 
     def test_links_to_person_edit_page(self):
         response = self.app.get("/person/2009/tessa-jowell", user=self.user)


### PR DESCRIPTION
This change removes the link to a 2019 google form, which is almost never used.