### PR TITLE
Do not edit v9 code comment

### DIFF
--- a/ynr/apps/api/v09/views.py
+++ b/ynr/apps/api/v09/views.py
@@ -1,4 +1,4 @@
-# v0.9 is legacy code
+# v0.9 is legacy code: Code in this app should not be edited, but can be used as a reference for new code.
 import json
 import subprocess
 import sys


### PR DESCRIPTION
Ref https://trello.com/c/K27dXm47/3404-remove-twitter-preview-add-mastodon-profiles-on-wcivf


~~We've already added mastodon to candidate profiles on YNR, but to do the same on WCIVF, we need to add the username to the API.~~ See [comment](https://github.com/DemocracyClub/yournextrepresentative/pull/2140#issuecomment-1623141562) below. This change simply updates the comment to do not edit `v0.9` code. 
