### PR TITLE
Reduce time and errors on photo uploads

### DIFF
--- a/deploy/crontab.yml
+++ b/deploy/crontab.yml
@@ -18,8 +18,7 @@
       user: "{{ project_name }}"
 
   - cron:
-      name: "Detect faces"
-      minute: "30,04,19"
+      name: "Process images in moderation queue"
       job: "nice -n 19 ionice -c 3 output-on-error {{project_root}}/env/bin/python {{project_root}}/code/manage.py moderation_queue_process_queued_images"
       disabled: no
 

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -3,7 +3,7 @@ aenum==3.1.12
 amazon-textract-textractor[pdf]==1.7.4
 beautifulsoup4==4.12.0
 bleach==6.0.0
-boto3==1.26.161
+boto3==1.34.105
 celery==5.2.7
 vine==5.0.0
 certifi>=2017.4.17

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -61,7 +61,7 @@ oauthlib==3.2.2
 path.py==12.5.0
 pexpect==4.8.0
 pickleshare==0.7.5
-Pillow==10.0.1
+Pillow==10.3.0
 psycopg==3.1.12
 pyasn1==0.4.8
 pycparser==2.21

--- a/requirements/deploy.txt
+++ b/requirements/deploy.txt
@@ -1,4 +1,4 @@
-boto3==1.26.161
+boto3==1.34.105
 ansible==3.2.0
 appdirs==1.4.4
 asn1crypto==1.5.1

--- a/ynr/apps/moderation_queue/forms.py
+++ b/ynr/apps/moderation_queue/forms.py
@@ -14,8 +14,6 @@ from django.template.loader import render_to_string
 from django.urls import reverse
 from moderation_queue.helpers import (
     convert_image_to_png,
-    resize_photo,
-    rotate_photo,
 )
 from people.forms.forms import StrippedCharField
 from PIL import Image as PILImage
@@ -64,9 +62,7 @@ class UploadPersonPhotoImageForm(forms.ModelForm):
         """
 
         original_image = self.instance.image
-        photo = rotate_photo(original_image)
-        resized_photo = resize_photo(photo, original_image)
-        png_image = convert_image_to_png(resized_photo)
+        png_image = convert_image_to_png(original_image)
         filename = self.instance.image.name
         extension = filename.split(".")[-1]
         filename = filename.replace(extension, "png")

--- a/ynr/apps/moderation_queue/helpers.py
+++ b/ynr/apps/moderation_queue/helpers.py
@@ -7,7 +7,6 @@ from candidates.views.version_data import get_client_ip
 from django.http import HttpResponseRedirect
 from django.shortcuts import render
 from django.urls import reverse
-from PIL import ExifTags, ImageOps
 from PIL import Image as PillowImage
 
 from .models import QueuedImage
@@ -45,46 +44,6 @@ def image_form_valid_response(request, person, image_form):
     return HttpResponseRedirect(
         reverse("photo-upload-success", kwargs={"person_id": person.id})
     )
-
-
-def rotate_photo(original_image):
-    # TO DO issue #2026 : This does not handle URL
-    # uploads.
-
-    # If an image has an EXIF Orientation tag, other than 1,
-    # return a new image that is transposed accordingly.
-    # The new image will have the orientation data removed.
-    # https://pillow.readthedocs.io/en/stable/_modules/PIL/ImageOps.html#exif_transpose
-    # Otherwise, return a copy of the image. If an image
-    # has an EXIF Orientation tag of 1, it might still
-    # need to be rotated, but we can handle that manually
-    # in the review process.
-    pil_image = PillowImage.open(original_image)
-
-    for orientation in ExifTags.TAGS:
-        if ExifTags.TAGS[orientation] == "Orientation":
-            break
-        exif = pil_image.getexif()
-        if exif and exif.get(274):
-            pil_image = ImageOps.exif_transpose(pil_image)
-        buffer = BytesIO()
-        pil_image.save(buffer, "PNG")
-    return pil_image
-
-
-def resize_photo(photo, original_image):
-    if not isinstance(photo, PillowImage.Image):
-        pil_image = PillowImage.open(photo)
-    else:
-        pil_image = photo
-
-    if original_image.width > 5000 or original_image.height > 5000:
-        size = 2000, 2000
-        pil_image.thumbnail(size)
-        buffer = BytesIO()
-        pil_image.save(buffer, "PNG")
-        return pil_image
-    return photo
 
 
 def convert_image_to_png(photo):

--- a/ynr/apps/moderation_queue/templates/moderation_queue/_photo-upload-image-form.html
+++ b/ynr/apps/moderation_queue/templates/moderation_queue/_photo-upload-image-form.html
@@ -23,7 +23,7 @@
     {% if queued_images %}
     If you still want to upload another photo of {{ person.name }}, cancel the existing queued photos first.
     {% else %}
-    Select an image from your computer (maximum size: 50 MB):
+    Select an image from your computer (maximum size: 50MB). If you have any trouble uploading the image, please <a href="mailto:hello@democracyclub.org.uk">contact us</a>.
     {% endif %}
   </p>
   <p>

--- a/ynr/apps/moderation_queue/tests/test_upload_photo.py
+++ b/ynr/apps/moderation_queue/tests/test_upload_photo.py
@@ -15,7 +15,6 @@ from moderation_queue.helpers import (
     ImageDownloadException,
     convert_image_to_png,
     download_image_from_url,
-    rotate_photo,
 )
 from moderation_queue.models import QueuedImage
 from moderation_queue.tests.paths import (
@@ -198,14 +197,6 @@ class PhotoUploadImageTests(UK2015ExamplesMixin, WebTest):
         queued_image = QueuedImage.objects.filter(person_id=2009).last()
         image_size = queued_image.image.size
         self.assertLessEqual(image_size, 5000000)
-
-    def test_rotate_image_from_file_upload(self):
-        image = PillowImage.open(self.rotated_image_filename)
-        exif = image.getexif()
-        self.assertEqual(exif.get(274), 1)
-        image = rotate_photo(self.example_image_filename)
-        exif = image.getexif()
-        self.assertIsNone(exif.get(274), None)
 
 
 @patch("moderation_queue.forms.requests")


### PR DESCRIPTION
Ref https://app.asana.com/0/1204880927741389/1207101641238151/f
These changes are aimed at speeding up the photo upload process. 
- removes the rotate functionality from the save method on the upload form
- moves the rotation to a renamed management command that processes moderation queue images, including running facial recognition
- runs the job every minute
---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207101641238151