### PR TITLE
Display candidate count on ballot page

### DIFF
--- a/ynr/apps/candidates/models/popolo_extra.py
+++ b/ynr/apps/candidates/models/popolo_extra.py
@@ -283,6 +283,9 @@ class Ballot(EEModifiedMixin, models.Model):
             return self.get_absolute_url(viewname="ballot_paper_results_form")
         return self.get_absolute_url()
 
+    def num_candidates(self):
+        return self.membership_set.count()
+
     @property
     def results_button_text(self):
         """

--- a/ynr/apps/elections/templates/elections/ballot_view.html
+++ b/ynr/apps/elections/templates/elections/ballot_view.html
@@ -57,9 +57,16 @@
 
     {% if not ballot.candidates_locked and candidates.exists %}
     <div class="panel">
-        <p>These candidates haven't been confirmed by the official "nomination papers"
+        <p>These {{ ballot.num_candidates }} candidates haven't been confirmed by the official "nomination papers"
             from the council yet. This means they might not all end up on the ballot paper.</p>
         <p>We will manually verify each candidate when the nomination papers are published.</p>
+    </div>
+    {% endif %}
+
+    {% if ballot.candidates_locked and candidates.exists %}
+    <div class="panel">
+        <p>These {{ ballot.num_candidates }} candidates have been confirmed by the official "nomination papers"
+            from the council. </p>
     </div>
     {% endif %}
 

--- a/ynr/apps/elections/tests/test_ballot_view.py
+++ b/ynr/apps/elections/tests/test_ballot_view.py
@@ -134,7 +134,7 @@ class TestBallotView(
         self.assertInHTML(
             """
             <p>
-                These candidates haven't been confirmed by the official
+                These 9 candidates haven't been confirmed by the official
                 "nomination papers" from the council yet. This means they might
                 not all end up on the ballot paper.
             </p>
@@ -175,7 +175,7 @@ class TestBallotView(
         )
 
         self.assertEqual(ballot.is_welsh_run, True)
-        with self.assertNumQueries(10):
+        with self.assertNumQueries(11):
             response = self.app.get(ballot.get_absolute_url())
         self.assertNotContains(response, self.old_party.name)
 


### PR DESCRIPTION
Closes https://github.com/DemocracyClub/yournextrepresentative/issues/2002

To test: 

- Find an unlocked ballot and add candidates, as needed.
- Suggest a lock on that ballot. 
- Log out and log back in as another user
- Approve the lock and visit the ballot page to see the text in the second image

Unlocked with candidates 
<img width="760" alt="Screenshot 2023-08-24 at 8 17 35 AM" src="https://github.com/DemocracyClub/yournextrepresentative/assets/7017118/7e9c59cc-dcba-4253-8fd6-28710e6c6a70">

I've added a block when locked with candidates
<img width="1194" alt="Screenshot 2023-08-24 at 8 08 23 AM" src="https://github.com/DemocracyClub/yournextrepresentative/assets/7017118/0263966a-f80e-4d48-9784-947202040552">


```[tasklist]
### PR Checklist
- [x] References a specific issue or if not, describes the bug or feature in detail
- [x] Note what card in Trello this work relates to
- [x] Instructions for how reviewers can test the code locally
- [x] Tests have been added and/or updated
- [x] Screenshot of the feature/bug fix (if applicable)
```


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205303544790831