### PR TITLE
Hotfix/post election display

### DIFF
--- a/ynr/apps/elections/uk/templates/includes/results_progress.html
+++ b/ynr/apps/elections/uk/templates/includes/results_progress.html
@@ -1,5 +1,5 @@
 {% load humanize %}
-{% if SHOW_RESULTS_PROGRESS %}
+{% comment %} {% if SHOW_RESULTS_PROGRESS %}
   <h3>Enter results as they come in</h3>
   <p><a href="{% url "election_list_view"%}?{{ has_results_shortcut.querystring }}" class="button">Get started</a></p>
   <p><a href="{% url "results-home"%}" class="button">Get the data</a></p>
@@ -59,4 +59,4 @@
     {% endfor %}
   </div>
 
-{% endif %}
+{% endif %} {% endcomment %}


### PR DESCRIPTION
Closes https://trello.com/c/rdHrIqz6/3372-put-candidates-back-to-pre-election-frontpage

This change hides the progress dashboard on the home page. 

<img width="1273" alt="Screenshot 2023-06-08 at 1 58 03 PM" src="https://github.com/DemocracyClub/yournextrepresentative/assets/7017118/c7c41a33-9d3c-4bf3-8897-0e6a42284b9e">
