### PR TITLE
Catch exception when photo does not have `fileno`

### DIFF
--- a/ynr/apps/moderation_queue/helpers.py
+++ b/ynr/apps/moderation_queue/helpers.py
@@ -68,7 +68,11 @@ def rotate_photo(original_image):
         if exif and exif.get(274):
             pil_image = ImageOps.exif_transpose(pil_image)
         buffer = BytesIO()
-        pil_image.save(buffer, "PNG")
+        try:
+            pil_image.save(buffer, "PNG")
+        except AttributeError as e:
+            print(f"An error occurred: {e}")
+            continue
     return pil_image
 
 


### PR DESCRIPTION
Closes https://github.com/DemocracyClub/yournextrepresentative/issues/2223

This error may require a refactor of how we handle photo uploads. In the mean time, this changes catches the error and permits the upload to succeed. 