### PR TITLE
 Biography timestamp should not be updated with non biography edits

### DIFF
--- a/ynr/apps/people/forms/forms.py
+++ b/ynr/apps/people/forms/forms.py
@@ -265,6 +265,7 @@ class BasePersonForm(forms.ModelForm):
             "summary",
             "national_identity",
             "name_search_vector",
+            "biography_last_updated",
         )
 
     honorific_prefix = StrippedCharField(
@@ -366,6 +367,7 @@ class BasePersonForm(forms.ModelForm):
             self.instance.biography_last_updated = self.cleaned_data[
                 "biography_last_updated"
             ]
+
         return super().save(commit)
 
 


### PR DESCRIPTION
Closes https://github.com/DemocracyClub/yournextrepresentative/issues/2196

This change fixes a bug where the `biography_last_updated` timestamp was being set to to `None` following a non biography (aka statement to voters) edit was made. 

To test: 

1. Find a person with a biography and make an edit to the biography or edit a person and add a biography and save. 
2. Make an edit to the same person to any field other than biography. 
3. The timestamp from the original biography edit should still be visible after the second edit. 

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205774500368854