### PR TITLE
Give users an option to delete results

### DIFF
--- a/ynr/apps/elections/templates/elections/ballot_view.html
+++ b/ynr/apps/elections/templates/elections/ballot_view.html
@@ -171,6 +171,9 @@
           {% csrf_token %}
           <input type="submit" class="button alert small" value="Unset the current winners, if incorrect">
         </form>
+        <form action="{% url 'delete_results' ballot_paper_id=ballot.ballot_paper_id %}" id="delete-results" method="post">
+          {% csrf_token %}
+          <input type="submit" class="button alert small" value="Delete all results for this ballot">
       {% endif %}
 
     {% else %}

--- a/ynr/apps/elections/urls.py
+++ b/ynr/apps/elections/urls.py
@@ -50,4 +50,9 @@ urlpatterns = [
         views.BallotsForSelectAjaxView.as_view(),
         name="ajax_ballots_for_select",
     ),
+    re_path(
+        r"^(?P<ballot_paper_id>[^/]+)/delete-results/$",
+        views.DeleteBallotResultsView.as_view(),
+        name="delete_results",
+    ),
 ]


### PR DESCRIPTION
There is currently no way to remove results from a ballot in the front end or admin panel. One might try to remove the results in the edit form but this leaves with validation errors that we don't want to change. This change gives user with permission that power, deleting result set, candidate result and reverting winner in the process. 

The context for this particular feature, requested by @pmk01, was: "One of the candidates needs splitting into two profiles, but this can only be done if the ballot doesn't have results added."

![Screenshot 2024-05-07 at 4 01 47 PM](https://github.com/DemocracyClub/yournextrepresentative/assets/7017118/bfd02b80-3413-49d2-8e7d-b22de81bdf40)


- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207254815979833