### PR TITLE
Remove references to git submodules from docs/INSTALL.md

### DIFF
--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -39,6 +39,8 @@ To populate the database run from the live site run:
 python manage.py candidates_import_from_live_site
 ```
 
+(Note that this command will take multiple hours to complete.)
+
 ## Build frontend assets
 
 ```

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -39,13 +39,6 @@ To populate the database run from the live site run:
 python manage.py candidates_import_from_live_site
 ```
 
-## Install Front-End Dependencies
-
-```
-git submodule init
-git submodule update
-```
-
 ## Build frontend assets
 
 ```


### PR DESCRIPTION
The git submodules were removed in 45daf4e0fe7845f38687286

This PR also includes a change to note that the `candidates_import_from_live_site` may take several hours.
