### PR TITLE
Uppercase `party_id` before attempting to get party

### DIFF
--- a/ynr/apps/parties/views.py
+++ b/ynr/apps/parties/views.py
@@ -29,8 +29,8 @@ class CandidatesByElectionForPartyView(TemplateView):
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
-
-        party = Party.objects.get(ec_id=kwargs["party_id"])
+        party_id = kwargs["party_id"].upper()
+        party = Party.objects.get(ec_id=party_id)
 
         candidates_qs = party.membership_set.select_related(
             "ballot", "person", "ballot__post"


### PR DESCRIPTION
Ref https://app.asana.com/0/1204880927741389/1205727090071462/f

This change addresses "party not found" errors in Sentry.