### PR TITLE
Bump black from 22.10.0 to 23.7.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.black]
 line-length = 80
-extend-exclude = ["ynr/settings/local.py"]
+extend-exclude = "ynr/settings/local.py"
 
 
 [tool.ruff]

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,7 +1,7 @@
 attrs==22.2.0
 aenum==3.1.12
 beautifulsoup4==4.12.0
-black==22.10.0
+black==23.7.0
 bleach==6.0.0
 boto3==1.26.161
 celery==5.2.7

--- a/ynr/apps/api/next/views.py
+++ b/ynr/apps/api/next/views.py
@@ -26,7 +26,6 @@ class ResultsSetPagination(pagination.PageNumberPagination):
 
 
 class OrganizationViewSet(viewsets.ReadOnlyModelViewSet):
-
     queryset = (
         Organization.objects.all()
         .order_by("slug")

--- a/ynr/apps/api/v09/views.py
+++ b/ynr/apps/api/v09/views.py
@@ -38,7 +38,6 @@ def parse_date(date_text):
 
 
 class UpcomingElectionsView(View):
-
     http_method_names = ["get"]
 
     def get(self, request, *args, **kwargs):
@@ -175,7 +174,6 @@ class CurrentElectionsView(View):
 
 
 class VersionView(View):
-
     http_method_names = ["get"]
 
     def get(self, request, *args, **kwargs):

--- a/ynr/apps/bulk_adding/forms.py
+++ b/ynr/apps/bulk_adding/forms.py
@@ -21,7 +21,6 @@ from search.utils import search_person_by_name
 
 class BaseBulkAddFormSet(forms.BaseFormSet):
     def __init__(self, *args, **kwargs):
-
         if "source" in kwargs:
             self.source = kwargs["source"]
             del kwargs["source"]
@@ -216,7 +215,6 @@ class BaseBulkAddReviewFormSet(BaseBulkAddFormSet):
             )
 
         for form_data in self.cleaned_data:
-
             if (
                 "select_person" in form_data
                 and form_data["select_person"] == "_new"
@@ -398,7 +396,6 @@ PartyBulkAddReviewNameOnlyFormSet = forms.formset_factory(
 
 class SelectPartyForm(forms.Form):
     def __init__(self, *args, **kwargs):
-
         election = kwargs.pop("election")
         super().__init__(*args, **kwargs)
 
@@ -433,10 +430,8 @@ class SelectPartyForm(forms.Form):
 
 
 class AddByPartyForm(forms.Form):
-
     source = forms.CharField(required=True)
 
 
 class DeleteRawPeopleForm(forms.Form):
-
     ballot_paper_id = forms.CharField(required=True, widget=forms.HiddenInput)

--- a/ynr/apps/bulk_adding/helpers.py
+++ b/ynr/apps/bulk_adding/helpers.py
@@ -172,7 +172,6 @@ class CSVImporter:
         raise ValueError("No party description header matched")
 
     def clean_area_name(self, name):
-
         name = name.replace(" Ward", "").strip().lower()
         name = name.replace("`", "'")
         return name.replace(" & ", " and ")

--- a/ynr/apps/bulk_adding/migrations/0002_rawpeople.py
+++ b/ynr/apps/bulk_adding/migrations/0002_rawpeople.py
@@ -9,7 +9,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     initial = True
 
     dependencies = [

--- a/ynr/apps/bulk_adding/migrations/0003_rawpeople_source_type.py
+++ b/ynr/apps/bulk_adding/migrations/0003_rawpeople_source_type.py
@@ -6,7 +6,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("bulk_adding", "0002_rawpeople")]
 
     operations = [

--- a/ynr/apps/bulk_adding/migrations/0004_move_to_jsonfield.py
+++ b/ynr/apps/bulk_adding/migrations/0004_move_to_jsonfield.py
@@ -7,7 +7,6 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("bulk_adding", "0003_rawpeople_source_type")]
 
     operations = [

--- a/ynr/apps/bulk_adding/migrations/0005_source_max_length.py
+++ b/ynr/apps/bulk_adding/migrations/0005_source_max_length.py
@@ -6,7 +6,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("bulk_adding", "0004_move_to_jsonfield")]
 
     operations = [

--- a/ynr/apps/bulk_adding/migrations/0006_auto_20210401_0811.py
+++ b/ynr/apps/bulk_adding/migrations/0006_auto_20210401_0811.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("bulk_adding", "0005_source_max_length")]
 
     operations = [

--- a/ynr/apps/bulk_adding/migrations/0007_alter_rawpeople_data.py
+++ b/ynr/apps/bulk_adding/migrations/0007_alter_rawpeople_data.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("bulk_adding", "0006_auto_20210401_0811")]
 
     operations = [

--- a/ynr/apps/bulk_adding/tests/test_helpers.py
+++ b/ynr/apps/bulk_adding/tests/test_helpers.py
@@ -14,7 +14,6 @@ class TestBulkAddingByParty(TestUserMixin, UK2015ExamplesMixin, WebTest):
         self.factory = RequestFactory()
 
     def test_add_person(self):
-
         request = self.factory.get("/")
         request.user = self.user
 
@@ -37,7 +36,6 @@ class TestBulkAddingByParty(TestUserMixin, UK2015ExamplesMixin, WebTest):
         person = PersonFactory()
         for description in [None, party_description]:
             with self.subTest(description=description):
-
                 helpers.update_person(
                     request=request,
                     person=person,

--- a/ynr/apps/bulk_adding/views/parties.py
+++ b/ynr/apps/bulk_adding/views/parties.py
@@ -200,7 +200,6 @@ class BulkAddPartyReviewView(BasePartyBulkAddView):
         return self.form_invalid()
 
     def form_valid(self, formsets):
-
         source = self.request.session["bulk_add_by_party_data"].get("source")
         assert len(formsets) >= 1
 

--- a/ynr/apps/bulk_adding/views/sopns.py
+++ b/ynr/apps/bulk_adding/views/sopns.py
@@ -248,7 +248,6 @@ class BulkAddSOPNReviewView(BaseSOPNBulkAddView):
         return context
 
     def form_valid(self, context):
-
         with transaction.atomic():
             for person_form in context["formset"]:
                 data = person_form.cleaned_data

--- a/ynr/apps/cached_counts/migrations/0001_initial.py
+++ b/ynr/apps/cached_counts/migrations/0001_initial.py
@@ -2,7 +2,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = []
 
     operations = [

--- a/ynr/apps/cached_counts/migrations/0002_cachedcount_election.py
+++ b/ynr/apps/cached_counts/migrations/0002_cachedcount_election.py
@@ -2,7 +2,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("cached_counts", "0001_initial")]
 
     operations = [

--- a/ynr/apps/cached_counts/migrations/0003_set_default_election.py
+++ b/ynr/apps/cached_counts/migrations/0003_set_default_election.py
@@ -15,7 +15,6 @@ def set_uk_2015_election(apps, schema_editor):
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("cached_counts", "0002_cachedcount_election")]
 
     operations = [

--- a/ynr/apps/cached_counts/migrations/0004_constituency_to_post.py
+++ b/ynr/apps/cached_counts/migrations/0004_constituency_to_post.py
@@ -10,7 +10,6 @@ def change_constituency_to_post(apps, schema_editor):
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("cached_counts", "0003_set_default_election")]
 
     operations = [migrations.RunPython(change_constituency_to_post)]

--- a/ynr/apps/cached_counts/migrations/0005_delete_cachedcount.py
+++ b/ynr/apps/cached_counts/migrations/0005_delete_cachedcount.py
@@ -2,7 +2,6 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("cached_counts", "0004_constituency_to_post")]
 
     operations = [migrations.DeleteModel(name="CachedCount")]

--- a/ynr/apps/cached_counts/report_helpers.py
+++ b/ynr/apps/cached_counts/report_helpers.py
@@ -162,7 +162,6 @@ def report_runner(name, date, **kwargs):
 
 
 class NumberOfCandidates(BaseReport):
-
     name = "Number of candidates standing"
 
     def get_qs(self):
@@ -312,7 +311,6 @@ class UncontestedBallots(BaseReport):
 
         report_list.append("\n")
         for ballot in qs:
-
             for membership in ballot.membership_set.all():
                 report_list.append(
                     [
@@ -859,7 +857,6 @@ class SmallPartiesCandidatesCouncilAreas(BaseReport):
 
 
 class NumCandidatesStandingInMultipleSeats(BaseReport):
-
     name = "Candidates standing in multiple seats"
 
     def get_qs(self):
@@ -952,11 +949,9 @@ class PeopleWithMultipleCandidaciesDetailed(
 class NumCandidatesStandingInMultipleSeatsPerGender(
     NumCandidatesStandingInMultipleSeats
 ):
-
     name = "Num candidates standing in multiple per seats, per gender"
 
     def report(self):
-
         genders = (
             self.membership_qs.values_list(
                 "person__gender_guess__gender", flat=True
@@ -986,7 +981,6 @@ class NumCandidatesStandingInMultipleSeatsPerGender(
 
 
 class CommonFirstNames(BaseReport):
-
     name = "Common first names"
 
     def get_qs(self):
@@ -1041,7 +1035,6 @@ class CommonFirstNames(BaseReport):
 
 
 class CommonLastNames(CommonFirstNames):
-
     name = "Common last names"
 
     def collect_names(self, label, qs):
@@ -1053,7 +1046,6 @@ class CommonLastNames(CommonFirstNames):
 
 
 class CandidatesWithWithoutStatement(BaseReport):
-
     name = "Candidates with or without statement"
 
     def get_qs(self):

--- a/ynr/apps/candidatebot/management/commands/candidatebot_import_next_ppcs.py
+++ b/ynr/apps/candidatebot/management/commands/candidatebot_import_next_ppcs.py
@@ -117,7 +117,6 @@ class Command(BaseCommand):
         )
 
     def add_contact_details(self, bot, person, line):
-
         if not person.get_email and line["Email"]:
             bot.add_email(line["Email"])
             if line["Email Source"] and line["Source"] != line["Email Source"]:

--- a/ynr/apps/candidatebot/management/commands/candidatebot_import_twitter_usernames.py
+++ b/ynr/apps/candidatebot/management/commands/candidatebot_import_twitter_usernames.py
@@ -19,7 +19,6 @@ class Command(BaseCommand):
         )
 
     def handle(self, *args, **options):
-
         url = "https://docs.google.com/spreadsheets/d/e/2PACX-1vRZgJoqxpSSTs5hD5X-x4jt9i88Iv6amoJUwRokNS2G4EUkA368OQS7HTwJiJxrKhQKvKBfjIkXbNHz/pub?gid=0&single=true&output=csv"
         if options["url"]:
             url = options["url"]

--- a/ynr/apps/candidates/csv_helpers.py
+++ b/ynr/apps/candidates/csv_helpers.py
@@ -7,7 +7,6 @@ from utils.dict_io import BufferDictWriter
 
 
 def list_to_csv(membership_list):
-
     csv_fields = settings.CSV_ROW_FIELDS
     writer = BufferDictWriter(fieldnames=csv_fields)
     writer.writeheader()

--- a/ynr/apps/candidates/filters.py
+++ b/ynr/apps/candidates/filters.py
@@ -38,7 +38,6 @@ def get_version_fields():
 
 
 class LoggedActionAPIFilter(django_filters.FilterSet):
-
     created = django_filters.DateFilter(lookup_expr="gte")
 
     class Meta:

--- a/ynr/apps/candidates/forms.py
+++ b/ynr/apps/candidates/forms.py
@@ -5,7 +5,6 @@ from people.forms.forms import AddElectionFieldsMixin, StrippedCharField
 
 
 class ToggleLockForm(forms.ModelForm):
-
     hashed_memberships = forms.CharField(
         widget=forms.HiddenInput, required=False
     )

--- a/ynr/apps/candidates/management/commands/candidates_cache_api_to_directory.py
+++ b/ynr/apps/candidates/management/commands/candidates_cache_api_to_directory.py
@@ -31,7 +31,6 @@ def is_timestamped_dir(directory):
 
 
 class Command(BaseCommand):
-
     help = "Cache the output of the persons and posts endpoints to a directory"
 
     endpoints = ("people", "ballots")

--- a/ynr/apps/candidates/management/commands/candidates_create_csv.py
+++ b/ynr/apps/candidates/management/commands/candidates_create_csv.py
@@ -28,7 +28,6 @@ def safely_write(output_filename, memberships_list):
 
 
 class Command(BaseCommand):
-
     help = "Output CSV files for all elections"
 
     def add_arguments(self, parser):

--- a/ynr/apps/candidates/management/commands/candidates_import_from_live_site.py
+++ b/ynr/apps/candidates/management/commands/candidates_import_from_live_site.py
@@ -65,7 +65,6 @@ class Command(BaseCommand):
         # )
 
     def handle(self, **options):
-
         self.image_storage = FileSystemStorage()
         self.ynr_url = options["site_url"]
         self.party_cache = {}
@@ -193,7 +192,6 @@ class Command(BaseCommand):
                             name=other_name["name"], note=other_name["note"]
                         )
                 if person_data["identifiers"]:
-
                     for identifier in person_data["identifiers"]:
                         if not identifier["value"]:
                             continue

--- a/ynr/apps/candidates/management/commands/candidates_import_statements_of_persons_nominated.py
+++ b/ynr/apps/candidates/management/commands/candidates_import_statements_of_persons_nominated.py
@@ -65,7 +65,6 @@ class Command(BaseCommand):
         parser.add_argument("url")
 
     def handle(self, *args, **options):  # noqa
-
         csv_url = options["url"]
 
         mime_type_magic = magic.Magic(mime=True)
@@ -129,7 +128,6 @@ class Command(BaseCommand):
                 ignore_urls = ["drive.google.com"]
                 if not any(x in document_url for x in ignore_urls):
                     try:
-
                         req = requests.get(
                             document_url, headers=headers, verify=False
                         )

--- a/ynr/apps/candidates/migrations/0001_initial.py
+++ b/ynr/apps/candidates/migrations/0001_initial.py
@@ -3,7 +3,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [migrations.swappable_dependency(settings.AUTH_USER_MODEL)]
 
     operations = [

--- a/ynr/apps/candidates/migrations/0002_usertermsagreement.py
+++ b/ynr/apps/candidates/migrations/0002_usertermsagreement.py
@@ -3,7 +3,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         migrations.swappable_dependency(settings.AUTH_USER_MODEL),
         ("candidates", "0001_initial"),

--- a/ynr/apps/candidates/migrations/0003_create_user_terms_agreements.py
+++ b/ynr/apps/candidates/migrations/0003_create_user_terms_agreements.py
@@ -9,7 +9,6 @@ def create_user_terms_agreements(apps, schema_editor):
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("candidates", "0002_usertermsagreement")]
 
     operations = [migrations.RunPython(create_user_terms_agreements)]

--- a/ynr/apps/candidates/migrations/0004_add_trusted_to_merge_group.py
+++ b/ynr/apps/candidates/migrations/0004_add_trusted_to_merge_group.py
@@ -7,7 +7,6 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("candidates", "0003_create_user_terms_agreements")]
 
     operations = [

--- a/ynr/apps/candidates/migrations/0005_add_trusted_to_lock_group.py
+++ b/ynr/apps/candidates/migrations/0005_add_trusted_to_lock_group.py
@@ -7,7 +7,6 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("candidates", "0004_add_trusted_to_merge_group")]
 
     operations = [

--- a/ynr/apps/candidates/migrations/0006_auto_add_trusted_to_rename_group.py
+++ b/ynr/apps/candidates/migrations/0006_auto_add_trusted_to_rename_group.py
@@ -8,7 +8,6 @@ TRUSTED_TO_RENAME_GROUP_NAME = "Trusted To Rename"
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("candidates", "0005_add_trusted_to_lock_group")]
 
     operations = [

--- a/ynr/apps/candidates/migrations/0007_add_result_recorders_group.py
+++ b/ynr/apps/candidates/migrations/0007_add_result_recorders_group.py
@@ -7,7 +7,6 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("candidates", "0006_auto_add_trusted_to_rename_group")]
 
     operations = [

--- a/ynr/apps/candidates/migrations/0008_membershipextra_organizationextra_personextra_postextra.py
+++ b/ynr/apps/candidates/migrations/0008_membershipextra_organizationextra_personextra_postextra.py
@@ -3,7 +3,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         migrations.swappable_dependency(settings.AUTH_USER_MODEL),
         ("popolo", "0002_update_models_from_upstream"),

--- a/ynr/apps/candidates/migrations/0009_migrate_to_django_popolo.py
+++ b/ynr/apps/candidates/migrations/0009_migrate_to_django_popolo.py
@@ -2,7 +2,6 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         (
             "candidates",

--- a/ynr/apps/candidates/migrations/0010_loggedaction_person.py
+++ b/ynr/apps/candidates/migrations/0010_loggedaction_person.py
@@ -2,7 +2,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("popolo", "0002_update_models_from_upstream"),
         ("candidates", "0009_migrate_to_django_popolo"),

--- a/ynr/apps/candidates/migrations/0011_migrate_loggedaction_person.py
+++ b/ynr/apps/candidates/migrations/0011_migrate_loggedaction_person.py
@@ -28,7 +28,6 @@ def db_to_popit(apps, schema_editor):
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("candidates", "0010_loggedaction_person")]
 
     operations = [migrations.RunPython(popit_to_db, db_to_popit)]

--- a/ynr/apps/candidates/migrations/0012_remove_loggedaction_popit_person_id.py
+++ b/ynr/apps/candidates/migrations/0012_remove_loggedaction_popit_person_id.py
@@ -2,7 +2,6 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("candidates", "0011_migrate_loggedaction_person")]
 
     operations = [

--- a/ynr/apps/candidates/migrations/0013_remove_max_popit_ids.py
+++ b/ynr/apps/candidates/migrations/0013_remove_max_popit_ids.py
@@ -2,7 +2,6 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("candidates", "0012_remove_loggedaction_popit_person_id")]
 
     operations = [migrations.DeleteModel(name="MaxPopItIds")]

--- a/ynr/apps/candidates/migrations/0014_make_extra_slugs_unique.py
+++ b/ynr/apps/candidates/migrations/0014_make_extra_slugs_unique.py
@@ -2,7 +2,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("candidates", "0013_remove_max_popit_ids")]
 
     operations = [

--- a/ynr/apps/candidates/migrations/0015_add_configurable_extra_fields.py
+++ b/ynr/apps/candidates/migrations/0015_add_configurable_extra_fields.py
@@ -2,7 +2,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("popolo", "0002_update_models_from_upstream"),
         ("candidates", "0014_make_extra_slugs_unique"),

--- a/ynr/apps/candidates/migrations/0016_migrate_data_to_extra_fields.py
+++ b/ynr/apps/candidates/migrations/0016_migrate_data_to_extra_fields.py
@@ -50,7 +50,6 @@ def from_generic_fields_to_person_extra(apps, schema_editor):
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("candidates", "0015_add_configurable_extra_fields")]
 
     operations = [

--- a/ynr/apps/candidates/migrations/0017_remove_cv_and_program_fields.py
+++ b/ynr/apps/candidates/migrations/0017_remove_cv_and_program_fields.py
@@ -2,7 +2,6 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("candidates", "0016_migrate_data_to_extra_fields")]
 
     operations = [

--- a/ynr/apps/candidates/migrations/0018_cr_add_important_posts_field.py
+++ b/ynr/apps/candidates/migrations/0018_cr_add_important_posts_field.py
@@ -19,7 +19,6 @@ def remove_extra_field(apps, schema_editor):
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("candidates", "0017_remove_cv_and_program_fields")]
 
     operations = [migrations.RunPython(add_extra_field, remove_extra_field)]

--- a/ynr/apps/candidates/migrations/0019_add_yesno_to_extra_field_types.py
+++ b/ynr/apps/candidates/migrations/0019_add_yesno_to_extra_field_types.py
@@ -2,7 +2,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("candidates", "0018_cr_add_important_posts_field")]
 
     operations = [

--- a/ynr/apps/candidates/migrations/0020_cr_add_reelection_field.py
+++ b/ynr/apps/candidates/migrations/0020_cr_add_reelection_field.py
@@ -19,7 +19,6 @@ def remove_extra_field(apps, schema_editor):
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("candidates", "0019_add_yesno_to_extra_field_types")]
 
     operations = [migrations.RunPython(add_extra_field, remove_extra_field)]

--- a/ynr/apps/candidates/migrations/0021_simplepopolofield.py
+++ b/ynr/apps/candidates/migrations/0021_simplepopolofield.py
@@ -2,7 +2,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("candidates", "0020_cr_add_reelection_field")]
 
     operations = [

--- a/ynr/apps/candidates/migrations/0022_create_standard_simple_fields.py
+++ b/ynr/apps/candidates/migrations/0022_create_standard_simple_fields.py
@@ -54,7 +54,6 @@ def create_simple_fields(apps, schema_editor):
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("candidates", "0021_simplepopolofield")]
 
     operations = [migrations.RunPython(create_simple_fields)]

--- a/ynr/apps/candidates/migrations/0023_create_post_to_elections_m2m_with_extra_fields.py
+++ b/ynr/apps/candidates/migrations/0023_create_post_to_elections_m2m_with_extra_fields.py
@@ -2,7 +2,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("elections", "0012_election_people_elected_per_post"),
         ("candidates", "0022_create_standard_simple_fields"),

--- a/ynr/apps/candidates/migrations/0024_port_existing_post_to_election_m2m_data.py
+++ b/ynr/apps/candidates/migrations/0024_port_existing_post_to_election_m2m_data.py
@@ -20,7 +20,6 @@ def new_post_election_m2m_to_old(apps, schema_editor):
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("candidates", "0023_create_post_to_elections_m2m_with_extra_fields")
     ]

--- a/ynr/apps/candidates/migrations/0025_remove_old_post_to_election_m2m_and_rename_new.py
+++ b/ynr/apps/candidates/migrations/0025_remove_old_post_to_election_m2m_and_rename_new.py
@@ -2,7 +2,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("candidates", "0024_port_existing_post_to_election_m2m_data")
     ]

--- a/ynr/apps/candidates/migrations/0026_complexpopolofield.py
+++ b/ynr/apps/candidates/migrations/0026_complexpopolofield.py
@@ -2,7 +2,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("candidates", "0025_remove_old_post_to_election_m2m_and_rename_new")
     ]

--- a/ynr/apps/candidates/migrations/0027_create_standard_complex_fields.py
+++ b/ynr/apps/candidates/migrations/0027_create_standard_complex_fields.py
@@ -89,7 +89,6 @@ def create_complex_fields(apps, schema_editor):
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("candidates", "0026_complexpopolofield")]
 
     operations = [

--- a/ynr/apps/candidates/migrations/0028_auto_20160411_1055.py
+++ b/ynr/apps/candidates/migrations/0028_auto_20160411_1055.py
@@ -2,7 +2,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("candidates", "0027_create_standard_complex_fields")]
 
     operations = [

--- a/ynr/apps/candidates/migrations/0028_create_order_attr_of_extra.py
+++ b/ynr/apps/candidates/migrations/0028_create_order_attr_of_extra.py
@@ -2,7 +2,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("candidates", "0027_create_standard_complex_fields")]
 
     operations = [

--- a/ynr/apps/candidates/migrations/0029_add_ordering_to_fields_meta.py
+++ b/ynr/apps/candidates/migrations/0029_add_ordering_to_fields_meta.py
@@ -2,7 +2,6 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("candidates", "0028_create_order_attr_of_extra")]
 
     operations = [

--- a/ynr/apps/candidates/migrations/0030_merge.py
+++ b/ynr/apps/candidates/migrations/0030_merge.py
@@ -2,7 +2,6 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("candidates", "0029_add_ordering_to_fields_meta"),
         ("candidates", "0028_auto_20160411_1055"),

--- a/ynr/apps/candidates/migrations/0031_loggedaction_post.py
+++ b/ynr/apps/candidates/migrations/0031_loggedaction_post.py
@@ -2,7 +2,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("popolo", "0002_update_models_from_upstream"),
         ("candidates", "0030_merge"),

--- a/ynr/apps/candidates/migrations/0032_migrate_org_slugs.py
+++ b/ynr/apps/candidates/migrations/0032_migrate_org_slugs.py
@@ -52,7 +52,6 @@ def remove_classification_from_slugs(apps, schema_editor):
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("candidates", "0031_loggedaction_post")]
 
     operations = [

--- a/ynr/apps/candidates/migrations/0033_postextraelection_candidates_locked.py
+++ b/ynr/apps/candidates/migrations/0033_postextraelection_candidates_locked.py
@@ -2,7 +2,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("candidates", "0032_migrate_org_slugs")]
 
     operations = [

--- a/ynr/apps/candidates/migrations/0034_candidates_locked_data.py
+++ b/ynr/apps/candidates/migrations/0034_candidates_locked_data.py
@@ -42,7 +42,6 @@ def move_candidates_locked_to_postextra(apps, schema_editor):
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("candidates", "0033_postextraelection_candidates_locked")]
 
     operations = [

--- a/ynr/apps/candidates/migrations/0035_remove_postextra_candidates_locked.py
+++ b/ynr/apps/candidates/migrations/0035_remove_postextra_candidates_locked.py
@@ -2,7 +2,6 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("candidates", "0034_candidates_locked_data")]
 
     operations = [

--- a/ynr/apps/candidates/migrations/0036_postextra_election_unique_togther.py
+++ b/ynr/apps/candidates/migrations/0036_postextra_election_unique_togther.py
@@ -2,7 +2,6 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("candidates", "0035_remove_postextra_candidates_locked")]
 
     operations = [

--- a/ynr/apps/candidates/migrations/0037_auto_20170510_2200.py
+++ b/ynr/apps/candidates/migrations/0037_auto_20170510_2200.py
@@ -2,7 +2,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("candidates", "0036_postextra_election_unique_togther")]
 
     operations = [

--- a/ynr/apps/candidates/migrations/0038_postextraelection_ballot_paper_id.py
+++ b/ynr/apps/candidates/migrations/0038_postextraelection_ballot_paper_id.py
@@ -2,7 +2,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("candidates", "0037_auto_20170510_2200")]
 
     operations = [

--- a/ynr/apps/candidates/migrations/0039_create_ballot_paper_ids_and_set_unique.py
+++ b/ynr/apps/candidates/migrations/0039_create_ballot_paper_ids_and_set_unique.py
@@ -15,7 +15,6 @@ def do_nothing(apps, schema_editor):
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("candidates", "0038_postextraelection_ballot_paper_id")]
 
     operations = [

--- a/ynr/apps/candidates/migrations/0040_membershipextra_post_election.py
+++ b/ynr/apps/candidates/migrations/0040_membershipextra_post_election.py
@@ -25,7 +25,6 @@ def do_nothing(apps, schema_editor):
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("candidates", "0039_create_ballot_paper_ids_and_set_unique")
     ]

--- a/ynr/apps/candidates/migrations/0041_auto_20180323_1400.py
+++ b/ynr/apps/candidates/migrations/0041_auto_20180323_1400.py
@@ -6,7 +6,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("candidates", "0040_membershipextra_post_election")]
 
     operations = [

--- a/ynr/apps/candidates/migrations/0042_loggedaction_post_election.py
+++ b/ynr/apps/candidates/migrations/0042_loggedaction_post_election.py
@@ -6,7 +6,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("candidates", "0041_auto_20180323_1400")]
 
     operations = [

--- a/ynr/apps/candidates/migrations/0043_remove_simple_popolo_field.py
+++ b/ynr/apps/candidates/migrations/0043_remove_simple_popolo_field.py
@@ -5,7 +5,6 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("candidates", "0042_loggedaction_post_election"),
         ("uk", "0004_add_biography"),

--- a/ynr/apps/candidates/migrations/0044_remove_membership_fk_to_election.py
+++ b/ynr/apps/candidates/migrations/0044_remove_membership_fk_to_election.py
@@ -5,7 +5,6 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("candidates", "0043_remove_simple_popolo_field")]
 
     operations = [

--- a/ynr/apps/candidates/migrations/0045_delete_membership_extra.py
+++ b/ynr/apps/candidates/migrations/0045_delete_membership_extra.py
@@ -5,7 +5,6 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("candidates", "0044_remove_membership_fk_to_election"),
         ("popolo", "0004_move-extra-data-to-base"),

--- a/ynr/apps/candidates/migrations/0046_delete_person_extra.py
+++ b/ynr/apps/candidates/migrations/0046_delete_person_extra.py
@@ -6,7 +6,6 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("popolo", "0009_move_extra_person_data_to_base"),
         ("candidates", "0045_delete_membership_extra"),

--- a/ynr/apps/candidates/migrations/0047_add_post_to_pee.py
+++ b/ynr/apps/candidates/migrations/0047_add_post_to_pee.py
@@ -7,7 +7,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("popolo", "0010_rename_not_standing_related_name"),
         ("candidates", "0046_delete_person_extra"),

--- a/ynr/apps/candidates/migrations/0048_move_pee_postextra_to_post.py
+++ b/ynr/apps/candidates/migrations/0048_move_pee_postextra_to_post.py
@@ -16,7 +16,6 @@ def add_extra_fields_to_base(apps, schema_editor):
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("candidates", "0047_add_post_to_pee")]
 
     operations = [

--- a/ynr/apps/candidates/migrations/0049_cleanup_post_extra.py
+++ b/ynr/apps/candidates/migrations/0049_cleanup_post_extra.py
@@ -7,7 +7,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("popolo", "0012_move_post_extra_data_to_base"),
         ("candidates", "0048_move_pee_postextra_to_post"),

--- a/ynr/apps/candidates/migrations/0050_delete_imageextra.py
+++ b/ynr/apps/candidates/migrations/0050_delete_imageextra.py
@@ -6,7 +6,6 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("candidates", "0049_cleanup_post_extra"),
         ("popolo", "0022_populate_person_image_from_image"),

--- a/ynr/apps/candidates/migrations/0051_remove_areaextra.py
+++ b/ynr/apps/candidates/migrations/0051_remove_areaextra.py
@@ -6,7 +6,6 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("candidates", "0050_delete_imageextra")]
 
     operations = [

--- a/ynr/apps/candidates/migrations/0052_python_3_changes.py
+++ b/ynr/apps/candidates/migrations/0052_python_3_changes.py
@@ -6,7 +6,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("candidates", "0051_remove_areaextra")]
 
     operations = [

--- a/ynr/apps/candidates/migrations/0053_move_person_fk_to_people_app.py
+++ b/ynr/apps/candidates/migrations/0053_move_person_fk_to_people_app.py
@@ -7,7 +7,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("people", "0004_move_person_data"),
         ("candidates", "0052_python_3_changes"),

--- a/ynr/apps/candidates/migrations/0054_postextraelection_cancelled.py
+++ b/ynr/apps/candidates/migrations/0054_postextraelection_cancelled.py
@@ -6,7 +6,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("candidates", "0053_move_person_fk_to_people_app")]
 
     operations = [

--- a/ynr/apps/candidates/migrations/0055_delete_complexpopolofield.py
+++ b/ynr/apps/candidates/migrations/0055_delete_complexpopolofield.py
@@ -6,7 +6,6 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("candidates", "0054_postextraelection_cancelled"),
         ("people", "0009_copy_popolo_fields_to_person_identifiers"),

--- a/ynr/apps/candidates/migrations/0056_tmp_ids_to_ballot_id.py
+++ b/ynr/apps/candidates/migrations/0056_tmp_ids_to_ballot_id.py
@@ -27,7 +27,6 @@ def move_tmp_ids_to_actual_ids(apps, schema_editor):
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("candidates", "0055_delete_complexpopolofield")]
 
     operations = [

--- a/ynr/apps/candidates/migrations/0057_remove_extra_field.py
+++ b/ynr/apps/candidates/migrations/0057_remove_extra_field.py
@@ -6,7 +6,6 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("candidates", "0056_tmp_ids_to_ballot_id"),
         ("people", "0014_remove_person_email"),

--- a/ynr/apps/candidates/migrations/0058_pee_to_ballot.py
+++ b/ynr/apps/candidates/migrations/0058_pee_to_ballot.py
@@ -6,7 +6,6 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("candidates", "0057_remove_extra_field"),
         ("official_documents", "0024_add_relevant_pages"),

--- a/ynr/apps/candidates/migrations/0059_rename_logged_action_fk_to_ballot.py
+++ b/ynr/apps/candidates/migrations/0059_rename_logged_action_fk_to_ballot.py
@@ -6,7 +6,6 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("candidates", "0058_pee_to_ballot")]
 
     operations = [

--- a/ynr/apps/candidates/migrations/0060_add_flagged_type.py
+++ b/ynr/apps/candidates/migrations/0060_add_flagged_type.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("candidates", "0059_rename_logged_action_fk_to_ballot")]
 
     operations = [

--- a/ynr/apps/candidates/migrations/0061_positive_int_field.py
+++ b/ynr/apps/candidates/migrations/0061_positive_int_field.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("candidates", "0060_add_flagged_type")]
 
     operations = [

--- a/ynr/apps/candidates/migrations/0062_loggedaction_edit_type.py
+++ b/ynr/apps/candidates/migrations/0062_loggedaction_edit_type.py
@@ -5,7 +5,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("candidates", "0061_positive_int_field")]
 
     operations = [

--- a/ynr/apps/candidates/migrations/0063_populate_loggedaction_edit_types.py
+++ b/ynr/apps/candidates/migrations/0063_populate_loggedaction_edit_types.py
@@ -13,7 +13,6 @@ def populate_edit_types(apps, schema_editor):
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("candidates", "0062_loggedaction_edit_type")]
 
     operations = [

--- a/ynr/apps/candidates/migrations/0064_loggedaction_approved.py
+++ b/ynr/apps/candidates/migrations/0064_loggedaction_approved.py
@@ -5,7 +5,6 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("candidates", "0063_populate_loggedaction_edit_types")]
 
     operations = [

--- a/ynr/apps/candidates/migrations/0065_ballot_replaces.py
+++ b/ynr/apps/candidates/migrations/0065_ballot_replaces.py
@@ -5,7 +5,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("candidates", "0064_loggedaction_approved")]
 
     operations = [

--- a/ynr/apps/candidates/migrations/0066_drop_unique_on_election_post.py
+++ b/ynr/apps/candidates/migrations/0066_drop_unique_on_election_post.py
@@ -4,7 +4,6 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("candidates", "0065_ballot_replaces")]
 
     operations = [

--- a/ynr/apps/candidates/migrations/0067_ballot_tags.py
+++ b/ynr/apps/candidates/migrations/0067_ballot_tags.py
@@ -5,7 +5,6 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("candidates", "0066_drop_unique_on_election_post")]
 
     operations = [

--- a/ynr/apps/candidates/migrations/0068_add_blank_to_tags.py
+++ b/ynr/apps/candidates/migrations/0068_add_blank_to_tags.py
@@ -5,7 +5,6 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("candidates", "0067_ballot_tags")]
 
     operations = [

--- a/ynr/apps/candidates/migrations/0069_ballot_voting_system.py
+++ b/ynr/apps/candidates/migrations/0069_ballot_voting_system.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("candidates", "0068_add_blank_to_tags")]
 
     operations = [

--- a/ynr/apps/candidates/migrations/0070_auto_20210617_1506.py
+++ b/ynr/apps/candidates/migrations/0070_auto_20210617_1506.py
@@ -6,7 +6,6 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("candidates", "0069_ballot_voting_system")]
 
     operations = [

--- a/ynr/apps/candidates/migrations/0071_add_created_data.py
+++ b/ynr/apps/candidates/migrations/0071_add_created_data.py
@@ -14,7 +14,6 @@ def add_created_date(apps, schema_editor):
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("candidates", "0070_auto_20210617_1506")]
 
     operations = [

--- a/ynr/apps/candidates/migrations/0072_alter_ballot_options.py
+++ b/ynr/apps/candidates/migrations/0072_alter_ballot_options.py
@@ -4,7 +4,6 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("candidates", "0071_add_created_data")]
 
     operations = [

--- a/ynr/apps/candidates/migrations/0073_alter_loggedaction_action_type.py
+++ b/ynr/apps/candidates/migrations/0073_alter_loggedaction_action_type.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("candidates", "0072_alter_ballot_options")]
 
     operations = [

--- a/ynr/apps/candidates/migrations/0074_auto_20211006_1027.py
+++ b/ynr/apps/candidates/migrations/0074_auto_20211006_1027.py
@@ -12,7 +12,6 @@ def clean_up_action_types(apps, schema_editor):
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("candidates", "0073_alter_loggedaction_action_type")]
 
     operations = [

--- a/ynr/apps/candidates/migrations/0075_use_jsonfield_from_django.py
+++ b/ynr/apps/candidates/migrations/0075_use_jsonfield_from_django.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("candidates", "0074_auto_20211006_1027")]
 
     operations = [

--- a/ynr/apps/candidates/migrations/0076_ballot_ee_modified.py
+++ b/ynr/apps/candidates/migrations/0076_ballot_ee_modified.py
@@ -5,7 +5,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("candidates", "0075_use_jsonfield_from_django")]
 
     operations = [

--- a/ynr/apps/candidates/migrations/0077_loggedaction_person_pk.py
+++ b/ynr/apps/candidates/migrations/0077_loggedaction_person_pk.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("candidates", "0076_ballot_ee_modified")]
 
     operations = [

--- a/ynr/apps/candidates/migrations/0078_populate_person_pk_on_loggedaction.py
+++ b/ynr/apps/candidates/migrations/0078_populate_person_pk_on_loggedaction.py
@@ -12,7 +12,6 @@ def forwards(apps, schema_editor):
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("candidates", "0077_loggedaction_person_pk")]
 
     operations = [

--- a/ynr/apps/candidates/migrations/0079_change_logged_action_person_on_delete.py
+++ b/ynr/apps/candidates/migrations/0079_change_logged_action_person_on_delete.py
@@ -5,7 +5,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("people", "0033_auto_20210928_1007"),
         ("candidates", "0078_populate_person_pk_on_loggedaction"),

--- a/ynr/apps/candidates/migrations/0080_add_person_delete_action_type.py
+++ b/ynr/apps/candidates/migrations/0080_add_person_delete_action_type.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("candidates", "0079_change_logged_action_person_on_delete")
     ]

--- a/ynr/apps/candidates/migrations/0081_alter_loggedaction_action_type.py
+++ b/ynr/apps/candidates/migrations/0081_alter_loggedaction_action_type.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("candidates", "0080_add_person_delete_action_type")]
 
     operations = [

--- a/ynr/apps/candidates/migrations/0082_alter_ballot_winner_count.py
+++ b/ynr/apps/candidates/migrations/0082_alter_ballot_winner_count.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("candidates", "0081_alter_loggedaction_action_type")]
 
     operations = [

--- a/ynr/apps/candidates/migrations/0083_loggedaction_version_fields.py
+++ b/ynr/apps/candidates/migrations/0083_loggedaction_version_fields.py
@@ -5,7 +5,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("candidates", "0082_alter_ballot_winner_count")]
 
     operations = [

--- a/ynr/apps/candidates/migrations/0084_delete_usertermsagreement.py
+++ b/ynr/apps/candidates/migrations/0084_delete_usertermsagreement.py
@@ -4,7 +4,6 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("candidates", "0083_loggedaction_version_fields"),
     ]

--- a/ynr/apps/candidates/models/popolo_extra.py
+++ b/ynr/apps/candidates/models/popolo_extra.py
@@ -225,7 +225,6 @@ class BallotQueryset(models.QuerySet):
 
 
 class Ballot(EEModifiedMixin, models.Model):
-
     VOTING_SYSTEM_FPTP = "FPTP"
 
     post = models.ForeignKey("popolo.Post", on_delete=models.CASCADE)

--- a/ynr/apps/candidates/models/versions.py
+++ b/ynr/apps/candidates/models/versions.py
@@ -114,7 +114,6 @@ def get_person_as_version_data(person, new_person=False):
 
 
 def revert_person_from_version_data(person, version_data):
-
     from candidates.models import raise_if_unsafe_to_delete
     from elections.models import Election
     from popolo.models import Membership

--- a/ynr/apps/candidates/tests/test_csv_export.py
+++ b/ynr/apps/candidates/tests/test_csv_export.py
@@ -241,7 +241,6 @@ class CSVTests(TmpMediaRootMixin, TestUserMixin, UK2015ExamplesMixin, TestCase):
         self.assertEqual(len(non_empty_file.splitlines()), 3)
 
     def test_previous_party_affiliations_string(self):
-
         for membership in Membership.objects.all():
             with self.subTest(msg=membership):
                 self.assertEqual(

--- a/ynr/apps/candidates/tests/test_flash_calls_to_action.py
+++ b/ynr/apps/candidates/tests/test_flash_calls_to_action.py
@@ -13,7 +13,6 @@ def normalize_whitespace(s):
 
 
 class TestGetFlashMessage(UK2015ExamplesMixin, TestCase):
-
     maxDiff = None
 
     def setUp(self):

--- a/ynr/apps/candidates/tests/test_group_elections.py
+++ b/ynr/apps/candidates/tests/test_group_elections.py
@@ -13,7 +13,6 @@ def get_election_extra(post, election):
 
 
 class TestElectionGrouping(UK2015ExamplesMixin, TestCase):
-
     maxDiff = None
 
     def setUp(self):

--- a/ynr/apps/candidates/views/candidacies.py
+++ b/ynr/apps/candidates/views/candidacies.py
@@ -27,7 +27,6 @@ def raise_if_locked(request, post, election):
 
 
 class CandidacyView(ElectionMixin, LoginRequiredMixin, FormView):
-
     form_class = CandidacyCreateForm
     template_name = "candidates/candidacy-create.html"
 
@@ -73,7 +72,6 @@ class CandidacyView(ElectionMixin, LoginRequiredMixin, FormView):
 
 
 class CandidacyDeleteView(ElectionMixin, LoginRequiredMixin, FormView):
-
     form_class = CandidacyDeleteForm
     template_name = "candidates/candidacy-delete.html"
 

--- a/ynr/apps/candidates/views/constituencies.py
+++ b/ynr/apps/candidates/views/constituencies.py
@@ -33,12 +33,10 @@ class CanRecordResultsMixin:
 class ConstituencyRecordWinnerView(
     ElectionMixin, CanRecordResultsMixin, FormView
 ):
-
     form_class = ConstituencyRecordWinnerForm
     template_name = "candidates/record-winner.html"
 
     def dispatch(self, request, *args, **kwargs):
-
         person_id = self.request.POST.get("person_id")
         self.ballot = self.get_ballot()
         self.person = get_object_or_404(Person, id=person_id)
@@ -82,7 +80,6 @@ class ConstituencyRecordWinnerView(
 
 
 class ConstituencyRetractWinnerView(ElectionMixin, CanRecordResultsMixin, View):
-
     required_group_name = RESULT_RECORDERS_GROUP_NAME
     http_method_names = ["post"]
 

--- a/ynr/apps/candidates/views/other_names.py
+++ b/ynr/apps/candidates/views/other_names.py
@@ -31,7 +31,6 @@ class PersonMixin(object):
 
 
 class PersonOtherNamesView(PersonMixin, ListView):
-
     model = OtherName
     template_name = "candidates/othername_list.html"
 
@@ -44,7 +43,6 @@ class PersonOtherNamesView(PersonMixin, ListView):
 
 
 class PersonOtherNameCreateView(LoginRequiredMixin, PersonMixin, CreateView):
-
     model = OtherName
     form_class = OtherNameForm
     template_name = "candidates/othername_new.html"
@@ -106,7 +104,6 @@ class PersonOtherNameCreateView(LoginRequiredMixin, PersonMixin, CreateView):
 
 
 class PersonOtherNameDeleteView(LoginRequiredMixin, PersonMixin, DeleteView):
-
     model = OtherName
     raise_exception = True
 
@@ -130,7 +127,6 @@ class PersonOtherNameDeleteView(LoginRequiredMixin, PersonMixin, DeleteView):
 
 
 class PersonOtherNameUpdateView(LoginRequiredMixin, PersonMixin, UpdateView):
-
     model = OtherName
     form_class = OtherNameForm
     template_name = "candidates/othername_edit.html"

--- a/ynr/apps/candidates/views/people.py
+++ b/ynr/apps/candidates/views/people.py
@@ -153,7 +153,6 @@ class PersonView(TemplateView):
 
 
 class RevertPersonView(LoginRequiredMixin, View):
-
     http_method_names = ["post"]
 
     def post(self, request, *args, **kwargs):
@@ -281,7 +280,6 @@ class DuplicatePersonView(LoginRequiredMixin, FormView, DetailView):
 
 
 class MergePeopleView(GroupRequiredMixin, TemplateView, MergePeopleMixin):
-
     http_method_names = ["get", "post"]
     required_group_name = TRUSTED_TO_MERGE_GROUP_NAME
     template_name = "candidates/generic-merge-error.html"
@@ -430,7 +428,6 @@ class UpdatePersonView(LoginRequiredMixin, ProcessInlineFormsMixin, UpdateView):
         return kwargs
 
     def get_context_data(self, **kwargs):
-
         context = super().get_context_data(**kwargs)
 
         person = self.object
@@ -447,7 +444,6 @@ class UpdatePersonView(LoginRequiredMixin, ProcessInlineFormsMixin, UpdateView):
         return context
 
     def form_valid(self, all_forms):
-
         form = all_forms["form"]
 
         if not (settings.EDITS_ALLOWED or self.request.user.is_staff):
@@ -461,7 +457,6 @@ class UpdatePersonView(LoginRequiredMixin, ProcessInlineFormsMixin, UpdateView):
         membership_formset = all_forms["memberships_formset"]
 
         with transaction.atomic():
-
             person = context["person"]
             identifiers_formset.instance = person
             identifiers_formset.save()
@@ -550,7 +545,6 @@ class NewPersonView(
         form = all_forms["form"]
         identifiers_formset = all_forms["identifiers_formset"]
         with transaction.atomic():
-
             person = form.save()
 
             identifiers_formset.instance = person

--- a/ynr/apps/candidates/views/users.py
+++ b/ynr/apps/candidates/views/users.py
@@ -45,7 +45,6 @@ class LeaderboardView(ContributorsMixin, TemplateView):
 
 
 class UserContributions(View):
-
     http_method_names = ["get"]
 
     def get(self, request, *args, **kwargs):

--- a/ynr/apps/duplicates/merge_helpers.py
+++ b/ynr/apps/duplicates/merge_helpers.py
@@ -6,7 +6,6 @@ from .models import DuplicateSuggestion
 
 
 def alter_duplicate_suggestion_post_merge(source_person, dest_person):
-
     # Case 1, the primary and secondary people are the same as the DS
     # Because the secondary person is about to get deleted, we need to delete
     # this DuplicateSuggestion too.

--- a/ynr/apps/duplicates/migrations/0001_initial_squashed_0003_auto_20180322_1445.py
+++ b/ynr/apps/duplicates/migrations/0001_initial_squashed_0003_auto_20180322_1445.py
@@ -11,7 +11,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("popolo", "0002_update_models_from_upstream"),
         migrations.swappable_dependency(settings.AUTH_USER_MODEL),

--- a/ynr/apps/duplicates/migrations/0002_add_reasoning_field.py
+++ b/ynr/apps/duplicates/migrations/0002_add_reasoning_field.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("duplicates", "0001_initial_squashed_0003_auto_20180322_1445")
     ]

--- a/ynr/apps/duplicates/migrations/0003_reasoning_as_textfield.py
+++ b/ynr/apps/duplicates/migrations/0003_reasoning_as_textfield.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("duplicates", "0002_add_reasoning_field")]
 
     operations = [

--- a/ynr/apps/elections/api/next/api_views.py
+++ b/ynr/apps/elections/api/next/api_views.py
@@ -74,7 +74,6 @@ class BallotViewSet(viewsets.ReadOnlyModelViewSet):
     filterset_class = BallotFilter
 
     def filter_queryset(self, queryset):
-
         try:
             queryset = super().filter_queryset(queryset)
         except BadPostcodeException as e:

--- a/ynr/apps/elections/migrations/0001_initial.py
+++ b/ynr/apps/elections/migrations/0001_initial.py
@@ -2,7 +2,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = []
 
     operations = [

--- a/ynr/apps/elections/migrations/0002_auto_20151012_1731.py
+++ b/ynr/apps/elections/migrations/0002_auto_20151012_1731.py
@@ -312,7 +312,6 @@ def load_election_data(apps, schema_editor):
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("elections", "0001_initial")]
 
     operations = [migrations.RunPython(load_election_data)]

--- a/ynr/apps/elections/migrations/0003_allow_null_winner_membership_role.py
+++ b/ynr/apps/elections/migrations/0003_allow_null_winner_membership_role.py
@@ -2,7 +2,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("elections", "0002_auto_20151012_1731")]
 
     operations = [

--- a/ynr/apps/elections/migrations/0004_election_new_organization.py
+++ b/ynr/apps/elections/migrations/0004_election_new_organization.py
@@ -2,7 +2,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("popolo", "0002_update_models_from_upstream"),
         ("elections", "0003_allow_null_winner_membership_role"),

--- a/ynr/apps/elections/migrations/0005_migrate_to_popolo_organizations.py
+++ b/ynr/apps/elections/migrations/0005_migrate_to_popolo_organizations.py
@@ -26,7 +26,6 @@ def migrate_to_popolo_organizations(apps, schema_editor):
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("elections", "0004_election_new_organization"),
         ("candidates", "0009_migrate_to_django_popolo"),

--- a/ynr/apps/elections/migrations/0006_remove_old_organization_fields.py
+++ b/ynr/apps/elections/migrations/0006_remove_old_organization_fields.py
@@ -2,7 +2,6 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("elections", "0005_migrate_to_popolo_organizations")]
 
     operations = [

--- a/ynr/apps/elections/migrations/0007_rename_new_organization_to_organization.py
+++ b/ynr/apps/elections/migrations/0007_rename_new_organization_to_organization.py
@@ -2,7 +2,6 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("elections", "0006_remove_old_organization_fields")]
 
     operations = [

--- a/ynr/apps/elections/migrations/0008_remove_artificial_start_and_end_dates.py
+++ b/ynr/apps/elections/migrations/0008_remove_artificial_start_and_end_dates.py
@@ -2,7 +2,6 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("elections", "0007_rename_new_organization_to_organization")
     ]

--- a/ynr/apps/elections/migrations/0009_make_election_slug_unique.py
+++ b/ynr/apps/elections/migrations/0009_make_election_slug_unique.py
@@ -2,7 +2,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("elections", "0008_remove_artificial_start_and_end_dates")]
 
     operations = [

--- a/ynr/apps/elections/migrations/0010_make_post_id_format_optional.py
+++ b/ynr/apps/elections/migrations/0010_make_post_id_format_optional.py
@@ -2,7 +2,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("elections", "0009_make_election_slug_unique")]
 
     operations = [

--- a/ynr/apps/elections/migrations/0011_remove_election_post_id_format.py
+++ b/ynr/apps/elections/migrations/0011_remove_election_post_id_format.py
@@ -2,7 +2,6 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("elections", "0010_make_post_id_format_optional")]
 
     operations = [

--- a/ynr/apps/elections/migrations/0012_election_people_elected_per_post.py
+++ b/ynr/apps/elections/migrations/0012_election_people_elected_per_post.py
@@ -2,7 +2,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("elections", "0011_remove_election_post_id_format")]
 
     operations = [

--- a/ynr/apps/elections/migrations/0013_remove_area.py
+++ b/ynr/apps/elections/migrations/0013_remove_area.py
@@ -6,7 +6,6 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("candidates", "0051_remove_areaextra"),
         ("elections", "0012_election_people_elected_per_post"),

--- a/ynr/apps/elections/migrations/0014_cleanup_for_post_role.py
+++ b/ynr/apps/elections/migrations/0014_cleanup_for_post_role.py
@@ -25,7 +25,6 @@ def update_for_post_role(apps, schema_editor):
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("elections", "0013_remove_area")]
 
     operations = [

--- a/ynr/apps/elections/migrations/0015_election_date_index.py
+++ b/ynr/apps/elections/migrations/0015_election_date_index.py
@@ -6,7 +6,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("elections", "0014_cleanup_for_post_role")]
 
     operations = [

--- a/ynr/apps/elections/migrations/0016_positive_int_field.py
+++ b/ynr/apps/elections/migrations/0016_positive_int_field.py
@@ -11,7 +11,6 @@ def set_people_elected_per_post_to_zero(apps, schema_editor):
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("elections", "0015_election_date_index")]
 
     operations = [

--- a/ynr/apps/elections/migrations/0017_election_modgov_url.py
+++ b/ynr/apps/elections/migrations/0017_election_modgov_url.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("elections", "0016_positive_int_field")]
 
     operations = [

--- a/ynr/apps/elections/migrations/0018_add_timestamps_to_election.py
+++ b/ynr/apps/elections/migrations/0018_add_timestamps_to_election.py
@@ -6,7 +6,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("elections", "0017_election_modgov_url")]
 
     operations = [

--- a/ynr/apps/elections/migrations/0019_add_created.py
+++ b/ynr/apps/elections/migrations/0019_add_created.py
@@ -12,7 +12,6 @@ def add_created_date(apps, schema_editor):
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("elections", "0018_add_timestamps_to_election")]
 
     operations = [

--- a/ynr/apps/elections/migrations/0020_alter_election_modified.py
+++ b/ynr/apps/elections/migrations/0020_alter_election_modified.py
@@ -5,7 +5,6 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("elections", "0019_add_created")]
 
     operations = [

--- a/ynr/apps/elections/tests/test_ballot_lock.py
+++ b/ynr/apps/elections/tests/test_ballot_lock.py
@@ -274,7 +274,6 @@ class TestCancelledBallots(TestUserMixin, UK2015ExamplesMixin, WebTest):
         self.person = PersonFactory.create(id=4170, name="Naomi Newstead")
 
     def test_cancelled_ballot_no_add_button_on_ballot_page(self):
-
         """
         When a ballot is cancelled, we expect it to act like a locked ballot
         for most users. Staff users can still edit candidates

--- a/ynr/apps/elections/tests/test_ballot_view.py
+++ b/ynr/apps/elections/tests/test_ballot_view.py
@@ -125,7 +125,6 @@ class TestBallotView(
         )
 
     def test_ballot_with_candidates_no_sopn(self):
-
         self.create_memberships(self.ballot, self.parties)
         response = self.app.get(self.ballot.get_absolute_url())
 

--- a/ynr/apps/elections/tests/test_election_list_view.py
+++ b/ynr/apps/elections/tests/test_election_list_view.py
@@ -15,7 +15,6 @@ class TestPostsView(UK2015ExamplesMixin, WebTest):
         return super().setUp()
 
     def test_single_election_posts_page(self):
-
         response = self.app.get("/elections/")
 
         self.assertContains(response, "2015 General Election")
@@ -27,7 +26,6 @@ class TestPostsView(UK2015ExamplesMixin, WebTest):
         )
 
     def test_elections_link_to_constituencies_page(self):
-
         response = self.app.get("/elections/")
         self.assertEqual(response.context["filter"].qs.count(), 6)
         self.assertContains(response, "2015 General Election")
@@ -35,7 +33,6 @@ class TestPostsView(UK2015ExamplesMixin, WebTest):
         self.assertFalse(response.context["filter"].data)
 
     def test_two_elections_posts_page(self):
-
         self.earlier_election.current = True
         self.earlier_election.save()
 
@@ -91,7 +88,6 @@ class TestResultsAnnotated(BallotsWithResultsMixin, TestCase):
         return super().setUp()
 
     def test_elections_annotated_correctly(self):
-
         # create 10 ballots matching out filter above
         self.create_ballots_with_results(
             num=10,

--- a/ynr/apps/elections/uk/migrations/0001_migrate_area_ids.py
+++ b/ynr/apps/elections/uk/migrations/0001_migrate_area_ids.py
@@ -60,7 +60,6 @@ def gss_to_old_mapit_ids(apps, schema_editor):
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("popolo", "0002_update_models_from_upstream"),
         ("candidates", "0009_migrate_to_django_popolo"),

--- a/ynr/apps/elections/uk/migrations/0002_remove-gb-prefix.py
+++ b/ynr/apps/elections/uk/migrations/0002_remove-gb-prefix.py
@@ -34,7 +34,6 @@ def add_gb_prefix(apps, schema_editor):
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("uk", "0001_migrate_area_ids")]
 
     operations = [migrations.RunPython(remove_gb_prefix, add_gb_prefix)]

--- a/ynr/apps/elections/uk/migrations/0003_adjust_roles_for_grouping.py
+++ b/ynr/apps/elections/uk/migrations/0003_adjust_roles_for_grouping.py
@@ -18,7 +18,6 @@ def adjust_roles_for_grouping(apps, schema_editor):
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("uk", "0002_remove-gb-prefix")]
 
     operations = [migrations.RunPython(adjust_roles_for_grouping)]

--- a/ynr/apps/elections/uk/templatetags/home_page_tags.py
+++ b/ynr/apps/elections/uk/templatetags/home_page_tags.py
@@ -35,7 +35,6 @@ def results_progress_by_value(base_qs, lookup_value, label_field=None):
     values_dict = {}
 
     for row in ballot_qs:
-
         if label_field:
             row["label"] = row.get(label_field)
             if not row["label"]:
@@ -100,7 +99,6 @@ def sopn_progress_by_value(base_qs, lookup_value, label_field=None):
     "includes/sopn_import_progress.html", takes_context=True
 )
 def sopn_import_progress(context):
-
     context["SHOW_SOPN_TRACKER"] = (
         getattr(settings, "FRONT_PAGE_CTA", False) == "SOPN_TRACKER"
     )

--- a/ynr/apps/elections/uk/views/redirects.py
+++ b/ynr/apps/elections/uk/views/redirects.py
@@ -6,7 +6,6 @@ from elections.uk.lib import is_valid_postcode
 
 
 class ConstituenciesRedirect(RedirectView):
-
     permanent = True
 
     def get_redirect_url(self, *args, **kwargs):
@@ -14,7 +13,6 @@ class ConstituenciesRedirect(RedirectView):
 
 
 class ConstituencyRedirect(RedirectView):
-
     permanent = True
 
     def get_redirect_url(self, *args, **kwargs):
@@ -22,7 +20,6 @@ class ConstituencyRedirect(RedirectView):
 
 
 class PartyRedirect(RedirectView):
-
     permanent = True
 
     def get_redirect_url(self, *args, **kwargs):
@@ -30,7 +27,6 @@ class PartyRedirect(RedirectView):
 
 
 class CandidacyRedirect(RedirectView):
-
     permanent = True
 
     def get_redirect_url(self, *args, **kwargs):
@@ -38,7 +34,6 @@ class CandidacyRedirect(RedirectView):
 
 
 class PersonCreateRedirect(RedirectView):
-
     permanent = True
 
     def get_redirect_url(self, *args, **kwargs):
@@ -46,7 +41,6 @@ class PersonCreateRedirect(RedirectView):
 
 
 class CachedCountsRedirect(RedirectView):
-
     permanent = True
 
     def get_redirect_url(self, *args, **kwargs):
@@ -58,7 +52,6 @@ class CachedCountsRedirect(RedirectView):
 
 
 class OfficialDocumentsRedirect(RedirectView):
-
     permanent = True
 
     def get_redirect_url(self, *args, **kwargs):
@@ -69,7 +62,6 @@ class OfficialDocumentsRedirect(RedirectView):
 
 
 class WhoPostcodeRedirect(RedirectView):
-
     permanent = False
 
     def get_redirect_url(self, *args, **kwargs):
@@ -80,7 +72,6 @@ class WhoPostcodeRedirect(RedirectView):
 
 
 class HelpOutCTAView(RedirectView):
-
     permanent = False
 
     def get_redirect_url(self, *args, **kwargs):

--- a/ynr/apps/facebook_data/migrations/0001_initial.py
+++ b/ynr/apps/facebook_data/migrations/0001_initial.py
@@ -6,7 +6,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     initial = True
 
     dependencies = [("people", "0017_set_vandalism_list")]

--- a/ynr/apps/facebook_data/migrations/0002_facebookadvert_image.py
+++ b/ynr/apps/facebook_data/migrations/0002_facebookadvert_image.py
@@ -5,7 +5,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("facebook_data", "0001_initial")]
 
     operations = [

--- a/ynr/apps/facebook_data/migrations/0003_auto_20210401_0811.py
+++ b/ynr/apps/facebook_data/migrations/0003_auto_20210401_0811.py
@@ -6,7 +6,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("facebook_data", "0002_facebookadvert_image")]
 
     operations = [

--- a/ynr/apps/facebook_data/migrations/0004_alter_facebookadvert_ad_json.py
+++ b/ynr/apps/facebook_data/migrations/0004_alter_facebookadvert_ad_json.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("facebook_data", "0003_auto_20210401_0811")]
 
     operations = [

--- a/ynr/apps/frontend/migrations/0001_initial.py
+++ b/ynr/apps/frontend/migrations/0001_initial.py
@@ -8,7 +8,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     initial = True
 
     dependencies = []

--- a/ynr/apps/frontend/migrations/0002_auto_20210401_0811.py
+++ b/ynr/apps/frontend/migrations/0002_auto_20210401_0811.py
@@ -4,7 +4,6 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("frontend", "0001_initial")]
 
     operations = [

--- a/ynr/apps/moderation_queue/management/commands/moderation_queue_detect_faces_in_queued_images.py
+++ b/ynr/apps/moderation_queue/management/commands/moderation_queue_detect_faces_in_queued_images.py
@@ -13,7 +13,6 @@ MAX_SCALING_FACTOR = 1.3
 
 class Command(BaseCommand):
     def handle(self, **options):
-
         rekognition = boto3.client("rekognition", "eu-west-1")
         attributes = ["ALL"]
 
@@ -23,7 +22,6 @@ class Command(BaseCommand):
         )
 
         for qi in qs:
-
             try:
                 detected = rekognition.detect_faces(
                     Image={"Bytes": qi.image.file.read()}, Attributes=attributes

--- a/ynr/apps/moderation_queue/migrations/0001_initial.py
+++ b/ynr/apps/moderation_queue/migrations/0001_initial.py
@@ -3,7 +3,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [migrations.swappable_dependency(settings.AUTH_USER_MODEL)]
 
     operations = [

--- a/ynr/apps/moderation_queue/migrations/0002_auto_20150213_0838.py
+++ b/ynr/apps/moderation_queue/migrations/0002_auto_20150213_0838.py
@@ -2,7 +2,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("moderation_queue", "0001_initial")]
 
     operations = [

--- a/ynr/apps/moderation_queue/migrations/0003_auto_20150301_2035.py
+++ b/ynr/apps/moderation_queue/migrations/0003_auto_20150301_2035.py
@@ -2,7 +2,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("moderation_queue", "0002_auto_20150213_0838")]
 
     operations = [

--- a/ynr/apps/moderation_queue/migrations/0004_queuedimage_why_allowed.py
+++ b/ynr/apps/moderation_queue/migrations/0004_queuedimage_why_allowed.py
@@ -2,7 +2,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("moderation_queue", "0003_auto_20150301_2035")]
 
     operations = [

--- a/ynr/apps/moderation_queue/migrations/0005_migrate_data_to_why_allowed.py
+++ b/ynr/apps/moderation_queue/migrations/0005_migrate_data_to_why_allowed.py
@@ -24,7 +24,6 @@ def backwards_from_why_allowed(apps, schema_editor):
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("moderation_queue", "0004_queuedimage_why_allowed")]
 
     operations = [

--- a/ynr/apps/moderation_queue/migrations/0006_auto_20150303_0838.py
+++ b/ynr/apps/moderation_queue/migrations/0006_auto_20150303_0838.py
@@ -2,7 +2,6 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("moderation_queue", "0005_migrate_data_to_why_allowed")]
 
     operations = [

--- a/ynr/apps/moderation_queue/migrations/0007_auto_20150303_1420.py
+++ b/ynr/apps/moderation_queue/migrations/0007_auto_20150303_1420.py
@@ -2,7 +2,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("moderation_queue", "0006_auto_20150303_0838")]
 
     operations = [

--- a/ynr/apps/moderation_queue/migrations/0008_add_ignore_to_decision_choices.py
+++ b/ynr/apps/moderation_queue/migrations/0008_add_ignore_to_decision_choices.py
@@ -2,7 +2,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("moderation_queue", "0007_auto_20150303_1420")]
 
     operations = [

--- a/ynr/apps/moderation_queue/migrations/0008_add_photo_review_permissions.py
+++ b/ynr/apps/moderation_queue/migrations/0008_add_photo_review_permissions.py
@@ -7,7 +7,6 @@ from moderation_queue.models import PHOTO_REVIEWERS_GROUP_NAME
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("moderation_queue", "0007_auto_20150303_1420")]
 
     operations = [

--- a/ynr/apps/moderation_queue/migrations/0009_merge.py
+++ b/ynr/apps/moderation_queue/migrations/0009_merge.py
@@ -2,7 +2,6 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("moderation_queue", "0008_add_photo_review_permissions"),
         ("moderation_queue", "0008_add_ignore_to_decision_choices"),

--- a/ynr/apps/moderation_queue/migrations/0010_auto_add_crop_bounds.py
+++ b/ynr/apps/moderation_queue/migrations/0010_auto_add_crop_bounds.py
@@ -2,7 +2,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("moderation_queue", "0009_merge")]
 
     operations = [

--- a/ynr/apps/moderation_queue/migrations/0011_queuedimage_face_detection_tried.py
+++ b/ynr/apps/moderation_queue/migrations/0011_queuedimage_face_detection_tried.py
@@ -2,7 +2,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("moderation_queue", "0010_auto_add_crop_bounds")]
 
     operations = [

--- a/ynr/apps/moderation_queue/migrations/0012_auto_20150717_0811.py
+++ b/ynr/apps/moderation_queue/migrations/0012_auto_20150717_0811.py
@@ -2,7 +2,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("moderation_queue", "0011_queuedimage_face_detection_tried")
     ]

--- a/ynr/apps/moderation_queue/migrations/0013_auto_20150916_1753.py
+++ b/ynr/apps/moderation_queue/migrations/0013_auto_20150916_1753.py
@@ -2,7 +2,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("moderation_queue", "0012_auto_20150717_0811")]
 
     operations = [

--- a/ynr/apps/moderation_queue/migrations/0014_queuedimage_person.py
+++ b/ynr/apps/moderation_queue/migrations/0014_queuedimage_person.py
@@ -2,7 +2,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("popolo", "0002_update_models_from_upstream"),
         ("moderation_queue", "0013_auto_20150916_1753"),

--- a/ynr/apps/moderation_queue/migrations/0015_migrate_queuedimage_person.py
+++ b/ynr/apps/moderation_queue/migrations/0015_migrate_queuedimage_person.py
@@ -23,7 +23,6 @@ def db_to_popit(apps, schema_editor):
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("popolo", "0002_update_models_from_upstream"),
         ("moderation_queue", "0014_queuedimage_person"),

--- a/ynr/apps/moderation_queue/migrations/0016_remove_queuedimage_popit_person_id.py
+++ b/ynr/apps/moderation_queue/migrations/0016_remove_queuedimage_popit_person_id.py
@@ -2,7 +2,6 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("moderation_queue", "0015_migrate_queuedimage_person")]
 
     operations = [

--- a/ynr/apps/moderation_queue/migrations/0017_suggestedpostlock.py
+++ b/ynr/apps/moderation_queue/migrations/0017_suggestedpostlock.py
@@ -3,7 +3,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("candidates", "0028_auto_20160411_1055"),
         migrations.swappable_dependency(settings.AUTH_USER_MODEL),

--- a/ynr/apps/moderation_queue/migrations/0018_suggestedpostlock_postextraelection.py
+++ b/ynr/apps/moderation_queue/migrations/0018_suggestedpostlock_postextraelection.py
@@ -2,7 +2,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("candidates", "0036_postextra_election_unique_togther"),
         ("moderation_queue", "0017_suggestedpostlock"),

--- a/ynr/apps/moderation_queue/migrations/0019_migrate_post_extra_to_postextraelection.py
+++ b/ynr/apps/moderation_queue/migrations/0019_migrate_post_extra_to_postextraelection.py
@@ -71,7 +71,6 @@ def migrate_postextraelection_to_post_extra(apps, schema_editor):
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("moderation_queue", "0018_suggestedpostlock_postextraelection")
     ]

--- a/ynr/apps/moderation_queue/migrations/0020_postextraelection_not_null.py
+++ b/ynr/apps/moderation_queue/migrations/0020_postextraelection_not_null.py
@@ -2,7 +2,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("moderation_queue", "0019_migrate_post_extra_to_postextraelection")
     ]

--- a/ynr/apps/moderation_queue/migrations/0021_remove_suggestedpostlock_post_extra.py
+++ b/ynr/apps/moderation_queue/migrations/0021_remove_suggestedpostlock_post_extra.py
@@ -2,7 +2,6 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("moderation_queue", "0020_postextraelection_not_null")]
 
     operations = [

--- a/ynr/apps/moderation_queue/migrations/0022_add_detection_metadata.py
+++ b/ynr/apps/moderation_queue/migrations/0022_add_detection_metadata.py
@@ -6,7 +6,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("moderation_queue", "0021_remove_suggestedpostlock_post_extra")
     ]

--- a/ynr/apps/moderation_queue/migrations/0023_python_3_changes.py
+++ b/ynr/apps/moderation_queue/migrations/0023_python_3_changes.py
@@ -6,7 +6,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("moderation_queue", "0022_add_detection_metadata")]
 
     operations = [

--- a/ynr/apps/moderation_queue/migrations/0024_move_person_fk_to_people_app.py
+++ b/ynr/apps/moderation_queue/migrations/0024_move_person_fk_to_people_app.py
@@ -7,7 +7,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("moderation_queue", "0023_python_3_changes"),
         ("people", "0004_move_person_data"),

--- a/ynr/apps/moderation_queue/migrations/0025_cleanup_old_lock_suggestions.py
+++ b/ynr/apps/moderation_queue/migrations/0025_cleanup_old_lock_suggestions.py
@@ -13,7 +13,6 @@ def clean_up_lock_suggestions(apps, schema_editor):
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("moderation_queue", "0024_move_person_fk_to_people_app")]
 
     operations = [

--- a/ynr/apps/moderation_queue/migrations/0026_rename_pee_to_ballot.py
+++ b/ynr/apps/moderation_queue/migrations/0026_rename_pee_to_ballot.py
@@ -6,7 +6,6 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("moderation_queue", "0025_cleanup_old_lock_suggestions")]
 
     operations = [

--- a/ynr/apps/moderation_queue/migrations/0027_positive_int_field_update_existing.py
+++ b/ynr/apps/moderation_queue/migrations/0027_positive_int_field_update_existing.py
@@ -12,7 +12,6 @@ def set_ints_to_zero(apps, schema_editor):
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("moderation_queue", "0026_rename_pee_to_ballot")]
 
     operations = [

--- a/ynr/apps/moderation_queue/migrations/0028_positive_int_field_update_existing.py
+++ b/ynr/apps/moderation_queue/migrations/0028_positive_int_field_update_existing.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("moderation_queue", "0027_positive_int_field_update_existing")
     ]

--- a/ynr/apps/moderation_queue/migrations/0029_update_image_upload_to.py
+++ b/ynr/apps/moderation_queue/migrations/0029_update_image_upload_to.py
@@ -5,7 +5,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("moderation_queue", "0028_positive_int_field_update_existing")
     ]

--- a/ynr/apps/moderation_queue/migrations/0031_suggestedpostlock_ballot_hash.py
+++ b/ynr/apps/moderation_queue/migrations/0031_suggestedpostlock_ballot_hash.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("moderation_queue", "0030_add_very_trusted_user_group")]
 
     operations = [

--- a/ynr/apps/moderation_queue/migrations/0032_update_copyright.py
+++ b/ynr/apps/moderation_queue/migrations/0032_update_copyright.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("moderation_queue", "0031_suggestedpostlock_ballot_hash")]
 
     operations = [

--- a/ynr/apps/moderation_queue/models.py
+++ b/ynr/apps/moderation_queue/models.py
@@ -55,7 +55,6 @@ def queued_image_filename(queued_image_instance, filename):
 
 
 class QueuedImage(models.Model):
-
     APPROVED = "approved"
     REJECTED = "rejected"
     UNDECIDED = "undecided"

--- a/ynr/apps/moderation_queue/review_required_helper.py
+++ b/ynr/apps/moderation_queue/review_required_helper.py
@@ -197,7 +197,6 @@ class CandidateCurrentNameDecider(BaseReviewRequiredDecider):
         return "Edit of name of current candidate"
 
     def needs_review(self):
-
         if self.logged_action.user and self.logged_action.person:
             la = self.logged_action
             qs = la.person.memberships.filter(
@@ -212,7 +211,6 @@ class CandidateCurrentNameDecider(BaseReviewRequiredDecider):
                     ):
                         this_diff = version_diff["diffs"][0]["parent_diff"]
                         for op in this_diff:
-
                             if op["path"] == "name" and op["op"] == "replace":
                                 # this is an edit to a name
                                 return self.Status.NEEDS_REVIEW

--- a/ynr/apps/moderation_queue/slack.py
+++ b/ynr/apps/moderation_queue/slack.py
@@ -102,7 +102,6 @@ with the source: \n> {source}
         for diff in self.logged_action.person.version_diffs[0]["diffs"][0][
             "parent_diff"
         ]:
-
             fields_category = None
             section_category = None
             text_data = self.format_text(diff)

--- a/ynr/apps/moderation_queue/tests/factories.py
+++ b/ynr/apps/moderation_queue/tests/factories.py
@@ -2,7 +2,6 @@ import factory
 
 
 class QueuedImageFactory(factory.django.DjangoModelFactory):
-
     image = factory.django.ImageField()
     decision = "undecided"
 

--- a/ynr/apps/moderation_queue/tests/test_changes_for_review.py
+++ b/ynr/apps/moderation_queue/tests/test_changes_for_review.py
@@ -128,7 +128,6 @@ class TestFlaggedEdits(UK2015ExamplesMixin, TestUserMixin, WebTest):
         )
 
     def test_change_name_of_locked_ballot_candidate(self):
-
         example_person = people.tests.factories.PersonFactory.create(
             id="2009", name="Tessa Jowell"
         )
@@ -307,7 +306,6 @@ class TestFlaggedEdits(UK2015ExamplesMixin, TestUserMixin, WebTest):
 @patch.object(Person, "diff_for_version", fake_diff_html)
 @patch("candidates.models.db.datetime")
 class TestNeedsReviewFeed(UK2015ExamplesMixin, TestUserMixin, WebTest):
-
     maxDiff = None
     csrf_checks = False
 

--- a/ynr/apps/moderation_queue/tests/test_other_name_review.py
+++ b/ynr/apps/moderation_queue/tests/test_other_name_review.py
@@ -66,7 +66,6 @@ class OtherNameReviewTests(TestUserMixin, UK2015ExamplesMixin, WebTest):
         self.assertFalse(OtherName.objects.exists())
 
     def test_approve_name_keeps_previous_name(self):
-
         self.person.name = "Foo Bar"
         self.person.save()
 

--- a/ynr/apps/moderation_queue/tests/test_queue.py
+++ b/ynr/apps/moderation_queue/tests/test_queue.py
@@ -55,7 +55,6 @@ def get_image_type_and_dimensions(image_data):
 
 @override_settings(MEDIA_ROOT=TEST_MEDIA_ROOT)
 class PhotoReviewTests(UK2015ExamplesMixin, WebTest):
-
     example_image_filename = EXAMPLE_IMAGE_FILENAME
 
     @classmethod

--- a/ynr/apps/moderation_queue/tests/test_upload_photo.py
+++ b/ynr/apps/moderation_queue/tests/test_upload_photo.py
@@ -34,7 +34,6 @@ TEST_MEDIA_ROOT = realpath(join(dirname(__file__), "media"))
 
 @override_settings(MEDIA_ROOT=TEST_MEDIA_ROOT)
 class PhotoUploadImageTests(UK2015ExamplesMixin, WebTest):
-
     example_image_filename = EXAMPLE_IMAGE_FILENAME
     rotated_image_filename = ROTATED_IMAGE_FILENAME
     xl_image_filename = XL_IMAGE_FILENAME
@@ -213,7 +212,6 @@ class PhotoUploadImageTests(UK2015ExamplesMixin, WebTest):
 @patch("moderation_queue.helpers.requests")
 @override_settings(MEDIA_ROOT=TEST_MEDIA_ROOT)
 class PhotoUploadURLTests(UK2015ExamplesMixin, WebTest):
-
     example_image_filename = EXAMPLE_IMAGE_FILENAME
 
     @classmethod

--- a/ynr/apps/official_documents/admin.py
+++ b/ynr/apps/official_documents/admin.py
@@ -4,7 +4,6 @@ from .models import OfficialDocument
 
 
 class OfficialDocumentAdmin(admin.ModelAdmin):
-
     list_display = ("document_type", "created", "ballot", "source_url")
     search_fields = ("ballot__ballot_paper_id", "source_url")
     list_filter = ("document_type",)

--- a/ynr/apps/official_documents/management/commands/official_documents_check_hashes.py
+++ b/ynr/apps/official_documents/management/commands/official_documents_check_hashes.py
@@ -7,7 +7,6 @@ from utils.dict_io import BufferDictWriter
 
 
 class Command(BaseCommand):
-
     help = "Check the hash of a document against the source"
     fieldnames = [
         "ballot_paper_id",

--- a/ynr/apps/official_documents/management/commands/official_documents_create_candidate_csv.py
+++ b/ynr/apps/official_documents/management/commands/official_documents_create_candidate_csv.py
@@ -35,7 +35,6 @@ class Command(BaseCommand):
             }
 
             for membership in document_memberships:
-
                 other_names = "|".join(
                     [o.name for o in membership.base.person.other_names.all()]
                 )

--- a/ynr/apps/official_documents/management/commands/official_documents_create_sopn_sourcing_csv.py
+++ b/ynr/apps/official_documents/management/commands/official_documents_create_sopn_sourcing_csv.py
@@ -5,7 +5,6 @@ from utils.dict_io import BufferDictWriter
 
 
 class Command(BaseCommand):
-
     help = """
     Create a CSV file that can be populated and imported by
     candidates_import_statements_of_persons_nominated
@@ -36,7 +35,6 @@ class Command(BaseCommand):
         )
 
     def handle(self, *args, **options):
-
         out_csv = BufferDictWriter(self.fieldnames)
         out_csv.writeheader()
 

--- a/ynr/apps/official_documents/management/commands/official_documents_create_sopn_zip.py
+++ b/ynr/apps/official_documents/management/commands/official_documents_create_sopn_zip.py
@@ -7,7 +7,6 @@ from official_documents.models import OfficialDocument
 
 
 class Command(BaseCommand):
-
     help = "Create a ZIP file containing all SOPN PDFs"
 
     def handle(self, *args, **options):

--- a/ynr/apps/official_documents/migrations/0001_initial.py
+++ b/ynr/apps/official_documents/migrations/0001_initial.py
@@ -5,7 +5,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("candidates", "0041_auto_20180323_1400")]
 
     operations = [

--- a/ynr/apps/official_documents/migrations/0002_officialdocument_document_type.py
+++ b/ynr/apps/official_documents/migrations/0002_officialdocument_document_type.py
@@ -2,7 +2,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("official_documents", "0001_initial")]
 
     operations = [

--- a/ynr/apps/official_documents/migrations/0003_add_group.py
+++ b/ynr/apps/official_documents/migrations/0003_add_group.py
@@ -8,7 +8,6 @@ from official_documents.models import DOCUMENT_UPLOADERS_GROUP_NAME
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         migrations.swappable_dependency(settings.AUTH_USER_MODEL),
         ("official_documents", "0002_officialdocument_document_type"),

--- a/ynr/apps/official_documents/migrations/0004_auto_20150410_1054.py
+++ b/ynr/apps/official_documents/migrations/0004_auto_20150410_1054.py
@@ -2,7 +2,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("official_documents", "0003_add_group")]
 
     operations = [

--- a/ynr/apps/official_documents/migrations/0005_auto_20150410_1307.py
+++ b/ynr/apps/official_documents/migrations/0005_auto_20150410_1307.py
@@ -2,7 +2,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("official_documents", "0004_auto_20150410_1054")]
 
     operations = [

--- a/ynr/apps/official_documents/migrations/0006_rename_mapit_id_to_post_id.py
+++ b/ynr/apps/official_documents/migrations/0006_rename_mapit_id_to_post_id.py
@@ -2,7 +2,6 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("official_documents", "0005_auto_20150410_1307")]
 
     operations = [

--- a/ynr/apps/official_documents/migrations/0007_officialdocument_election.py
+++ b/ynr/apps/official_documents/migrations/0007_officialdocument_election.py
@@ -2,7 +2,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("official_documents", "0006_rename_mapit_id_to_post_id")]
 
     operations = [

--- a/ynr/apps/official_documents/migrations/0008_set_default_election.py
+++ b/ynr/apps/official_documents/migrations/0008_set_default_election.py
@@ -15,7 +15,6 @@ def set_uk_2015_election(apps, schema_editor):
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("official_documents", "0007_officialdocument_election")]
 
     operations = [

--- a/ynr/apps/official_documents/migrations/0009_officialdocument_document_post.py
+++ b/ynr/apps/official_documents/migrations/0009_officialdocument_document_post.py
@@ -2,7 +2,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("popolo", "0002_update_models_from_upstream"),
         ("official_documents", "0008_set_default_election"),

--- a/ynr/apps/official_documents/migrations/0010_post_id_to_officialdocument.py
+++ b/ynr/apps/official_documents/migrations/0010_post_id_to_officialdocument.py
@@ -17,7 +17,6 @@ def post_to_post_id(apps, schema_editor):
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("official_documents", "0009_officialdocument_document_post"),
         ("candidates", "0009_migrate_to_django_popolo"),

--- a/ynr/apps/official_documents/migrations/0011_officaldocument_to_post_remove_post_id.py
+++ b/ynr/apps/official_documents/migrations/0011_officaldocument_to_post_remove_post_id.py
@@ -2,7 +2,6 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("official_documents", "0010_post_id_to_officialdocument")]
 
     operations = [

--- a/ynr/apps/official_documents/migrations/0012_officialdocument_election_model.py
+++ b/ynr/apps/official_documents/migrations/0012_officialdocument_election_model.py
@@ -2,7 +2,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("elections", "0007_rename_new_organization_to_organization"),
         ("official_documents", "0011_officaldocument_to_post_remove_post_id"),

--- a/ynr/apps/official_documents/migrations/0013_election_id_to_election_model.py
+++ b/ynr/apps/official_documents/migrations/0013_election_id_to_election_model.py
@@ -17,7 +17,6 @@ def election_model_to_election(apps, schema_editor):
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("official_documents", "0012_officialdocument_election_model")
     ]

--- a/ynr/apps/official_documents/migrations/0014_remove_officialdocument_election.py
+++ b/ynr/apps/official_documents/migrations/0014_remove_officialdocument_election.py
@@ -2,7 +2,6 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("official_documents", "0013_election_id_to_election_model")
     ]

--- a/ynr/apps/official_documents/migrations/0015_rename_election_model_to_election.py
+++ b/ynr/apps/official_documents/migrations/0015_rename_election_model_to_election.py
@@ -2,7 +2,6 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("official_documents", "0014_remove_officialdocument_election")
     ]

--- a/ynr/apps/official_documents/migrations/0016_election_not_null.py
+++ b/ynr/apps/official_documents/migrations/0016_election_not_null.py
@@ -2,7 +2,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("official_documents", "0015_rename_election_model_to_election")
     ]

--- a/ynr/apps/official_documents/migrations/0017_update_django_extensions_datetime_fields.py
+++ b/ynr/apps/official_documents/migrations/0017_update_django_extensions_datetime_fields.py
@@ -3,7 +3,6 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("official_documents", "0016_election_not_null")]
 
     operations = [

--- a/ynr/apps/official_documents/migrations/0018_make_source_url_required.py
+++ b/ynr/apps/official_documents/migrations/0018_make_source_url_required.py
@@ -2,7 +2,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("official_documents", "0017_update_django_extensions_datetime_fields")
     ]

--- a/ynr/apps/official_documents/migrations/0019_officialdocument_post_election.py
+++ b/ynr/apps/official_documents/migrations/0019_officialdocument_post_election.py
@@ -6,7 +6,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("candidates", "0041_auto_20180323_1400"),
         ("official_documents", "0018_make_source_url_required"),

--- a/ynr/apps/official_documents/migrations/0020_add_post_election_values.py
+++ b/ynr/apps/official_documents/migrations/0020_add_post_election_values.py
@@ -21,7 +21,6 @@ def do_nothing(apps, schema_editor):
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("official_documents", "0019_officialdocument_post_election")
     ]

--- a/ynr/apps/official_documents/migrations/0021_auto_20180406_1555.py
+++ b/ynr/apps/official_documents/migrations/0021_auto_20180406_1555.py
@@ -6,7 +6,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("official_documents", "0020_add_post_election_values")]
 
     operations = [

--- a/ynr/apps/official_documents/migrations/0022_python_3_changes.py
+++ b/ynr/apps/official_documents/migrations/0022_python_3_changes.py
@@ -6,7 +6,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("official_documents", "0021_auto_20180406_1555")]
 
     operations = [

--- a/ynr/apps/official_documents/migrations/0023_remove_election_and_post.py
+++ b/ynr/apps/official_documents/migrations/0023_remove_election_and_post.py
@@ -6,7 +6,6 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("official_documents", "0022_python_3_changes")]
 
     operations = [

--- a/ynr/apps/official_documents/migrations/0024_add_relevant_pages.py
+++ b/ynr/apps/official_documents/migrations/0024_add_relevant_pages.py
@@ -6,7 +6,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("official_documents", "0023_remove_election_and_post")]
 
     operations = [

--- a/ynr/apps/official_documents/migrations/0025_rename_post_election_fk_to_ballot.py
+++ b/ynr/apps/official_documents/migrations/0025_rename_post_election_fk_to_ballot.py
@@ -6,7 +6,6 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("official_documents", "0024_add_relevant_pages")]
 
     operations = [

--- a/ynr/apps/official_documents/migrations/0026_remove_null_on_relevant_pages.py
+++ b/ynr/apps/official_documents/migrations/0026_remove_null_on_relevant_pages.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("official_documents", "0025_rename_post_election_fk_to_ballot")
     ]

--- a/ynr/apps/official_documents/migrations/0027_alter_officialdocument_source_url.py
+++ b/ynr/apps/official_documents/migrations/0027_alter_officialdocument_source_url.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("official_documents", "0026_remove_null_on_relevant_pages")
     ]

--- a/ynr/apps/official_documents/migrations/0028_alter_officialdocument_uploaded_file.py
+++ b/ynr/apps/official_documents/migrations/0028_alter_officialdocument_uploaded_file.py
@@ -6,7 +6,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("official_documents", "0027_alter_officialdocument_source_url")
     ]

--- a/ynr/apps/official_documents/tests/test_upload.py
+++ b/ynr/apps/official_documents/tests/test_upload.py
@@ -34,7 +34,6 @@ TEST_MEDIA_ROOT = realpath(
 
 
 class TestModels(TestUserMixin, WebTest):
-
     example_image_filename = EXAMPLE_IMAGE_FILENAME
     example_docx_filename = EXAMPLE_DOCX_FILENAME
     example_html_filename = EXAMPLE_HTML_FILENAME

--- a/ynr/apps/parties/api/next/api_views.py
+++ b/ynr/apps/parties/api/next/api_views.py
@@ -58,7 +58,6 @@ class PartyRegisterList(viewsets.ReadOnlyModelViewSet):
 
 
 class AllPartiesJSONView(View):
-
     http_method_names = ["get"]
 
     def get(self, request, *args, **kwargs):

--- a/ynr/apps/parties/migrations/0001_initial.py
+++ b/ynr/apps/parties/migrations/0001_initial.py
@@ -9,7 +9,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     initial = True
 
     dependencies = []

--- a/ynr/apps/parties/migrations/0002_add_independent_party.py
+++ b/ynr/apps/parties/migrations/0002_add_independent_party.py
@@ -14,7 +14,6 @@ def add_independent_party(apps, schema_editor):
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("parties", "0001_initial")]
 
     operations = [

--- a/ynr/apps/parties/migrations/0003_party_ordering.py
+++ b/ynr/apps/parties/migrations/0003_party_ordering.py
@@ -6,7 +6,6 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("parties", "0002_add_independent_party")]
 
     operations = [

--- a/ynr/apps/parties/migrations/0004_party_legacy_slug.py
+++ b/ynr/apps/parties/migrations/0004_party_legacy_slug.py
@@ -6,7 +6,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("parties", "0003_party_ordering")]
 
     operations = [

--- a/ynr/apps/parties/migrations/0005_popolate_legacy_slug.py
+++ b/ynr/apps/parties/migrations/0005_popolate_legacy_slug.py
@@ -17,7 +17,6 @@ def add_legacy_slug(apps, schema_editor):
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("parties", "0004_party_legacy_slug"),
         ("popolo", "0015_move_organization_to_parties"),

--- a/ynr/apps/parties/migrations/0006_legacy_slug_unique.py
+++ b/ynr/apps/parties/migrations/0006_legacy_slug_unique.py
@@ -6,7 +6,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("parties", "0005_popolate_legacy_slug")]
 
     operations = [

--- a/ynr/apps/parties/migrations/0007_add_speaker.py
+++ b/ynr/apps/parties/migrations/0007_add_speaker.py
@@ -18,7 +18,6 @@ def add_speaker(apps, schema_editor):
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("parties", "0006_legacy_slug_unique")]
 
     operations = [migrations.RunPython(add_speaker, migrations.RunPython.noop)]

--- a/ynr/apps/parties/migrations/0008_unique_ec_id.py
+++ b/ynr/apps/parties/migrations/0008_unique_ec_id.py
@@ -6,7 +6,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("parties", "0007_add_speaker")]
 
     operations = [

--- a/ynr/apps/parties/migrations/0009_slug_help_text.py
+++ b/ynr/apps/parties/migrations/0009_slug_help_text.py
@@ -6,7 +6,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("parties", "0008_unique_ec_id")]
 
     operations = [

--- a/ynr/apps/parties/migrations/0010_add_candidate_totals.py
+++ b/ynr/apps/parties/migrations/0010_add_candidate_totals.py
@@ -6,7 +6,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("parties", "0009_slug_help_text")]
 
     operations = [

--- a/ynr/apps/parties/migrations/0011_add_initial_candidates_counts.py
+++ b/ynr/apps/parties/migrations/0011_add_initial_candidates_counts.py
@@ -17,7 +17,6 @@ def populate_initial_candidate_counts(apps, schema_editor):
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("parties", "0010_add_candidate_totals")]
 
     operations = [

--- a/ynr/apps/parties/migrations/0012_add_party_docs.py
+++ b/ynr/apps/parties/migrations/0012_add_party_docs.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("parties", "0011_add_initial_candidates_counts")]
 
     operations = [

--- a/ynr/apps/parties/migrations/0013_add_independent_descriptions.py
+++ b/ynr/apps/parties/migrations/0013_add_independent_descriptions.py
@@ -11,7 +11,6 @@ def add_independent_party_descriptions(apps, schema_editor):
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("parties", "0012_add_party_docs")]
 
     operations = [

--- a/ynr/apps/parties/migrations/0014_alter_partydescription_options.py
+++ b/ynr/apps/parties/migrations/0014_alter_partydescription_options.py
@@ -4,7 +4,6 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("parties", "0013_add_independent_descriptions")]
 
     operations = [

--- a/ynr/apps/parties/migrations/0015_replace_dash_with_hyphen.py
+++ b/ynr/apps/parties/migrations/0015_replace_dash_with_hyphen.py
@@ -6,7 +6,6 @@ from django.db.models.functions import Replace
 
 
 def replace_dash_with_hyphen(apps, schema_editor):
-
     Party = apps.get_model("parties", "Party")
     PartyDescription = apps.get_model("parties", "PartyDescription")
     Party.objects.update(name=Replace("name", Value("\u2013"), Value("\u002d")))
@@ -16,7 +15,6 @@ def replace_dash_with_hyphen(apps, schema_editor):
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("parties", "0014_alter_partydescription_options")]
 
     operations = [

--- a/ynr/apps/parties/migrations/0016_enable_levenshtein.py
+++ b/ynr/apps/parties/migrations/0016_enable_levenshtein.py
@@ -5,7 +5,6 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("parties", "0015_replace_dash_with_hyphen")]
 
     operations = [CreateExtension(name="fuzzystrmatch")]

--- a/ynr/apps/parties/migrations/0017_alter_party_ec_id.py
+++ b/ynr/apps/parties/migrations/0017_alter_party_ec_id.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("parties", "0016_enable_levenshtein")]
 
     operations = [

--- a/ynr/apps/parties/migrations/0018_party_alternative_name.py
+++ b/ynr/apps/parties/migrations/0018_party_alternative_name.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("parties", "0017_alter_party_ec_id"),
     ]

--- a/ynr/apps/parties/migrations/0019_party_ec_data.py
+++ b/ynr/apps/parties/migrations/0019_party_ec_data.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("parties", "0018_party_alternative_name"),
     ]

--- a/ynr/apps/parties/migrations/0020_alter_partyemblem_options_partyemblem_active.py
+++ b/ynr/apps/parties/migrations/0020_alter_partyemblem_options_partyemblem_active.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("parties", "0019_party_ec_data"),
     ]

--- a/ynr/apps/parties/migrations/0021_alter_partydescription_options_and_more.py
+++ b/ynr/apps/parties/migrations/0021_alter_partydescription_options_and_more.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("parties", "0020_alter_partyemblem_options_partyemblem_active"),
     ]

--- a/ynr/apps/parties/migrations/0022_party_nations.py
+++ b/ynr/apps/parties/migrations/0022_party_nations.py
@@ -5,7 +5,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("parties", "0021_alter_partydescription_options_and_more"),
     ]

--- a/ynr/apps/parties/models.py
+++ b/ynr/apps/parties/models.py
@@ -134,7 +134,6 @@ class Party(TimeStampedModel):
                 self.default_emblem.ec_emblem_id
             )
         if self.descriptions.exists():
-
             attachment["fields"] = [
                 {
                     "title": "Descriptions",

--- a/ynr/apps/people/admin.py
+++ b/ynr/apps/people/admin.py
@@ -133,7 +133,6 @@ class PersonAdmin(admin.ModelAdmin):
 
     def save_model(self, request, obj, form, change):
         if form.initial["edit_limitations"] != form["edit_limitations"].value():
-
             try:
                 limitation = EditLimitationStatuses[
                     form["edit_limitations"].value()

--- a/ynr/apps/people/forms/forms.py
+++ b/ynr/apps/people/forms/forms.py
@@ -329,7 +329,6 @@ class BasePersonForm(forms.ModelForm):
     )
 
     def clean_biography(self):
-
         if self.cleaned_data["biography"].find("\r"):
             self.cleaned_data["biography"] = self.cleaned_data[
                 "biography"

--- a/ynr/apps/people/merging.py
+++ b/ynr/apps/people/merging.py
@@ -195,7 +195,6 @@ class PersonMerger:
         attributes should be kept, replacing dest's.
         """
         for field_name in self.person_attrs_to_merge:
-
             source_value = getattr(self.source_person, field_name, None)
 
             # Assume we want to keep the value from source

--- a/ynr/apps/people/migrations/0001_initial.py
+++ b/ynr/apps/people/migrations/0001_initial.py
@@ -9,7 +9,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     initial = True
 
     dependencies = [

--- a/ynr/apps/people/migrations/0002_change_related_name.py
+++ b/ynr/apps/people/migrations/0002_change_related_name.py
@@ -7,7 +7,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("people", "0001_initial")]
 
     operations = [

--- a/ynr/apps/people/migrations/0003_add_person_model.py
+++ b/ynr/apps/people/migrations/0003_add_person_model.py
@@ -11,7 +11,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("elections", "0013_remove_area"),
         ("elections", "0013_remove_area"),

--- a/ynr/apps/people/migrations/0004_move_person_data.py
+++ b/ynr/apps/people/migrations/0004_move_person_data.py
@@ -38,7 +38,6 @@ def move_person_from_popolo(apps, schema_editor):
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("people", "0003_add_person_model")]
 
     operations = [

--- a/ynr/apps/people/migrations/0005_move_person_image_fk_to_person_app.py
+++ b/ynr/apps/people/migrations/0005_move_person_image_fk_to_person_app.py
@@ -7,7 +7,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("people", "0004_move_person_data")]
 
     operations = [

--- a/ynr/apps/people/migrations/0006_move_person_gfks.py
+++ b/ynr/apps/people/migrations/0006_move_person_gfks.py
@@ -28,7 +28,6 @@ def move_popolo_person_gfks_to_people_person(apps, schema_editor):
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("people", "0005_move_person_image_fk_to_person_app")]
 
     operations = [

--- a/ynr/apps/people/migrations/0007_remove_dateframe.py
+++ b/ynr/apps/people/migrations/0007_remove_dateframe.py
@@ -6,7 +6,6 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("people", "0006_move_person_gfks")]
 
     operations = [

--- a/ynr/apps/people/migrations/0008_person_identifier_model.py
+++ b/ynr/apps/people/migrations/0008_person_identifier_model.py
@@ -9,7 +9,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("people", "0007_remove_dateframe")]
 
     operations = [

--- a/ynr/apps/people/migrations/0009_copy_popolo_fields_to_person_identifiers.py
+++ b/ynr/apps/people/migrations/0009_copy_popolo_fields_to_person_identifiers.py
@@ -76,7 +76,6 @@ def populate_person_identifier_from_popolo_models(apps, schema_editor):
     )
     contact_detail_to_move = []
     for contact_detail in qs:
-
         contact_detail_to_move.append(
             PersonIdentifier(
                 value=contact_detail.value,
@@ -106,7 +105,6 @@ def populate_person_identifier_from_popolo_models(apps, schema_editor):
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("people", "0008_person_identifier_model")]
 
     operations = [

--- a/ynr/apps/people/migrations/0010_copy_email_to_person_identifier.py
+++ b/ynr/apps/people/migrations/0010_copy_email_to_person_identifier.py
@@ -21,7 +21,6 @@ def populate_person_identifier_from_person_email(apps, schema_editor):
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("people", "0009_copy_popolo_fields_to_person_identifiers")]
 
     operations = [

--- a/ynr/apps/people/migrations/0011_set_tmp_unique_constraints.py
+++ b/ynr/apps/people/migrations/0011_set_tmp_unique_constraints.py
@@ -7,7 +7,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("people", "0010_copy_email_to_person_identifier")]
 
     operations = [

--- a/ynr/apps/people/migrations/0012_add_person_favourite_biscuit.py
+++ b/ynr/apps/people/migrations/0012_add_person_favourite_biscuit.py
@@ -6,7 +6,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("people", "0011_set_tmp_unique_constraints")]
 
     operations = [

--- a/ynr/apps/people/migrations/0013_populate_favourite_biscuit.py
+++ b/ynr/apps/people/migrations/0013_populate_favourite_biscuit.py
@@ -40,7 +40,6 @@ def populate_favourite_biscuit_from_extrafieldvalue(apps, schema_editor):
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("people", "0012_add_person_favourite_biscuit")]
 
     operations = [

--- a/ynr/apps/people/migrations/0014_remove_person_email.py
+++ b/ynr/apps/people/migrations/0014_remove_person_email.py
@@ -6,7 +6,6 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("people", "0013_populate_favourite_biscuit")]
 
     operations = [migrations.RemoveField(model_name="person", name="email")]

--- a/ynr/apps/people/migrations/0015_date_lengths.py
+++ b/ynr/apps/people/migrations/0015_date_lengths.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("people", "0014_remove_person_email")]
 
     operations = [

--- a/ynr/apps/people/migrations/0016_add_edit_limitations.py
+++ b/ynr/apps/people/migrations/0016_add_edit_limitations.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("people", "0015_date_lengths")]
 
     operations = [

--- a/ynr/apps/people/migrations/0017_set_vandalism_list.py
+++ b/ynr/apps/people/migrations/0017_set_vandalism_list.py
@@ -204,7 +204,6 @@ def set_liable_to_vandalism(apps, schema_editor):
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("people", "0016_add_edit_limitations")]
 
     operations = [

--- a/ynr/apps/people/migrations/0018_gender_guess.py
+++ b/ynr/apps/people/migrations/0018_gender_guess.py
@@ -6,7 +6,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("people", "0017_set_vandalism_list")]
 
     operations = [

--- a/ynr/apps/people/migrations/0020_add_json_versions.py
+++ b/ynr/apps/people/migrations/0020_add_json_versions.py
@@ -5,7 +5,6 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("people", "0019_move_to_ballot_in_version_history")]
 
     operations = [

--- a/ynr/apps/people/migrations/0021_populate_json_versions.py
+++ b/ynr/apps/people/migrations/0021_populate_json_versions.py
@@ -15,7 +15,6 @@ def populate_json_versions(apps, schema):
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("people", "0020_add_json_versions")]
 
     operations = [

--- a/ynr/apps/people/migrations/0022_rename_json_versions_field.py
+++ b/ynr/apps/people/migrations/0022_rename_json_versions_field.py
@@ -4,7 +4,6 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("people", "0021_populate_json_versions")]
 
     operations = [

--- a/ynr/apps/people/migrations/0023_add_search_vector_field.py
+++ b/ynr/apps/people/migrations/0023_add_search_vector_field.py
@@ -6,7 +6,6 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("people", "0022_rename_json_versions_field")]
 
     operations = [

--- a/ynr/apps/people/migrations/0024_add_gist_index_for_search.py
+++ b/ynr/apps/people/migrations/0024_add_gist_index_for_search.py
@@ -6,7 +6,6 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("people", "0023_add_search_vector_field")]
 
     operations = [

--- a/ynr/apps/people/migrations/0025_add_name_search_trigger.py
+++ b/ynr/apps/people/migrations/0025_add_name_search_trigger.py
@@ -5,7 +5,6 @@ from people.managers import NAME_SEARCH_TRIGGER_SQL
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("people", "0024_add_gist_index_for_search")]
 
     operations = [migrations.RunSQL(NAME_SEARCH_TRIGGER_SQL)]

--- a/ynr/apps/people/migrations/0026_add_person_name_synonym.py
+++ b/ynr/apps/people/migrations/0026_add_person_name_synonym.py
@@ -7,7 +7,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("people", "0025_add_name_search_trigger")]
 
     operations = [

--- a/ynr/apps/people/migrations/0027_auto_20210401_0811.py
+++ b/ynr/apps/people/migrations/0027_auto_20210401_0811.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("people", "0026_add_person_name_synonym")]
 
     operations = [

--- a/ynr/apps/people/migrations/0028_add_default_to_extra_data.py
+++ b/ynr/apps/people/migrations/0028_add_default_to_extra_data.py
@@ -5,7 +5,6 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("people", "0027_auto_20210401_0811")]
 
     operations = [

--- a/ynr/apps/people/migrations/0029_default_versions_to_list.py
+++ b/ynr/apps/people/migrations/0029_default_versions_to_list.py
@@ -5,7 +5,6 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("people", "0028_add_default_to_extra_data")]
 
     operations = [

--- a/ynr/apps/people/migrations/0030_auto_20210616_1642.py
+++ b/ynr/apps/people/migrations/0030_auto_20210616_1642.py
@@ -6,7 +6,6 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("people", "0029_default_versions_to_list")]
 
     operations = [

--- a/ynr/apps/people/migrations/0031_copy_created.py
+++ b/ynr/apps/people/migrations/0031_copy_created.py
@@ -18,7 +18,6 @@ def copy_created(apps, schema_editor):
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("people", "0030_auto_20210616_1642")]
 
     operations = [

--- a/ynr/apps/people/migrations/0032_auto_20210616_1700.py
+++ b/ynr/apps/people/migrations/0032_auto_20210616_1700.py
@@ -4,7 +4,6 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("people", "0031_copy_created")]
 
     operations = [

--- a/ynr/apps/people/migrations/0033_auto_20210928_1007.py
+++ b/ynr/apps/people/migrations/0033_auto_20210928_1007.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("people", "0032_auto_20210616_1700")]
 
     operations = [

--- a/ynr/apps/people/migrations/0034_get_birth_year.py
+++ b/ynr/apps/people/migrations/0034_get_birth_year.py
@@ -12,7 +12,6 @@ def get_birth_year(apps, schema_editor):
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("people", "0033_auto_20210928_1007")]
 
     operations = [

--- a/ynr/apps/people/migrations/0035_alter_person_birth_date.py
+++ b/ynr/apps/people/migrations/0035_alter_person_birth_date.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("people", "0034_get_birth_year")]
 
     operations = [

--- a/ynr/apps/people/migrations/0036_delete_non_primary_images.py
+++ b/ynr/apps/people/migrations/0036_delete_non_primary_images.py
@@ -22,7 +22,6 @@ def delete_non_primary_images(apps, schema_editor):
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("people", "0035_alter_person_birth_date")]
 
     operations = [

--- a/ynr/apps/people/migrations/0037_alter_personimage_person.py
+++ b/ynr/apps/people/migrations/0037_alter_personimage_person.py
@@ -5,7 +5,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("people", "0036_delete_non_primary_images")]
 
     operations = [

--- a/ynr/apps/people/migrations/0038_remove_personimage_is_primary.py
+++ b/ynr/apps/people/migrations/0038_remove_personimage_is_primary.py
@@ -4,7 +4,6 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("people", "0037_alter_personimage_person")]
 
     operations = [

--- a/ynr/apps/people/migrations/0039_auto_20220428_1635.py
+++ b/ynr/apps/people/migrations/0039_auto_20220428_1635.py
@@ -5,7 +5,6 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("people", "0038_remove_personimage_is_primary")]
 
     operations = [

--- a/ynr/apps/people/migrations/0040_auto_20220511_1222.py
+++ b/ynr/apps/people/migrations/0040_auto_20220511_1222.py
@@ -16,7 +16,6 @@ def populate_version_fields(apps, schema):
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("people", "0039_auto_20220428_1635")]
 
     operations = []

--- a/ynr/apps/people/migrations/0041_add_person_name_edit_permissions.py
+++ b/ynr/apps/people/migrations/0041_add_person_name_edit_permissions.py
@@ -7,7 +7,6 @@ from people.models import TRUSTED_TO_EDIT_NAME
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("people", "0040_auto_20220511_1222")]
 
     operations = [

--- a/ynr/apps/people/tests/test_forms.py
+++ b/ynr/apps/people/tests/test_forms.py
@@ -23,7 +23,6 @@ class TestPersonMembershipForm(
             mock.assert_called_once()
 
     def test_show_previous_party_affiliations(self):
-
         # test without a membership instance
         form = PersonMembershipForm()
         self.assertFalse(form.show_previous_party_affiliations)

--- a/ynr/apps/people/tests/test_merge_people.py
+++ b/ynr/apps/people/tests/test_merge_people.py
@@ -3,7 +3,6 @@ from django.test import TestCase
 
 
 class TestMergePeople(TestCase):
-
     maxDiff = None
 
     def test_merge_basic_unknown_details(self):

--- a/ynr/apps/people/tests/test_merge_view.py
+++ b/ynr/apps/people/tests/test_merge_view.py
@@ -636,7 +636,6 @@ class TestMergeViewFullyFrontEnd(TestUserMixin, UK2015ExamplesMixin, WebTest):
         self.assertEqual(Person.objects.all().count(), 2)
 
     def test_merging_people(self):
-
         source, dest = Person.objects.all().values_list("pk", flat=True)
 
         response = self.app.get(

--- a/ynr/apps/people/tests/test_merging.py
+++ b/ynr/apps/people/tests/test_merging.py
@@ -628,7 +628,6 @@ class TestMerging(TestUserMixin, UK2015ExamplesMixin, WebTest):
         )
 
     def test_merging_with_gender_guess(self):
-
         GenderGuess.objects.create(gender="M", person=self.source_person)
         merger = PersonMerger(self.dest_person, self.source_person)
         merger.merge()

--- a/ynr/apps/people/tests/test_person_identifiers.py
+++ b/ynr/apps/people/tests/test_person_identifiers.py
@@ -8,7 +8,6 @@ class TestPersonIdentifiers(TestCase):
         self.person = PersonFactory(pk=1)
 
     def test_str(self):
-
         pi = PersonIdentifier.objects.create(
             person=self.person,
             value="democlub",

--- a/ynr/apps/people/tests/test_version_diffs.py
+++ b/ynr/apps/people/tests/test_version_diffs.py
@@ -19,7 +19,6 @@ def tidy_html_whitespace(html):
 
 
 class TestVersionDiffs(UK2015ExamplesMixin, TestCase):
-
     maxDiff = None
 
     def setUp(self):
@@ -964,7 +963,6 @@ class TestVersionDiffs(UK2015ExamplesMixin, TestCase):
 
 
 class TestSingleVersionRendering(UK2015ExamplesMixin, TestCase):
-
     maxDiff = None
 
     def setUp(self):

--- a/ynr/apps/popolo/behaviors/tests/test_behaviors.py
+++ b/ynr/apps/popolo/behaviors/tests/test_behaviors.py
@@ -19,7 +19,8 @@ class DateframeableTests(BehaviorTestCaseMixin):
 
     def test_new_instance_has_valid_dates(self):
         """Test complete or incomplete dates,
-        according to the "^[0-9]{4}(-[0-9]{2}){0,2}$" pattern (incomplete dates)"""
+        according to the "^[0-9]{4}(-[0-9]{2}){0,2}$" pattern (incomplete dates)
+        """
         obj = self.create_instance(start_date="2012-01")
         self.assertRegex(
             obj.start_date,

--- a/ynr/apps/popolo/migrations/0001_initial.py
+++ b/ynr/apps/popolo/migrations/0001_initial.py
@@ -6,7 +6,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("contenttypes", "0001_initial")]
 
     operations = [

--- a/ynr/apps/popolo/migrations/0002_update_models_from_upstream.py
+++ b/ynr/apps/popolo/migrations/0002_update_models_from_upstream.py
@@ -6,7 +6,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("contenttypes", "0001_initial"),
         ("popolo", "0001_initial"),

--- a/ynr/apps/popolo/migrations/0003_move-extra-fields-to-base.py
+++ b/ynr/apps/popolo/migrations/0003_move-extra-fields-to-base.py
@@ -7,7 +7,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("candidates", "0044_remove_membership_fk_to_election"),
         ("popolo", "0002_update_models_from_upstream"),

--- a/ynr/apps/popolo/migrations/0004_move-extra-data-to-base.py
+++ b/ynr/apps/popolo/migrations/0004_move-extra-data-to-base.py
@@ -18,7 +18,6 @@ def add_extra_fields_to_base(apps, schema_editor):
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("popolo", "0003_move-extra-fields-to-base")]
 
     operations = [

--- a/ynr/apps/popolo/migrations/0005_set_post_election_not_null_.py
+++ b/ynr/apps/popolo/migrations/0005_set_post_election_not_null_.py
@@ -7,7 +7,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("popolo", "0004_move-extra-data-to-base")]
 
 

--- a/ynr/apps/popolo/migrations/0006_membership_unique_together.py
+++ b/ynr/apps/popolo/migrations/0006_membership_unique_together.py
@@ -5,7 +5,6 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("popolo", "0005_set_post_election_not_null_")]
 
     operations = [

--- a/ynr/apps/popolo/migrations/0007_python_3_migrations.py
+++ b/ynr/apps/popolo/migrations/0007_python_3_migrations.py
@@ -9,7 +9,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("popolo", "0006_membership_unique_together")]
 
     operations = [

--- a/ynr/apps/popolo/migrations/0008_add_person_extra_fields.py
+++ b/ynr/apps/popolo/migrations/0008_add_person_extra_fields.py
@@ -6,7 +6,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("popolo", "0007_python_3_migrations")]
 
     operations = [

--- a/ynr/apps/popolo/migrations/0009_move_extra_person_data_to_base.py
+++ b/ynr/apps/popolo/migrations/0009_move_extra_person_data_to_base.py
@@ -6,7 +6,6 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("popolo", "0008_add_person_extra_fields")]
 
     operations = [

--- a/ynr/apps/popolo/migrations/0010_rename_not_standing_related_name.py
+++ b/ynr/apps/popolo/migrations/0010_rename_not_standing_related_name.py
@@ -6,7 +6,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("candidates", "0046_delete_person_extra"),
         ("popolo", "0009_move_extra_person_data_to_base"),

--- a/ynr/apps/popolo/migrations/0011_add_post_extra_fields.py
+++ b/ynr/apps/popolo/migrations/0011_add_post_extra_fields.py
@@ -7,7 +7,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("popolo", "0010_rename_not_standing_related_name")]
 
     operations = [

--- a/ynr/apps/popolo/migrations/0012_move_post_extra_data_to_base.py
+++ b/ynr/apps/popolo/migrations/0012_move_post_extra_data_to_base.py
@@ -19,7 +19,6 @@ def add_extra_fields_to_base(apps, schema_editor):
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("candidates", "0048_move_pee_postextra_to_post"),
         ("popolo", "0011_add_post_extra_fields"),

--- a/ynr/apps/popolo/migrations/0013_clean_up_after_postextra_move.py
+++ b/ynr/apps/popolo/migrations/0013_clean_up_after_postextra_move.py
@@ -6,7 +6,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("popolo", "0012_move_post_extra_data_to_base")]
 
     operations = [

--- a/ynr/apps/popolo/migrations/0014_membership_party.py
+++ b/ynr/apps/popolo/migrations/0014_membership_party.py
@@ -7,7 +7,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("parties", "0003_party_ordering"),
         ("popolo", "0013_clean_up_after_postextra_move"),

--- a/ynr/apps/popolo/migrations/0015_move_organization_to_parties.py
+++ b/ynr/apps/popolo/migrations/0015_move_organization_to_parties.py
@@ -113,7 +113,6 @@ def copy_org_to_party(apps, schema_editor):
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("popolo", "0014_membership_party")]
 
     operations = [

--- a/ynr/apps/popolo/migrations/0016_remove_membership_organization.py
+++ b/ynr/apps/popolo/migrations/0016_remove_membership_organization.py
@@ -6,7 +6,6 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("popolo", "0015_move_organization_to_parties")]
 
     operations = [

--- a/ynr/apps/popolo/migrations/0017_remove_membership_on_behalf_of.py
+++ b/ynr/apps/popolo/migrations/0017_remove_membership_on_behalf_of.py
@@ -6,7 +6,6 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("popolo", "0016_remove_membership_organization")]
 
     operations = [

--- a/ynr/apps/popolo/migrations/0018_protect_membership_on_party_deletion.py
+++ b/ynr/apps/popolo/migrations/0018_protect_membership_on_party_deletion.py
@@ -7,7 +7,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("popolo", "0017_remove_membership_on_behalf_of")]
 
     operations = [

--- a/ynr/apps/popolo/migrations/0019_move_organization_extra_fields_to_base.py
+++ b/ynr/apps/popolo/migrations/0019_move_organization_extra_fields_to_base.py
@@ -6,7 +6,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("popolo", "0018_protect_membership_on_party_deletion")]
 
     operations = [

--- a/ynr/apps/popolo/migrations/0020_move_extra_organization_data_to_base.py
+++ b/ynr/apps/popolo/migrations/0020_move_extra_organization_data_to_base.py
@@ -6,7 +6,6 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("popolo", "0019_move_organization_extra_fields_to_base")]
 
     operations = [

--- a/ynr/apps/popolo/migrations/0021_auto_20180918_1534.py
+++ b/ynr/apps/popolo/migrations/0021_auto_20180918_1534.py
@@ -6,7 +6,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("popolo", "0020_move_extra_organization_data_to_base")]
 
     operations = [

--- a/ynr/apps/popolo/migrations/0022_populate_person_image_from_image.py
+++ b/ynr/apps/popolo/migrations/0022_populate_person_image_from_image.py
@@ -6,7 +6,6 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("popolo", "0021_auto_20180918_1534"),
         ("people", "0001_initial"),

--- a/ynr/apps/popolo/migrations/0023_remove_area_model.py
+++ b/ynr/apps/popolo/migrations/0023_remove_area_model.py
@@ -6,7 +6,6 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("popolo", "0022_populate_person_image_from_image")]
 
     operations = [

--- a/ynr/apps/popolo/migrations/0024_remove_person_image.py
+++ b/ynr/apps/popolo/migrations/0024_remove_person_image.py
@@ -6,7 +6,6 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("popolo", "0023_remove_area_model")]
 
     operations = [migrations.RemoveField(model_name="person", name="image")]

--- a/ynr/apps/popolo/migrations/0025_move_person_fk_to_people_app.py
+++ b/ynr/apps/popolo/migrations/0025_move_person_fk_to_people_app.py
@@ -7,7 +7,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("popolo", "0024_remove_person_image"),
         ("people", "0004_move_person_data"),

--- a/ynr/apps/popolo/migrations/0026_remove_stale_models.py
+++ b/ynr/apps/popolo/migrations/0026_remove_stale_models.py
@@ -6,7 +6,6 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("popolo", "0025_move_person_fk_to_people_app"),
         ("uk_results", "0047_auto_20180501_1359"),

--- a/ynr/apps/popolo/migrations/0027_slug_org_unique_together.py
+++ b/ynr/apps/popolo/migrations/0027_slug_org_unique_together.py
@@ -6,7 +6,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("popolo", "0026_remove_stale_models")]
 
     operations = [

--- a/ynr/apps/popolo/migrations/0028_rename_post_election_to_ballot.py
+++ b/ynr/apps/popolo/migrations/0028_rename_post_election_to_ballot.py
@@ -6,7 +6,6 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("people", "0014_remove_person_email"),
         ("candidates", "0058_pee_to_ballot"),

--- a/ynr/apps/popolo/migrations/0029_positive_int_field.py
+++ b/ynr/apps/popolo/migrations/0029_positive_int_field.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("popolo", "0028_rename_post_election_to_ballot")]
 
     operations = [

--- a/ynr/apps/popolo/migrations/0030_remove_duplicate_other_names.py
+++ b/ynr/apps/popolo/migrations/0030_remove_duplicate_other_names.py
@@ -24,7 +24,6 @@ def deduplicate_other_names(apps, schema_editor):
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("popolo", "0029_positive_int_field")]
 
     operations = [

--- a/ynr/apps/popolo/migrations/0031_other_names_unique_constraint.py
+++ b/ynr/apps/popolo/migrations/0031_other_names_unique_constraint.py
@@ -4,7 +4,6 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("contenttypes", "0002_remove_content_type_name"),
         ("popolo", "0030_remove_duplicate_other_names"),

--- a/ynr/apps/popolo/migrations/0032_add_post_identifiers.py
+++ b/ynr/apps/popolo/migrations/0032_add_post_identifiers.py
@@ -7,7 +7,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("popolo", "0031_other_names_unique_constraint")]
 
     operations = [

--- a/ynr/apps/popolo/migrations/0033_unique_on_start_date.py
+++ b/ynr/apps/popolo/migrations/0033_unique_on_start_date.py
@@ -4,7 +4,6 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("popolo", "0032_add_post_identifiers")]
 
     operations = [

--- a/ynr/apps/popolo/migrations/0034_populate_from_ee_divisions.py
+++ b/ynr/apps/popolo/migrations/0034_populate_from_ee_divisions.py
@@ -52,7 +52,6 @@ def update_or_create_post_identifier(post):
 
 
 def populate_from_ee_divisions(apps, schema_editor):
-
     Ballot = apps.get_model("candidates", "Ballot")
     Post = apps.get_model("popolo", "Post")
     with open("data/ee_post_identifiers_2020-01.csv") as f:
@@ -91,7 +90,6 @@ def populate_from_ee_divisions(apps, schema_editor):
 
 
 def populate_from_ee_no_divisions(apps, schema_editor):
-
     Ballot = apps.get_model("candidates", "Ballot")
     Post = apps.get_model("popolo", "Post")
     with open("data/ee_post_identifiers_no_divisions_2020-01.csv") as f:
@@ -136,7 +134,6 @@ def clean_up_tmp_ids(apps, schema_editor):
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("popolo", "0033_unique_on_start_date")]
 
     operations = [

--- a/ynr/apps/popolo/migrations/0035_attach_memberships_to_posts.py
+++ b/ynr/apps/popolo/migrations/0035_attach_memberships_to_posts.py
@@ -12,7 +12,6 @@ def attach_memberships_to_posts(apps, schema_editor):
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("popolo", "0034_populate_from_ee_divisions")]
 
     operations = [

--- a/ynr/apps/popolo/migrations/0036_add_party_name_and_description.py
+++ b/ynr/apps/popolo/migrations/0036_add_party_name_and_description.py
@@ -5,7 +5,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("parties", "0012_add_party_docs"),
         ("popolo", "0035_attach_memberships_to_posts"),

--- a/ynr/apps/popolo/migrations/0037_data_migration_add_party_name.py
+++ b/ynr/apps/popolo/migrations/0037_data_migration_add_party_name.py
@@ -8,7 +8,6 @@ CHANGE_DATE = timezone.datetime(2021, 1, 6).date()
 
 
 def add_party_names(apps, schema_editor):
-
     Membership = apps.get_model("popolo", "Membership")
     for membership in Membership.objects.all().select_related(
         "party", "ballot__election"
@@ -33,7 +32,6 @@ def remove_party_names(apps, schema_editor):
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("popolo", "0036_add_party_name_and_description")]
 
     operations = [

--- a/ynr/apps/popolo/migrations/0038_auto_20210401_0811.py
+++ b/ynr/apps/popolo/migrations/0038_auto_20210401_0811.py
@@ -4,7 +4,6 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("popolo", "0037_data_migration_add_party_name")]
 
     operations = [

--- a/ynr/apps/popolo/migrations/0039_auto_20210616_1642.py
+++ b/ynr/apps/popolo/migrations/0039_auto_20210616_1642.py
@@ -6,7 +6,6 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("popolo", "0038_auto_20210401_0811")]
 
     operations = [

--- a/ynr/apps/popolo/migrations/0040_copy_created.py
+++ b/ynr/apps/popolo/migrations/0040_copy_created.py
@@ -22,7 +22,6 @@ def copy_created(apps, schema_editor):
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("popolo", "0039_auto_20210616_1642")]
 
     operations = [

--- a/ynr/apps/popolo/migrations/0041_auto_20210616_1705.py
+++ b/ynr/apps/popolo/migrations/0041_auto_20210616_1705.py
@@ -4,7 +4,6 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("popolo", "0040_copy_created")]
 
     operations = [

--- a/ynr/apps/popolo/migrations/0042_add_timestamps_to_post.py
+++ b/ynr/apps/popolo/migrations/0042_add_timestamps_to_post.py
@@ -5,7 +5,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("popolo", "0041_auto_20210616_1705")]
 
     operations = [

--- a/ynr/apps/popolo/migrations/0043_alter_membership_elected.py
+++ b/ynr/apps/popolo/migrations/0043_alter_membership_elected.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("popolo", "0042_add_timestamps_to_post")]
 
     operations = [

--- a/ynr/apps/popolo/migrations/0044_add_indexes_to_modified.py
+++ b/ynr/apps/popolo/migrations/0044_add_indexes_to_modified.py
@@ -5,7 +5,6 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("popolo", "0043_alter_membership_elected")]
 
     operations = [

--- a/ynr/apps/popolo/migrations/0045_clean_up_blank_party_names.py
+++ b/ynr/apps/popolo/migrations/0045_clean_up_blank_party_names.py
@@ -12,7 +12,6 @@ def forwards(apps, schema_editor):
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("popolo", "0044_add_indexes_to_modified")]
 
     operations = [

--- a/ynr/apps/popolo/migrations/0046_remove_blank_from_party_name.py
+++ b/ynr/apps/popolo/migrations/0046_remove_blank_from_party_name.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("popolo", "0045_clean_up_blank_party_names")]
 
     operations = [

--- a/ynr/apps/popolo/migrations/0047_membership_previous_party_affiliations.py
+++ b/ynr/apps/popolo/migrations/0047_membership_previous_party_affiliations.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("parties", "0017_alter_party_ec_id"),
         ("popolo", "0046_remove_blank_from_party_name"),

--- a/ynr/apps/popolo/migrations/0048_othername_needs_review.py
+++ b/ynr/apps/popolo/migrations/0048_othername_needs_review.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("popolo", "0047_membership_previous_party_affiliations"),
     ]

--- a/ynr/apps/popolo/models.py
+++ b/ynr/apps/popolo/models.py
@@ -606,6 +606,7 @@ class Language(models.Model):
 ## signals
 ##
 
+
 ## copy founding and dissolution dates into start and end dates,
 ## so that Organization can extend the abstract Dateframeable behavior
 ## (it's way easier than dynamic field names)

--- a/ynr/apps/popolo/querysets.py
+++ b/ynr/apps/popolo/querysets.py
@@ -66,7 +66,6 @@ class PostQuerySet(DateframeableQuerySet):
 
 class MembershipQuerySet(DateframeableQuerySet):
     def for_csv(self):
-
         return (
             self.select_related(
                 "ballot",

--- a/ynr/apps/results/migrations/0001_initial.py
+++ b/ynr/apps/results/migrations/0001_initial.py
@@ -3,7 +3,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [migrations.swappable_dependency(settings.AUTH_USER_MODEL)]
 
     operations = [

--- a/ynr/apps/results/migrations/0002_resultevent_parlparse_id.py
+++ b/ynr/apps/results/migrations/0002_resultevent_parlparse_id.py
@@ -2,7 +2,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("results", "0001_initial")]
 
     operations = [

--- a/ynr/apps/results/migrations/0003_resultevent_post_name.py
+++ b/ynr/apps/results/migrations/0003_resultevent_post_name.py
@@ -2,7 +2,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("results", "0002_resultevent_parlparse_id")]
 
     operations = [

--- a/ynr/apps/results/migrations/0004_resultevent_election.py
+++ b/ynr/apps/results/migrations/0004_resultevent_election.py
@@ -2,7 +2,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("results", "0003_resultevent_post_name")]
 
     operations = [

--- a/ynr/apps/results/migrations/0005_auto_fill_election_and_post_name.py
+++ b/ynr/apps/results/migrations/0005_auto_fill_election_and_post_name.py
@@ -14,7 +14,6 @@ def add_election_and_post_name(apps, schema_editor):
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("results", "0004_resultevent_election")]
 
     operations = [

--- a/ynr/apps/results/migrations/0006_resultevent_winner.py
+++ b/ynr/apps/results/migrations/0006_resultevent_winner.py
@@ -2,7 +2,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("popolo", "0002_update_models_from_upstream"),
         ("results", "0005_auto_fill_election_and_post_name"),

--- a/ynr/apps/results/migrations/0007_update_winner_from_popit_person_id.py
+++ b/ynr/apps/results/migrations/0007_update_winner_from_popit_person_id.py
@@ -23,7 +23,6 @@ def db_to_popit(apps, schema_editor):
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("results", "0006_resultevent_winner")]
 
     operations = [migrations.RunPython(popit_to_db, db_to_popit)]

--- a/ynr/apps/results/migrations/0008_remove_resultevent_winner_popit_person_id.py
+++ b/ynr/apps/results/migrations/0008_remove_resultevent_winner_popit_person_id.py
@@ -2,7 +2,6 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("results", "0007_update_winner_from_popit_person_id")]
 
     operations = [

--- a/ynr/apps/results/migrations/0009_resultevent_election_new.py
+++ b/ynr/apps/results/migrations/0009_resultevent_election_new.py
@@ -2,7 +2,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("elections", "0012_election_people_elected_per_post"),
         ("results", "0008_remove_resultevent_winner_popit_person_id"),

--- a/ynr/apps/results/migrations/0010_resultevent_winner_party_new.py
+++ b/ynr/apps/results/migrations/0010_resultevent_winner_party_new.py
@@ -2,7 +2,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("popolo", "0002_update_models_from_upstream"),
         ("results", "0009_resultevent_election_new"),

--- a/ynr/apps/results/migrations/0011_resultevent_post_new.py
+++ b/ynr/apps/results/migrations/0011_resultevent_post_new.py
@@ -2,7 +2,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("popolo", "0002_update_models_from_upstream"),
         ("results", "0010_resultevent_winner_party_new"),

--- a/ynr/apps/results/migrations/0012_migrate_resultevent_data.py
+++ b/ynr/apps/results/migrations/0012_migrate_resultevent_data.py
@@ -34,7 +34,6 @@ def migrate_remaining_fields_to_popolo_models(apps, schema_editor):
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("results", "0011_resultevent_post_new")]
 
     operations = [

--- a/ynr/apps/results/migrations/0013_remove_old_fields.py
+++ b/ynr/apps/results/migrations/0013_remove_old_fields.py
@@ -2,7 +2,6 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("results", "0012_migrate_resultevent_data")]
 
     operations = [

--- a/ynr/apps/results/migrations/0014_rename_election_new_to_election.py
+++ b/ynr/apps/results/migrations/0014_rename_election_new_to_election.py
@@ -2,7 +2,6 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("results", "0013_remove_old_fields")]
 
     operations = [

--- a/ynr/apps/results/migrations/0015_rename_to_winner_party.py
+++ b/ynr/apps/results/migrations/0015_rename_to_winner_party.py
@@ -2,7 +2,6 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("results", "0014_rename_election_new_to_election")]
 
     operations = [

--- a/ynr/apps/results/migrations/0016_rename_post_id_to_old_post_id.py
+++ b/ynr/apps/results/migrations/0016_rename_post_id_to_old_post_id.py
@@ -2,7 +2,6 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("results", "0015_rename_to_winner_party")]
 
     operations = [

--- a/ynr/apps/results/migrations/0017_rename_post_name_to_old_post_name.py
+++ b/ynr/apps/results/migrations/0017_rename_post_name_to_old_post_name.py
@@ -2,7 +2,6 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("results", "0016_rename_post_id_to_old_post_id")]
 
     operations = [

--- a/ynr/apps/results/migrations/0018_fix_2015_resultevent_winners.py
+++ b/ynr/apps/results/migrations/0018_fix_2015_resultevent_winners.py
@@ -19,7 +19,6 @@ def fix_2015_winners(apps, schema_editor):
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("results", "0017_rename_post_name_to_old_post_name")]
 
     operations = [migrations.RunPython(fix_2015_winners)]

--- a/ynr/apps/results/migrations/0019_rename_post_new_to_post.py
+++ b/ynr/apps/results/migrations/0019_rename_post_new_to_post.py
@@ -2,7 +2,6 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("results", "0018_fix_2015_resultevent_winners")]
 
     operations = [

--- a/ynr/apps/results/migrations/0020_remove_resultevent_proxy_image_url_template.py
+++ b/ynr/apps/results/migrations/0020_remove_resultevent_proxy_image_url_template.py
@@ -2,7 +2,6 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("results", "0019_rename_post_new_to_post")]
 
     operations = [

--- a/ynr/apps/results/migrations/0021_resultevent_retraction.py
+++ b/ynr/apps/results/migrations/0021_resultevent_retraction.py
@@ -2,7 +2,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("results", "0020_remove_resultevent_proxy_image_url_template")
     ]

--- a/ynr/apps/results/migrations/0022_resultevent_winner_party_tmp.py
+++ b/ynr/apps/results/migrations/0022_resultevent_winner_party_tmp.py
@@ -7,7 +7,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("results", "0021_resultevent_retraction"),
         ("parties", "0008_unique_ec_id"),

--- a/ynr/apps/results/migrations/0023_migrate_winner_party_to_party_model.py
+++ b/ynr/apps/results/migrations/0023_migrate_winner_party_to_party_model.py
@@ -33,7 +33,6 @@ def add_tmp_party(apps, schema_editor):
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("results", "0022_resultevent_winner_party_tmp"),
         ("parties", "0008_unique_ec_id"),

--- a/ynr/apps/results/migrations/0024_rename_tmp_field.py
+++ b/ynr/apps/results/migrations/0024_rename_tmp_field.py
@@ -6,7 +6,6 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("results", "0023_migrate_winner_party_to_party_model")]
 
     operations = [

--- a/ynr/apps/results/migrations/0025_winner_party_not_null.py
+++ b/ynr/apps/results/migrations/0025_winner_party_not_null.py
@@ -7,7 +7,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("results", "0024_rename_tmp_field")]
 
     operations = [

--- a/ynr/apps/results/migrations/0026_move_person_fk_to_people_app.py
+++ b/ynr/apps/results/migrations/0026_move_person_fk_to_people_app.py
@@ -7,7 +7,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("results", "0025_winner_party_not_null"),
         ("people", "0004_move_person_data"),

--- a/ynr/apps/results/migrations/0027_alter_resultevent_source.py
+++ b/ynr/apps/results/migrations/0027_alter_resultevent_source.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("results", "0026_move_person_fk_to_people_app")]
 
     operations = [

--- a/ynr/apps/results/tests/test_results.py
+++ b/ynr/apps/results/tests/test_results.py
@@ -12,7 +12,6 @@ from results.models import ResultEvent
 
 
 class XMLEqualityMixin(object):
-
     maxDiff = None
 
     def compare_xml(self, xml_a, xml_b):

--- a/ynr/apps/resultsbot/management/commands/resultsbot_match_elections_for_mg_url.py
+++ b/ynr/apps/resultsbot/management/commands/resultsbot_match_elections_for_mg_url.py
@@ -49,7 +49,6 @@ class Command(BaseCommand):
             data.append((election_id, url))
 
         for election_id, url in data:
-
             if election_id in id_to_url:
                 continue
             print(election_id)

--- a/ynr/apps/sopn_parsing/helpers/extract_pages.py
+++ b/ynr/apps/sopn_parsing/helpers/extract_pages.py
@@ -21,7 +21,7 @@ def extract_pages_for_ballot(ballot):
             election_date=ballot.election.election_date,
         )
         return sopn.match_all_pages()
-    except (NoTextInDocumentError):
+    except NoTextInDocumentError:
         raise NoTextInDocumentError(
             f"Failed to extract pages for {ballot.sopn.uploaded_file.path} as a NoTextInDocumentError was raised"
         )

--- a/ynr/apps/sopn_parsing/management/commands/sopn_parsing_parse_tables.py
+++ b/ynr/apps/sopn_parsing/management/commands/sopn_parsing_parse_tables.py
@@ -44,7 +44,6 @@ class Command(BaseSOPNParsingCommand):
         return filter_kwargs
 
     def handle(self, *args, **options):
-
         # filters that we never change with args. These two would raise
         # ValueErrors in the parse_raw_data_for_ballot function
         base_qs = self.get_queryset(options)

--- a/ynr/apps/sopn_parsing/management/commands/sopn_tooling_compare_raw_people.py
+++ b/ynr/apps/sopn_parsing/management/commands/sopn_tooling_compare_raw_people.py
@@ -12,7 +12,6 @@ from sopn_parsing.models import ParsedSOPN
 
 
 class Command(BaseSOPNParsingCommand):
-
     CORRECT_EXACTLY = "correct_exactly"
     NUM_CORRECT_MISSING_PARTIES = "num_correct_some_parties_missing"
     NUM_INCORRECT = "num_incorrect"
@@ -107,7 +106,6 @@ class Command(BaseSOPNParsingCommand):
             )
 
     def compare_raw_people(self, ballot, ballot_data):
-
         try:
             raw_people = ballot.rawpeople.data
         except RawPeople.DoesNotExist:

--- a/ynr/apps/sopn_parsing/migrations/0001_initial.py
+++ b/ynr/apps/sopn_parsing/migrations/0001_initial.py
@@ -9,7 +9,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     initial = True
 
     dependencies = [("official_documents", "0024_add_relevant_pages")]

--- a/ynr/apps/sopn_parsing/tests/test_extract_page_numbers.py
+++ b/ynr/apps/sopn_parsing/tests/test_extract_page_numbers.py
@@ -18,7 +18,6 @@ from sopn_parsing.tests import should_skip_pdf_tests
 
 @skipIf(should_skip_pdf_tests(), "Required PDF libs not installed")
 class TestSOPNHelpers(UK2015ExamplesMixin, TestCase):
-
     example_docx_filename = EXAMPLE_DOCX_FILENAME
     example_html_filename = EXAMPLE_HTML_FILENAME
     example_image_filename = EXAMPLE_IMAGE_FILENAME

--- a/ynr/apps/sopn_parsing/tests/test_pdf_conversion.py
+++ b/ynr/apps/sopn_parsing/tests/test_pdf_conversion.py
@@ -20,7 +20,6 @@ from sopn_parsing.tests import should_skip_conversion_tests
     should_skip_conversion_tests(), "Required conversion libs not installed"
 )
 class TestSOPNHelpers(UK2015ExamplesMixin, TestCase):
-
     example_docx_filename = EXAMPLE_DOCX_FILENAME
     example_html_filename = EXAMPLE_HTML_FILENAME
     example_image_filename = EXAMPLE_IMAGE_FILENAME

--- a/ynr/apps/twitterbot/management/commands/twitterbot_add_images_to_queue.py
+++ b/ynr/apps/twitterbot/management/commands/twitterbot_add_images_to_queue.py
@@ -17,7 +17,6 @@ def verbose(*args, **kwargs):
 
 
 class Command(BaseCommand):
-
     help = "Add Twitter avatars for candidates without images to the moderation queue"
 
     def add_twitter_image_to_queue(self, person, image_url, user_id):

--- a/ynr/apps/twitterbot/management/commands/twitterbot_update_usernames.py
+++ b/ynr/apps/twitterbot/management/commands/twitterbot_update_usernames.py
@@ -14,7 +14,6 @@ def verbose(*args, **kwargs):
 
 
 class Command(BaseCommand):
-
     help = (
         "Use the Twitter API to check / fix Twitter screen names and user IDs"
     )
@@ -43,7 +42,6 @@ class Command(BaseCommand):
                 )
 
                 if user_id not in self.twitter_data.user_id_to_screen_name:
-
                     # user ID not in our list our prefertched twitter_data but
                     # before we delete them do a check to see if they were
                     # suspended
@@ -111,7 +109,6 @@ class Command(BaseCommand):
                     screen_name.lower()
                     not in self.twitter_data.screen_name_to_user_id
                 ):
-
                     # at this point we have a screen name stored but it is not
                     # in the `twitter_data` with valid names and ID's so we do a
                     # final check to see if the user is currently suspended

--- a/ynr/apps/twitterbot/management/twitter.py
+++ b/ynr/apps/twitterbot/management/twitter.py
@@ -17,7 +17,6 @@ def none_found_error(parsed_result):
 
 
 class TwitterAPIData(object):
-
     MAX_IN_A_REQUEST = 100
 
     def __init__(self):

--- a/ynr/apps/twitterbot/migrations/0001_initial.py
+++ b/ynr/apps/twitterbot/migrations/0001_initial.py
@@ -11,7 +11,6 @@ def create_user(apps, schema_editor):
 
 
 class Migration(migrations.Migration):
-
     dependencies = []
 
     operations = [migrations.RunPython(create_user, migrations.RunPython.noop)]

--- a/ynr/apps/twitterbot/tests/test_twitter_queue_images_command.py
+++ b/ynr/apps/twitterbot/tests/test_twitter_queue_images_command.py
@@ -16,7 +16,6 @@ from people.tests.factories import PersonFactory
     "twitterbot.management.commands.twitterbot_add_images_to_queue.TwitterAPIData"
 )
 class TestTwitterImageQueueCommand(TestUserMixin, TestCase):
-
     maxDiff = None
 
     def setUp(self):
@@ -102,7 +101,6 @@ class TestTwitterImageQueueCommand(TestUserMixin, TestCase):
         )
 
     def test_command(self, mock_twitter_data, mock_requests):
-
         mock_twitter_data.return_value.user_id_to_photo_url = {
             "1001": "https://pbs.twimg.com/profile_images/abc/foo.jpg",
             "1002": "https://pbs.twimg.com/profile_images/def/bar.jpg",
@@ -199,7 +197,6 @@ class TestTwitterImageQueueCommand(TestUserMixin, TestCase):
     def test_only_enqueue_from_200_status_code(
         self, mock_twitter_data, mock_requests
     ):
-
         mock_twitter_data.return_value.user_id_to_photo_url = {
             "1001": "https://pbs.twimg.com/profile_images/abc/foo.jpg",
             "1002": "https://pbs.twimg.com/profile_images/def/bar.jpg",
@@ -247,7 +244,6 @@ class TestTwitterImageQueueCommand(TestUserMixin, TestCase):
     def test_only_enqueue_files_that_seem_to_be_images(
         self, mock_twitter_data, mock_requests
     ):
-
         mock_twitter_data.return_value.user_id_to_photo_url = {
             "1001": "https://pbs.twimg.com/profile_images/abc/foo.jpg",
             "1002": "https://pbs.twimg.com/profile_images/def/bar.jpg",

--- a/ynr/apps/twitterbot/tests/test_twitter_update_usernames_command.py
+++ b/ynr/apps/twitterbot/tests/test_twitter_update_usernames_command.py
@@ -74,7 +74,6 @@ class TestUpdateTwitterUsernamesCommand(TestUserMixin, TestCase):
 
     @override_settings(TWITTER_APP_ONLY_BEARER_TOKEN="madeuptoken")
     def test_commmand_verbose_output(self, mock_requests):
-
         mock_requests.post.side_effect = fake_post_for_username_updater
 
         with capture_output() as (out, err):
@@ -95,7 +94,6 @@ class TestUpdateTwitterUsernamesCommand(TestUserMixin, TestCase):
 
     @override_settings(TWITTER_APP_ONLY_BEARER_TOKEN="madeuptoken")
     def test_commmand_adds_screen_name(self, mock_requests):
-
         mock_requests.post.side_effect = fake_post_for_username_updater
 
         with capture_output() as (out, err):
@@ -118,7 +116,6 @@ class TestUpdateTwitterUsernamesCommand(TestUserMixin, TestCase):
 
     @override_settings(TWITTER_APP_ONLY_BEARER_TOKEN="madeuptoken")
     def test_commmand_adds_user_id(self, mock_requests):
-
         mock_requests.post.side_effect = fake_post_for_username_updater
 
         with capture_output() as (out, err):

--- a/ynr/apps/uk_results/management/commands/import_2010_parl_results.py
+++ b/ynr/apps/uk_results/management/commands/import_2010_parl_results.py
@@ -11,7 +11,6 @@ from uk_results.helpers import RecordBallotResultsHelper, read_csv_from_url
 
 
 class Command(BaseCommand):
-
     EDGECASES = {
         "ynys mon": "ynys môn",
         "down south": "south down",
@@ -83,7 +82,6 @@ class Command(BaseCommand):
         return None
 
     def create_results(self, ballot, candidates):
-
         if ballot.membership_set.count() != len(candidates):
             return self.stdout.write(
                 "Incorrect number of candidates for ballot, skipping"

--- a/ynr/apps/uk_results/management/commands/uk_results_create_file.py
+++ b/ynr/apps/uk_results/management/commands/uk_results_create_file.py
@@ -55,7 +55,6 @@ class Command(BaseCommand):
         )
         out_data = []
         for result in qs:
-
             for membership in result.ballot.membership_set.all():
                 if not hasattr(membership, "result"):
                     continue

--- a/ynr/apps/uk_results/management/commands/uk_results_mark_uncontested.py
+++ b/ynr/apps/uk_results/management/commands/uk_results_mark_uncontested.py
@@ -3,7 +3,6 @@ from django.core.management.base import BaseCommand
 
 
 class Command(BaseCommand):
-
     help = """
     Find and mark any uncontested ballots not already marked after ballot lock
     """

--- a/ynr/apps/uk_results/migrations/0001_initial.py
+++ b/ynr/apps/uk_results/migrations/0001_initial.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("popolo", "0002_update_models_from_upstream"),
         migrations.swappable_dependency(settings.AUTH_USER_MODEL),

--- a/ynr/apps/uk_results/migrations/0002_auto_20160425_2110.py
+++ b/ynr/apps/uk_results/migrations/0002_auto_20160425_2110.py
@@ -3,7 +3,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("popolo", "0002_update_models_from_upstream"),
         ("elections", "0012_election_people_elected_per_post"),

--- a/ynr/apps/uk_results/migrations/0003_auto_20160425_2151.py
+++ b/ynr/apps/uk_results/migrations/0003_auto_20160425_2151.py
@@ -2,7 +2,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("uk_results", "0002_auto_20160425_2110")]
 
     operations = [

--- a/ynr/apps/uk_results/migrations/0004_councilelection_party_set.py
+++ b/ynr/apps/uk_results/migrations/0004_councilelection_party_set.py
@@ -2,7 +2,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("candidates", "0030_merge"),
         ("uk_results", "0003_auto_20160425_2151"),

--- a/ynr/apps/uk_results/migrations/0005_auto_20160426_1058.py
+++ b/ynr/apps/uk_results/migrations/0005_auto_20160426_1058.py
@@ -3,7 +3,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         migrations.swappable_dependency(settings.AUTH_USER_MODEL),
         ("uk_results", "0004_councilelection_party_set"),

--- a/ynr/apps/uk_results/migrations/0006_add_admin_persmissions.py
+++ b/ynr/apps/uk_results/migrations/0006_add_admin_persmissions.py
@@ -15,7 +15,6 @@ except ImportError:
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("uk_results", "0005_auto_20160426_1058")]
 
     operations = [

--- a/ynr/apps/uk_results/migrations/0007_councilelectionresultset_noc.py
+++ b/ynr/apps/uk_results/migrations/0007_councilelectionresultset_noc.py
@@ -2,7 +2,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("uk_results", "0006_add_admin_persmissions")]
 
     operations = [

--- a/ynr/apps/uk_results/migrations/0008_auto_20160426_1629.py
+++ b/ynr/apps/uk_results/migrations/0008_auto_20160426_1629.py
@@ -2,7 +2,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("uk_results", "0007_councilelectionresultset_noc")]
 
     operations = [

--- a/ynr/apps/uk_results/migrations/0009_auto_20160427_0858.py
+++ b/ynr/apps/uk_results/migrations/0009_auto_20160427_0858.py
@@ -3,7 +3,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         migrations.swappable_dependency(settings.AUTH_USER_MODEL),
         ("uk_results", "0008_auto_20160426_1629"),

--- a/ynr/apps/uk_results/migrations/0010_auto_20160427_0926.py
+++ b/ynr/apps/uk_results/migrations/0010_auto_20160427_0926.py
@@ -3,7 +3,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         migrations.swappable_dependency(settings.AUTH_USER_MODEL),
         ("uk_results", "0009_auto_20160427_0858"),

--- a/ynr/apps/uk_results/migrations/0011_auto_20160427_1305.py
+++ b/ynr/apps/uk_results/migrations/0011_auto_20160427_1305.py
@@ -2,7 +2,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("popolo", "0002_update_models_from_upstream"),
         ("uk_results", "0010_auto_20160427_0926"),

--- a/ynr/apps/uk_results/migrations/0012_auto_20160427_1339.py
+++ b/ynr/apps/uk_results/migrations/0012_auto_20160427_1339.py
@@ -2,7 +2,6 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("uk_results", "0011_auto_20160427_1305")]
 
     operations = [

--- a/ynr/apps/uk_results/migrations/0013_auto_20160427_1410.py
+++ b/ynr/apps/uk_results/migrations/0013_auto_20160427_1410.py
@@ -3,7 +3,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         migrations.swappable_dependency(settings.AUTH_USER_MODEL),
         ("uk_results", "0012_auto_20160427_1339"),

--- a/ynr/apps/uk_results/migrations/0014_auto_20160427_1429.py
+++ b/ynr/apps/uk_results/migrations/0014_auto_20160427_1429.py
@@ -2,7 +2,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("popolo", "0002_update_models_from_upstream"),
         ("uk_results", "0013_auto_20160427_1410"),

--- a/ynr/apps/uk_results/migrations/0015_auto_20160428_0805.py
+++ b/ynr/apps/uk_results/migrations/0015_auto_20160428_0805.py
@@ -2,7 +2,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("elections", "0012_election_people_elected_per_post"),
         ("uk_results", "0014_auto_20160427_1429"),

--- a/ynr/apps/uk_results/migrations/0016_auto_20160429_0938.py
+++ b/ynr/apps/uk_results/migrations/0016_auto_20160429_0938.py
@@ -2,7 +2,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("popolo", "0002_update_models_from_upstream"),
         ("uk_results", "0015_auto_20160428_0805"),

--- a/ynr/apps/uk_results/migrations/0018_electionarea_noc.py
+++ b/ynr/apps/uk_results/migrations/0018_electionarea_noc.py
@@ -2,7 +2,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("uk_results", "0017_auto_20160429_0938")]
 
     operations = [

--- a/ynr/apps/uk_results/migrations/0019_councilelection_confirming_result_set.py
+++ b/ynr/apps/uk_results/migrations/0019_councilelection_confirming_result_set.py
@@ -2,7 +2,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("uk_results", "0018_electionarea_noc")]
 
     operations = [

--- a/ynr/apps/uk_results/migrations/0020_auto_20160503_1920.py
+++ b/ynr/apps/uk_results/migrations/0020_auto_20160503_1920.py
@@ -2,7 +2,6 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("uk_results", "0019_councilelection_confirming_result_set")
     ]

--- a/ynr/apps/uk_results/migrations/0021_auto_20160503_1923.py
+++ b/ynr/apps/uk_results/migrations/0021_auto_20160503_1923.py
@@ -2,7 +2,6 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("uk_results", "0020_auto_20160503_1920")]
 
     operations = [

--- a/ynr/apps/uk_results/migrations/0022_postresult_confirmed_resultset.py
+++ b/ynr/apps/uk_results/migrations/0022_postresult_confirmed_resultset.py
@@ -2,7 +2,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("uk_results", "0021_auto_20160503_1923")]
 
     operations = [

--- a/ynr/apps/uk_results/migrations/0023_auto_20160505_1636.py
+++ b/ynr/apps/uk_results/migrations/0023_auto_20160505_1636.py
@@ -2,7 +2,6 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("uk_results", "0022_postresult_confirmed_resultset")]
 
     operations = [

--- a/ynr/apps/uk_results/migrations/0024_auto_20160505_2334.py
+++ b/ynr/apps/uk_results/migrations/0024_auto_20160505_2334.py
@@ -2,7 +2,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("uk_results", "0023_auto_20160505_1636")]
 
     operations = [

--- a/ynr/apps/uk_results/migrations/0025_minus-1-to-null-on-num-fields.py
+++ b/ynr/apps/uk_results/migrations/0025_minus-1-to-null-on-num-fields.py
@@ -12,7 +12,6 @@ def move_minus_one_to_null(apps, schema_editor):
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("uk_results", "0024_auto_20160505_2334")]
 
     operations = [migrations.RunPython(move_minus_one_to_null)]

--- a/ynr/apps/uk_results/migrations/0026_auto_20170130_1541.py
+++ b/ynr/apps/uk_results/migrations/0026_auto_20170130_1541.py
@@ -2,7 +2,6 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("uk_results", "0025_minus-1-to-null-on-num-fields")]
 
     operations = [

--- a/ynr/apps/uk_results/migrations/0027_auto_20170502_2130.py
+++ b/ynr/apps/uk_results/migrations/0027_auto_20170502_2130.py
@@ -2,7 +2,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("uk_results", "0026_auto_20170130_1541")]
 
     operations = [

--- a/ynr/apps/uk_results/migrations/0028_auto_20170503_1633.py
+++ b/ynr/apps/uk_results/migrations/0028_auto_20170503_1633.py
@@ -2,7 +2,6 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("uk_results", "0027_auto_20170502_2130")]
 
     operations = [

--- a/ynr/apps/uk_results/migrations/0029_add_postresult_post_election.py
+++ b/ynr/apps/uk_results/migrations/0029_add_postresult_post_election.py
@@ -2,7 +2,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("candidates", "0032_migrate_org_slugs"),
         ("uk_results", "0028_auto_20170503_1633"),

--- a/ynr/apps/uk_results/migrations/0030_populate_postresult_post_election.py
+++ b/ynr/apps/uk_results/migrations/0030_populate_postresult_post_election.py
@@ -72,7 +72,6 @@ def set_post_election_from_post(apps, schema_editor):
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("uk_results", "0029_add_postresult_post_election")]
 
     operations = [migrations.RunPython(set_post_election_from_post)]

--- a/ynr/apps/uk_results/migrations/0031_remove_postresult_post.py
+++ b/ynr/apps/uk_results/migrations/0031_remove_postresult_post.py
@@ -2,7 +2,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("uk_results", "0030_populate_postresult_post_election")]
 
     operations = [

--- a/ynr/apps/uk_results/migrations/0032_rename_postresult_to_postelectionresult.py
+++ b/ynr/apps/uk_results/migrations/0032_rename_postresult_to_postelectionresult.py
@@ -2,7 +2,6 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("uk_results", "0031_remove_postresult_post")]
 
     operations = [migrations.RenameModel("PostResult", "PostElectionResult")]

--- a/ynr/apps/uk_results/migrations/0033_auto_20170506_2042.py
+++ b/ynr/apps/uk_results/migrations/0033_auto_20170506_2042.py
@@ -2,7 +2,6 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("uk_results", "0032_rename_postresult_to_postelectionresult")
     ]

--- a/ynr/apps/uk_results/migrations/0034_auto_20180130_1243.py
+++ b/ynr/apps/uk_results/migrations/0034_auto_20180130_1243.py
@@ -5,7 +5,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("uk_results", "0033_auto_20170506_2042")]
 
     operations = [

--- a/ynr/apps/uk_results/migrations/0035_auto_20180406_1555.py
+++ b/ynr/apps/uk_results/migrations/0035_auto_20180406_1555.py
@@ -5,7 +5,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("uk_results", "0034_auto_20180130_1243")]
 
     operations = [

--- a/ynr/apps/uk_results/migrations/0036_auto_20180424_1926.py
+++ b/ynr/apps/uk_results/migrations/0036_auto_20180424_1926.py
@@ -5,7 +5,6 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("uk_results", "0035_auto_20180406_1555")]
 
     operations = [

--- a/ynr/apps/uk_results/migrations/0037_delete_rejected_data.py
+++ b/ynr/apps/uk_results/migrations/0037_delete_rejected_data.py
@@ -10,7 +10,6 @@ def delete_rejected_results(apps, schema_editor):
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("uk_results", "0036_auto_20180424_1926")]
 
     operations = [

--- a/ynr/apps/uk_results/migrations/0038_auto_20180424_1949.py
+++ b/ynr/apps/uk_results/migrations/0038_auto_20180424_1949.py
@@ -5,7 +5,6 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("uk_results", "0037_delete_rejected_data")]
 
     operations = [

--- a/ynr/apps/uk_results/migrations/0039_resultset_post_election.py
+++ b/ynr/apps/uk_results/migrations/0039_resultset_post_election.py
@@ -6,7 +6,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("candidates", "0041_auto_20180323_1400"),
         ("uk_results", "0038_auto_20180424_1949"),

--- a/ynr/apps/uk_results/migrations/0040_add_pee_to_resultset.py
+++ b/ynr/apps/uk_results/migrations/0040_add_pee_to_resultset.py
@@ -32,7 +32,6 @@ def remove_duplicate_resultsets(apps, schema_editor):
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("uk_results", "0039_resultset_post_election")]
 
     operations = [

--- a/ynr/apps/uk_results/migrations/0041_auto_20180424_2049.py
+++ b/ynr/apps/uk_results/migrations/0041_auto_20180424_2049.py
@@ -6,7 +6,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("uk_results", "0040_add_pee_to_resultset")]
 
     operations = [

--- a/ynr/apps/uk_results/migrations/0042_auto_20180424_2053.py
+++ b/ynr/apps/uk_results/migrations/0042_auto_20180424_2053.py
@@ -5,7 +5,6 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("uk_results", "0041_auto_20180424_2049")]
 
     operations = [

--- a/ynr/apps/uk_results/migrations/0043_auto_20180424_2148.py
+++ b/ynr/apps/uk_results/migrations/0043_auto_20180424_2148.py
@@ -6,7 +6,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("uk_results", "0042_auto_20180424_2053")]
 
     operations = [

--- a/ynr/apps/uk_results/migrations/0044_auto_20180424_2149.py
+++ b/ynr/apps/uk_results/migrations/0044_auto_20180424_2149.py
@@ -5,7 +5,6 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("uk_results", "0043_auto_20180424_2148")]
 
     operations = [

--- a/ynr/apps/uk_results/migrations/0045_auto_20180424_2150.py
+++ b/ynr/apps/uk_results/migrations/0045_auto_20180424_2150.py
@@ -5,7 +5,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("uk_results", "0044_auto_20180424_2149")]
 
     operations = [

--- a/ynr/apps/uk_results/migrations/0046_auto_20180501_1052.py
+++ b/ynr/apps/uk_results/migrations/0046_auto_20180501_1052.py
@@ -6,7 +6,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("uk_results", "0045_auto_20180424_2150")]
 
     operations = [

--- a/ynr/apps/uk_results/migrations/0047_auto_20180501_1359.py
+++ b/ynr/apps/uk_results/migrations/0047_auto_20180501_1359.py
@@ -6,7 +6,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("uk_results", "0046_auto_20180501_1052")]
 
     operations = [

--- a/ynr/apps/uk_results/migrations/0048_rename_post_election_fk_to_ballot.py
+++ b/ynr/apps/uk_results/migrations/0048_rename_post_election_fk_to_ballot.py
@@ -6,7 +6,6 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("uk_results", "0047_auto_20180501_1359")]
 
     operations = [

--- a/ynr/apps/uk_results/migrations/0049_positive_int_field.py
+++ b/ynr/apps/uk_results/migrations/0049_positive_int_field.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("uk_results", "0048_rename_post_election_fk_to_ballot")]
 
     operations = [

--- a/ynr/apps/uk_results/migrations/0050_candidateresult_tied_vote_winner.py
+++ b/ynr/apps/uk_results/migrations/0050_candidateresult_tied_vote_winner.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("uk_results", "0049_positive_int_field")]
 
     operations = [

--- a/ynr/apps/uk_results/migrations/0051_resultset_total_electorate.py
+++ b/ynr/apps/uk_results/migrations/0051_resultset_total_electorate.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("uk_results", "0050_candidateresult_tied_vote_winner")]
 
     operations = [

--- a/ynr/apps/uk_results/migrations/0052_add_turnout_percentage.py
+++ b/ynr/apps/uk_results/migrations/0052_add_turnout_percentage.py
@@ -5,7 +5,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("uk_results", "0051_resultset_total_electorate")]
 
     operations = [

--- a/ynr/apps/uk_results/migrations/0053_auto_20210928_1007.py
+++ b/ynr/apps/uk_results/migrations/0053_auto_20210928_1007.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("uk_results", "0052_add_turnout_percentage")]
 
     operations = [

--- a/ynr/apps/uk_results/migrations/0054_update_is_winner_to_elected.py
+++ b/ynr/apps/uk_results/migrations/0054_update_is_winner_to_elected.py
@@ -31,7 +31,6 @@ def backwards(apps, schema_editor):
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("uk_results", "0053_auto_20210928_1007")]
 
     operations = [migrations.RunPython(code=forwards, reverse_code=backwards)]

--- a/ynr/apps/uk_results/migrations/0055_migrate_is_winner_to_elected.py
+++ b/ynr/apps/uk_results/migrations/0055_migrate_is_winner_to_elected.py
@@ -34,7 +34,6 @@ def backwards(apps, schema_editor):
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("uk_results", "0054_update_is_winner_to_elected")]
 
     operations = [migrations.RunPython(code=forwards, reverse_code=backwards)]

--- a/ynr/apps/uk_results/migrations/0056_remove_candidateresult_is_winner.py
+++ b/ynr/apps/uk_results/migrations/0056_remove_candidateresult_is_winner.py
@@ -4,7 +4,6 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("uk_results", "0055_migrate_is_winner_to_elected")]
 
     operations = [

--- a/ynr/apps/uk_results/migrations/0057_candidateresult_rank.py
+++ b/ynr/apps/uk_results/migrations/0057_candidateresult_rank.py
@@ -4,7 +4,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     dependencies = [
         ("uk_results", "0056_remove_candidateresult_is_winner"),
     ]

--- a/ynr/apps/wombles/managers.py
+++ b/ynr/apps/wombles/managers.py
@@ -2,5 +2,4 @@ from django.db import models
 
 
 class WombleQuerySet(models.QuerySet):
-
     pass

--- a/ynr/apps/wombles/migrations/0001_initial.py
+++ b/ynr/apps/wombles/migrations/0001_initial.py
@@ -8,7 +8,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     initial = True
 
     dependencies = [migrations.swappable_dependency(settings.AUTH_USER_MODEL)]

--- a/ynr/apps/wombles/migrations/0002_add_initial_profiles.py
+++ b/ynr/apps/wombles/migrations/0002_add_initial_profiles.py
@@ -16,7 +16,6 @@ def add_initial_profiles(apps, schema_editor):
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("wombles", "0001_initial")]
 
     operations = [

--- a/ynr/apps/wombles/migrations/0003_auto_20210401_0811.py
+++ b/ynr/apps/wombles/migrations/0003_auto_20210401_0811.py
@@ -4,7 +4,6 @@ from django.db import migrations
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("wombles", "0002_add_initial_profiles")]
 
     operations = [

--- a/ynr/apps/ynr_refactoring/migrations/0001_initial.py
+++ b/ynr/apps/ynr_refactoring/migrations/0001_initial.py
@@ -8,7 +8,6 @@ from django.db import migrations, models
 
 
 class Migration(migrations.Migration):
-
     initial = True
 
     dependencies = []

--- a/ynr/apps/ynr_refactoring/migrations/0002_move_old_election_slugs.py
+++ b/ynr/apps/ynr_refactoring/migrations/0002_move_old_election_slugs.py
@@ -192,7 +192,6 @@ def update_election_slug(apps, schema_editor):
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("ynr_refactoring", "0001_initial")]
 
     operations = [

--- a/ynr/apps/ynr_refactoring/migrations/0003_move_person_identifiers.py
+++ b/ynr/apps/ynr_refactoring/migrations/0003_move_person_identifiers.py
@@ -28,7 +28,6 @@ def move_person_identifiers(apps, schema_editor):
 
 
 class Migration(migrations.Migration):
-
     dependencies = [("ynr_refactoring", "0002_move_old_election_slugs")]
 
     operations = [

--- a/ynr/apps/ynr_refactoring/views.py
+++ b/ynr/apps/ynr_refactoring/views.py
@@ -42,7 +42,6 @@ class RedirectConstituencyListView(PermanentRedirectView):
     """
 
     def get_redirect_url(self, *args, **kwargs):
-
         election = get_object_or_404(Election, slug=self.kwargs["election"])
         url = election.get_absolute_url()
 
@@ -77,7 +76,6 @@ class RedirectConstituenciesUnlockedView(PermanentRedirectView):
 
 class RedirectConstituencyDetailView(PermanentRedirectView):
     def get_redirect_url(self, *args, **kwargs):
-
         ballot = get_object_or_404(
             Ballot,
             election__slug=self.kwargs["election"],
@@ -93,7 +91,6 @@ class RedirectConstituencyDetailView(PermanentRedirectView):
 
 class RedirectConstituencyDetailCSVView(PermanentRedirectView):
     def get_redirect_url(self, *args, **kwargs):
-
         ballot = get_object_or_404(
             Ballot,
             election__slug=self.kwargs["election"],


### PR DESCRIPTION
Getting the new version of `black` to run required a small formatting change to the config. This PR makes that change, bumps the version and reformats files as needed. 