### PR TITLE
Post to slack again

### DIFF
--- a/ynr/apps/bulk_adding/tests/test_bulk_add.py
+++ b/ynr/apps/bulk_adding/tests/test_bulk_add.py
@@ -157,7 +157,7 @@ class TestBulkAdding(TestUserMixin, UK2015ExamplesMixin, WebTest):
         # make it lower and at least make sure it's not getting bigger.
         #
         # [1]: https://github.com/DemocracyClub/yournextrepresentative/pull/467#discussion_r179186705
-        with self.assertNumQueries(FuzzyInt(51, 53)):
+        with self.assertNumQueries(FuzzyInt(49, 53)):
             response = form.submit()
 
         self.assertEqual(Person.objects.count(), 1)
@@ -265,7 +265,7 @@ class TestBulkAdding(TestUserMixin, UK2015ExamplesMixin, WebTest):
         form["form-0-select_person"].select("_new")
 
         # this is a smaller increase but may be unavoidable
-        with self.assertNumQueries(FuzzyInt(56, 58)):
+        with self.assertNumQueries(FuzzyInt(53, 58)):
             response = form.submit()
 
         self.assertEqual(Person.objects.count(), 1)

--- a/ynr/apps/candidates/templates/candidates/recent-changes.html
+++ b/ynr/apps/candidates/templates/candidates/recent-changes.html
@@ -91,7 +91,7 @@
       <td style="overflow: scroll; width: 15%">{{ action.source }}</td>
       <td>
         {% if action.flagged_reason %}
-        ⚠
+         <small style="display:inline-block;max-width:20ch;color:red;">⚠ {{ action.flagged_reason }}</small>
         {% endif %}
       </td>
       {% if action.diff_html %}

--- a/ynr/apps/moderation_queue/review_required_helper.py
+++ b/ynr/apps/moderation_queue/review_required_helper.py
@@ -340,11 +340,11 @@ REVIEW_TYPES = (
         label="Automated moderation of statement",
         cls=OpenAIModerationReview,
     ),
-    ReviewType(
-        type="needs_review_due_to_statement_edit",
-        label="Edit of a statement to voters",
-        cls=CandidateStatementEditDecider,
-    ),
+    # ReviewType(
+    #     type="needs_review_due_to_statement_edit",
+    #     label="Edit of a statement to voters",
+    #     cls=CandidateStatementEditDecider,
+    # ),
     ReviewType(
         type="needs_review_due_to_current_candidate_name_change",
         label="Edit of name of current candidate",

--- a/ynr/apps/moderation_queue/slack.py
+++ b/ynr/apps/moderation_queue/slack.py
@@ -218,10 +218,8 @@ with the source: \n> {source}
     def post_message(self):
         self.sh.post_message(
             getattr(settings, "SLACK_REVIEW_CHANNEL", "C59LHLH7A"),
-            text="Edit to {}".format(self.logged_action.person.name),
+            "Edit to {}".format(self.logged_action.person.name),
             blocks=self.message,
-            username=settings.CANDIDATE_BOT_USERNAME,
-            icon_emoji=":robot_face:",
         )
 
 

--- a/ynr/apps/moderation_queue/tests/test_changes_for_review.py
+++ b/ynr/apps/moderation_queue/tests/test_changes_for_review.py
@@ -498,8 +498,7 @@ class TestNeedsReviewFeed(UK2015ExamplesMixin, TestUserMixin, WebTest):
         #    1 edit from a user who was mostly active in the past to the
         #      prime minister's record
         #    1 constituency-lock from a new user
-        #    1 edit of a biography field
-        self.assertEqual(needs_review_qs.count(), 1 + 3 + 1 + 1 + 1 + 1)
+        self.assertEqual(needs_review_qs.count(), 1 + 3 + 1 + 1 + 1)
         results = [
             (la.user.username, la.action_type, la.flagged_reason)
             for la in needs_review_qs
@@ -542,11 +541,6 @@ class TestNeedsReviewFeed(UK2015ExamplesMixin, TestUserMixin, WebTest):
                     "new_suddenly_lots",
                     "person-update",
                     "One of the first 3 edits of user new_suddenly_lots",
-                ),
-                (
-                    "lapsed_experienced",
-                    "person-update",
-                    "Edit of a statement to voters",
                 ),
             ],
         )
@@ -605,12 +599,6 @@ class TestNeedsReviewFeed(UK2015ExamplesMixin, TestUserMixin, WebTest):
             b"<author><name>new_suddenly_lots</name></author>"
             b"<id>needs-review:2002</id>"
             b'<summary type="html">&lt;p&gt;person-update of &lt;a href="/person/2009"&gt;Tessa Jowell (2009)&lt;/a&gt; by new_suddenly_lots with source: \xe2\x80\x9c Just for tests \xe2\x80\x9d;&lt;/p&gt;\n&lt;ul&gt;\nOne of the first 3 edits of user new_suddenly_lots\n&lt;/ul&gt;&lt;/p&gt;&lt;div style="color: red"&gt;Fake diff&lt;/div&gt;</summary></entry>'
-            b"<entry><title>Yoshi Aarle (**YoshiAarleID**) - person-update</title>"
-            b'<link href="http://example.com/person/**YoshiAarleID**" rel="alternate"></link>'
-            b"<updated>2017-05-02T16:30:05+00:00</updated>"
-            b"<author><name>lapsed_experienced</name></author>"
-            b"<id>needs-review:**laID**</id>"
-            b'<summary type="html">&lt;p&gt;person-update of &lt;a href="/person/**YoshiAarleID**"&gt;Yoshi Aarle (**YoshiAarleID**)&lt;/a&gt; by lapsed_experienced with source: \xe2\x80\x9c just a test \xe2\x80\x9d;&lt;/p&gt;\n&lt;ul&gt;\nEdit of a statement to voters\n&lt;/ul&gt;&lt;/p&gt;&lt;div style="color: red"&gt;Fake diff&lt;/div&gt;</summary></entry>'
             b"</feed>"
         )
 

--- a/ynr/apps/utils/slack.py
+++ b/ynr/apps/utils/slack.py
@@ -11,12 +11,15 @@ class SlackHelper:
             self.client = Slacker(settings.SLACK_TOKEN)
         self.user = user
 
-    def post_message(self, to, message_text, attachments=None, extra_dict=None):
+    def post_message(
+        self, to, message_text, blocks=None, attachments=None, extra_dict=None
+    ):
         kwargs = {
             "username": self.user,
             "icon_emoji": ":robot_face:",
             "text": message_text,
             "attachments": attachments,
+            "blocks": blocks,
         }
         if extra_dict:
             kwargs.update(extra_dict)


### PR DESCRIPTION
This PR does a couple of things:

1. Show flagged reason in recent changes feed
2. Post to Slack again
3. Don't post all edits to statements to Slack