### PR TITLE
Hotfix/update joint party name

### DIFF
--- a/ynr/apps/parties/constants.py
+++ b/ynr/apps/parties/constants.py
@@ -70,7 +70,7 @@ CORRECTED_PARTY_NAMES_IN_DESC = {
     "The Christian Party Christian Peoples Alliance": "Christian Party Christian Peoples Alliance",
     "St. George's Independents": "Weybridge & St. George's Independents",
     "English Democrats Party": "English Democrats",
-    "Tattenhams' Residents' Association": "Tattenhams Residents' Association",
+    "Tattenhams' Residents' Association": "Tattenham & Preston Residents",
     "Trade Unionists and Socialists Coalition": "Trade Unionist and Socialist Coalition",
     "Molesey Residents Association": "The Molesey Residents Association",
 }


### PR DESCRIPTION
Ref https://trello.com/c/CHgmEb2F/3370-tattenhams-residents-association

https://search.electoralcommission.org.uk/English/Registrations/PP141

To test, run the party importer. There should no longer be an error with "Tattenhams' Residents' Association not found"
