### PR TITLE
Remove src files from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,7 +26,6 @@ node_modules/
 /test-env
 /ynr/apps/sopn_parsing/tests/data/sopn_baseline.json
 /ynr/apps/sopn_parsing/tests/data/sopn_baseline_copy.json
-/src
 # PyCharm
 .idea/
 


### PR DESCRIPTION
I added `/src` to `.gitignore` while testing `black` changes but committed by mistake. This PR removes that change. 