### PR TITLE
Hotfix/biography in markdown

### DIFF
--- a/ynr/apps/elections/uk/templates/candidates/person-view.html
+++ b/ynr/apps/elections/uk/templates/candidates/person-view.html
@@ -8,6 +8,7 @@
 {% load extra_field_value %}
 {% load thumbnail %}
 {% load approximate_dates %}
+{% load markdown_filter %}
 
 {% block extra_head %}
     <link rel="canonical" href="{{ canonical_url }}" />
@@ -126,7 +127,7 @@
     
     {% if person.biography %}
       <dt>Statement to voters</dt>
-      <dd class="person_biography">{{ person.biography|linebreaks }}</dd>
+      <dd class="person_biography">{{ person.biography|markdown}}</dd>
       {% if person.biography_last_updated %}<dd>This statement was last updated on {{ person.biography_last_updated }}.</dd>{% endif %}
     {% endif %}
   </dl>


### PR DESCRIPTION
This change renders the statement to voters (aka biography) in markdown, when markdown is used to create the biography. 

person edit view
![Screenshot 2024-05-28 at 10 08 17 PM](https://github.com/DemocracyClub/yournextrepresentative/assets/7017118/46bba289-21dc-4a8e-9a41-8db1ed13dad9)
person view
![Screenshot 2024-05-28 at 10 08 06 PM](https://github.com/DemocracyClub/yournextrepresentative/assets/7017118/1019c758-117b-436e-8279-1b95d27264c1)
