### PR TITLE
Add ballot `results` to ballot serializer

### DIFF
--- a/ynr/apps/api/tests/test_api_next.py
+++ b/ynr/apps/api/tests/test_api_next.py
@@ -11,6 +11,7 @@ from parties.tests.factories import PartyDescriptionFactory, PartyEmblemFactory
 from parties.tests.fixtures import DefaultPartyFixtures
 from people.models import PersonImage
 from people.tests.factories import PersonFactory
+from uk_results.models import ResultSet
 
 
 class TestAPI(
@@ -285,5 +286,44 @@ class TestAPI(
                 "document_type": "Nomination paper",
                 "uploaded_file": None,
                 "source_url": "",
+            },
+        )
+
+    def test_no_results_on_ballot(self):
+        response = self.app.get(
+            "/api/next/ballots/{}/".format(
+                self.edinburgh_east_post_ballot.ballot_paper_id
+            )
+        )
+        result = response.json
+        self.assertEqual(
+            result["results"],
+            None,
+        )
+
+    def test_results_on_ballot(self):
+        ResultSet.objects.create(
+            ballot=self.edinburgh_east_post_ballot,
+            created="2015-05-08T00:00:00Z",
+            modified="2015-05-08T00:00:00Z",
+            source="Example ResultSet for testing",
+            num_spoilt_ballots=100,
+            num_turnout_reported=900,
+            total_electorate=1000,
+        )
+        response = self.app.get(
+            "/api/next/ballots/{}/".format(
+                self.edinburgh_east_post_ballot.ballot_paper_id
+            )
+        )
+        result = response.json
+        self.assertEqual(
+            result["results"],
+            {
+                "num_turnout_reported": 900,
+                "turnout_percentage": 90.0,
+                "num_spoilt_ballots": 100,
+                "source": "Example ResultSet for testing",
+                "total_electorate": 1000,
             },
         )

--- a/ynr/apps/elections/api/next/api_views.py
+++ b/ynr/apps/elections/api/next/api_views.py
@@ -39,7 +39,7 @@ class BallotViewSet(viewsets.ReadOnlyModelViewSet):
     lookup_value_regex = r"(?!\.json$)[^/]+"
     queryset = (
         extra_models.Ballot.objects.select_related(
-            "election", "post", "replaces", "replaced_by"
+            "election", "post", "replaces", "replaced_by", "resultset"
         )
         .prefetch_related(
             Prefetch(

--- a/ynr/apps/elections/api/next/serializers.py
+++ b/ynr/apps/elections/api/next/serializers.py
@@ -9,6 +9,7 @@ from popolo.api.next.serializers import (
     MinimalPostSerializer,
 )
 from rest_framework import serializers
+from uk_results.api.next.serializers import MinimalResultSerializer
 
 
 class MinimalElectionSerializer(serializers.HyperlinkedModelSerializer):
@@ -102,6 +103,7 @@ class BallotSerializer(serializers.HyperlinkedModelSerializer):
             "replaces",
             "replaced_by",
             "uncontested",
+            "results",
         )
 
     replaces = serializers.SlugRelatedField(
@@ -126,6 +128,7 @@ class BallotSerializer(serializers.HyperlinkedModelSerializer):
     post = MinimalPostSerializer(read_only=True)
     sopn = serializers.SerializerMethodField()
     candidacies = serializers.SerializerMethodField()
+    results = MinimalResultSerializer(read_only=True, source="resultset")
 
     results_url = serializers.HyperlinkedIdentityField(
         view_name="resultset-detail",

--- a/ynr/apps/elections/tests/test_ballot_view.py
+++ b/ynr/apps/elections/tests/test_ballot_view.py
@@ -131,7 +131,7 @@ class TestBallotView(
         self.assertEqual(response.context["candidates"].count(), 9)
         self.assertDataTimelineCandidateAddingInProgress(response)
         self.assertInHTML(
-            "<h1>Candidates for Bar Ward on <br>7 September 2023</h1>",
+            f"<h1>Candidates for Bar Ward on <br>{ self.election.election_date.strftime('%d %B %Y') }</h1>",
             response.text,
         )
         self.assertInHTML(

--- a/ynr/apps/official_documents/api/next/serializers.py
+++ b/ynr/apps/official_documents/api/next/serializers.py
@@ -6,3 +6,4 @@ class OfficialDocumentSerializer(serializers.HyperlinkedModelSerializer):
     class Meta:
         model = OfficialDocument
         fields = ("document_type", "uploaded_file", "source_url")
+        ref_name = None  # Tells swagger that this is always embedded

--- a/ynr/apps/uk_results/api/next/serializers.py
+++ b/ynr/apps/uk_results/api/next/serializers.py
@@ -68,6 +68,18 @@ class ResultSerializer(serializers.ModelSerializer):
     candidate_results = CandidateResultSerializer(many=True)
 
 
+class MinimalResultSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = ResultSet
+        fields = (
+            "num_turnout_reported",
+            "turnout_percentage",
+            "num_spoilt_ballots",
+            "source",
+            "total_electorate",
+        )
+
+
 class ElectedSerializer(CandidacyOnBallotSerializer):
     class Meta:
         model = Membership

--- a/ynr/apps/uk_results/api/next/serializers.py
+++ b/ynr/apps/uk_results/api/next/serializers.py
@@ -78,6 +78,7 @@ class MinimalResultSerializer(serializers.ModelSerializer):
             "source",
             "total_electorate",
         )
+        ref_name = None  # Tells swagger that this is always embedded
 
 
 class ElectedSerializer(CandidacyOnBallotSerializer):


### PR DESCRIPTION
Closes https://github.com/DemocracyClub/yournextrepresentative/issues/2172
Related to https://github.com/DemocracyClub/WhoCanIVoteFor/pull/1685
The data I needed was already a part of `results_bot` process and the `ResultSet` model so I just needed to expose it the ballot serializer to be consumed by WCIVF. 

To test, find a locked ballot with results entered or manually enter and lock a ballot. 
Navigate to `http://localhost:8000/api/next/ballots/local.st-albans.marshalswick-east-jersey-farm.by.2023-08-17/?format=json` for example, and you should see data similar to the block below at the **end** of your request: 

`"results": 
{
        "num_turnout_reported": 300,
        "turnout_percentage": 7.5,
        "num_spoilt_ballots": 100,
        "source": "[google.com](http://google.com/)",
        "total_electorate": 4000
    }`

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205303544790826