### PR TITLE
Get exif data to address key error

### DIFF
--- a/ynr/apps/moderation_queue/helpers.py
+++ b/ynr/apps/moderation_queue/helpers.py
@@ -63,7 +63,7 @@ def rotate_photo(original_image):
         if ExifTags.TAGS[orientation] == "Orientation":
             break
         exif = pil_image.getexif()
-        if exif and exif[274]:
+        if exif and exif.get(274):
             pil_image = ImageOps.exif_transpose(pil_image)
         buffer = BytesIO()
         pil_image.save(buffer, "PNG")


### PR DESCRIPTION
This change addresses an ongoing internal server key error in the mod queue related to exif data (previous fixes did not address or properly test the root cause of the issue https://github.com/DemocracyClub/yournextrepresentative/pull/2111)
The change to tests improves the checks against the `rotate_photo` function.



```[tasklist]
### PR Checklist
<!-- Not all the items in this list will be relevant for every repo -->
<!-- When creating a Pull Request please delete items as necessary, leaving those that are relevant.  -->

Check off items once the PR addresses them.

- [ ] References a specific issue or if not, describes the bug or feature in detail
- [ ] Note what card in Trello this work relates to
- [ ] Instructions for how reviewers can test the code locally
- [ ] Tests have been added and/or updated
- [ ] Screenshot of the feature/bug fix (if applicable)
- [ ] If any new text is added, it's internationalized
- [ ] Any new elements have aria labels
- [ ] No unintentional console.logs left behind after debugging
- [ ] Did I use the clear and concise names for variables and functions?
- [ ] Did I explain all possible solutions and why I chose the one I did?
- [ ] Added any comments to make new functions clearer
- [ ] Did I added or updated any new dependencies? Explain why.
- [ ] Did I update the package.json and/or Pipfile.lock version if relevant?
- [ ] Have I rebased with the latest version of master?
- [ ] Added PR labels
- [ ] Update any history/changelog file
- [ ] Update any documentation
- [ ] Update dev handbook
```
