### PR TITLE
Add candidate result rank where rank is None

### DIFF
--- a/ynr/apps/uk_results/migrations/0058_add_candidate_result_rank.py
+++ b/ynr/apps/uk_results/migrations/0058_add_candidate_result_rank.py
@@ -2,14 +2,27 @@ from django.db import migrations
 
 
 def get_candidate_rank(apps, schema_editor):
-    candidate_results = apps.get_model("uk_results", "CandidateResult")
-    results = candidate_results.objects.filter(rank=None).order_by(
-        "-num_ballots"
-    )
-    for index, result in enumerate(results):
-        index = index + 1
-        result.rank = index
-        result.save()
+    """Only update the rank for the candidate results in a
+    given resultset. It's possible that a resultset exists
+    without any candidate results, so we need to check for
+    that first.
+    """
+    candidate_result = apps.get_model("uk_results", "CandidateResult")
+    resultsets = apps.get_model("uk_results", "ResultSet")
+    for resultset in resultsets.objects.all():
+        candidate_results = candidate_result.objects.filter(
+            result_set=resultset
+        ).order_by("-num_ballots")
+
+        if candidate_results.exists():
+            for i, cr in enumerate(candidate_results):
+                if cr.rank is None:
+                    cr.rank = i + 1
+                    cr.save()
+                else:
+                    pass
+        else:
+            pass
 
 
 class Migration(migrations.Migration):

--- a/ynr/apps/uk_results/migrations/0058_add_candidate_result_rank.py
+++ b/ynr/apps/uk_results/migrations/0058_add_candidate_result_rank.py
@@ -1,0 +1,25 @@
+from django.db import migrations
+
+
+def get_candidate_rank(apps, schema_editor):
+    candidate_results = apps.get_model("uk_results", "CandidateResult")
+    results = candidate_results.objects.filter(rank=None).order_by(
+        "-num_ballots"
+    )
+    for index, result in enumerate(results):
+        index = index + 1
+        result.rank = index
+        result.save()
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("uk_results", "0057_candidateresult_rank"),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            get_candidate_rank,
+            migrations.RunPython.noop,
+        ),
+    ]


### PR DESCRIPTION
Ref https://github.com/DemocracyClub/yournextrepresentative/issues/2173

I tested this migration by updating `num_ballots` in the db (rather than in the form where the rank would be automatically set) then running the migration to set rank where it had previously been set to `None`. Rank was updated as expected. 

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1206089991942155