### PR TITLE
Ignore case when looking up parties

### DIFF
--- a/ynr/apps/parties/views.py
+++ b/ynr/apps/parties/views.py
@@ -29,8 +29,8 @@ class CandidatesByElectionForPartyView(TemplateView):
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
-        party_id = kwargs["party_id"].upper()
-        party = Party.objects.get(ec_id=party_id)
+        party_id = kwargs["party_id"]
+        party = Party.objects.get(ec_id__iexact=party_id)
 
         candidates_qs = party.membership_set.select_related(
             "ballot", "person", "ballot__post"


### PR DESCRIPTION
The previous change converted the party ID to uppercase. This broke the 'special' IDs that we use like 'ynmp-party:2'.

This change ignores the case when querying the database.
