### PR TITLE
Other field changes should not biography_last_updated timestamp

### DIFF
--- a/ynr/apps/people/forms/forms.py
+++ b/ynr/apps/people/forms/forms.py
@@ -361,13 +361,13 @@ class BasePersonForm(forms.ModelForm):
                 user=user,
             )
 
-        if "biography" in self.changed_data:
-            self.cleaned_data[
-                "biography_last_updated"
-            ] = datetime.datetime.now()
-            self.instance.biography_last_updated = self.cleaned_data[
-                "biography_last_updated"
-            ]
+        initial_biography = self.initial.get("biography", None)
+        biography_updated = (
+            "biography" in self.changed_data
+            and initial_biography != self.cleaned_data["biography"]
+        )
+        if biography_updated:
+            self.instance.biography_last_updated = datetime.datetime.now()
 
         return super().save(commit)
 


### PR DESCRIPTION
This change ensures biography time stamp is only be updated with a change in form data in the biography field. 

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1205303544790836