### PR TITLE
Add date to ballot and election detail pages

### DIFF
--- a/ynr/apps/elections/templates/elections/ballot_view.html
+++ b/ynr/apps/elections/templates/elections/ballot_view.html
@@ -31,10 +31,10 @@
 
 {% block body_class %}constituency{% endblock %}
 
-{% block title %}Candidates for {{ ballot.post.label }} in the {{ ballot.election.name }}{% endblock %}
+{% block title %}Candidates for {{ ballot.post.label }} in the {{ ballot.election.name }} on {{ ballot.election.election_date|date:"j F Y" }}{% endblock %}
 
 {% block hero %}
-  <h1>Candidates for {{ ballot.post.label }}</h1>
+  <h1>Candidates for {{ ballot.post.label }} on <br>{{ ballot.election.election_date|date:"j F Y" }}</h1>
 {% endblock %}
 
 

--- a/ynr/apps/elections/templates/elections/election_detail.html
+++ b/ynr/apps/elections/templates/elections/election_detail.html
@@ -2,9 +2,9 @@
 
 {% block title %}
 {% if ballot.candidates_locked %}
-  Candidates for each ballot in the {{ object.name }}
+  Candidates for each ballot in the {{ object.name }} on {{ object.election_date|date:"j F Y" }}
 {% else %}
-  Known candidates for each ballot in the {{ object.name }}
+  Known candidates for each ballot in the {{ object.name }} on {{ object.election_date|date:"j F Y" }}
 {% endif %}
 {% endblock %}
 
@@ -33,7 +33,7 @@
 
   {% for ballot in ballots %}
   <h3>
-    <a href="{{ ballot.get_absolute_url }}">{{ ballot.post.label }}</a>
+    <a href="{{ ballot.get_absolute_url }}">{{ ballot.post.label }} on {{ object.election_date|date:"j F Y" }}</a>
     {{ ballot.cancelled_status_html }}
     {{ ballot.locked_status_html }}
   </h3>

--- a/ynr/apps/elections/templates/elections/party_for_ballot.html
+++ b/ynr/apps/elections/templates/elections/party_for_ballot.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 {% block body_class %}constituency{% endblock %}
-{% block title %}Candidates for {{ object.post.label }} in the {{ object.election.name }}{% endblock %}
+{% block title %}Candidates for {{ object.post.label }} in the {{ object.election.name }} on {{ ballot.election.election_date|date:"j F Y" }}{% endblock %}
 
 {% block hero %}
   <h1>

--- a/ynr/apps/elections/tests/test_ballot_view.py
+++ b/ynr/apps/elections/tests/test_ballot_view.py
@@ -130,7 +130,10 @@ class TestBallotView(
 
         self.assertEqual(response.context["candidates"].count(), 9)
         self.assertDataTimelineCandidateAddingInProgress(response)
-        self.assertInHTML("<h1>Candidates for Bar Ward</h1>", response.text)
+        self.assertInHTML(
+            "<h1>Candidates for Bar Ward on <br>7 September 2023</h1>",
+            response.text,
+        )
         self.assertInHTML(
             """
             <p>


### PR DESCRIPTION
Ref https://github.com/DemocracyClub/yournextrepresentative/issues/303

To test, visit any locked or unlocked election page and ballot page to see the election date referenced in the header and title details. 

<img width="917" alt="Screenshot 2023-08-24 at 10 16 26 AM" src="https://github.com/DemocracyClub/yournextrepresentative/assets/7017118/67b9954f-b71d-4929-a491-be5310156327">

<img width="1022" alt="Screenshot 2023-08-24 at 10 17 28 AM" src="https://github.com/DemocracyClub/yournextrepresentative/assets/7017118/cf07315a-e3d8-4f5a-a179-bfbdd29ed6e3">


```[tasklist]
### PR Checklist
- [x] References a specific issue or if not, describes the bug or feature in detail
- [x] Note what card in Trello this work relates to
- [x] Instructions for how reviewers can test the code locally
- [x] Tests have been added and/or updated
- [x] Screenshot of the feature/bug fix (if applicable)
- [x] Have I rebased with the latest version of master?
```


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205303544790829