### PR TITLE
Add missing migration dependencies

### DIFF
--- a/ynr/apps/bulk_adding/migrations/0008_rawpeople_aws_textract_parsed_data.py
+++ b/ynr/apps/bulk_adding/migrations/0008_rawpeople_aws_textract_parsed_data.py
@@ -7,6 +7,7 @@ from django.db import migrations, models
 class Migration(migrations.Migration):
     dependencies = [
         ("bulk_adding", "0007_alter_rawpeople_data"),
+        ("sopn_parsing", "0002_awstextractparsedsopn"),
     ]
 
     operations = [

--- a/ynr/apps/sopn_parsing/migrations/0007_awstextractparsedsopn_sopn_camelotparsedsopn_sopn.py
+++ b/ynr/apps/sopn_parsing/migrations/0007_awstextractparsedsopn_sopn_camelotparsedsopn_sopn.py
@@ -10,6 +10,10 @@ class Migration(migrations.Migration):
             "sopn_parsing",
             "0006_rename_sopn_awstextractparsedsopn_official_document_and_more",
         ),
+        (
+            "official_documents",
+            "0033_ballotsopnhistory_ballotsopn"
+        ),
     ]
 
     operations = [


### PR DESCRIPTION
These missing dependencies mean that running `./manage.py migrate` from scratch fails, since the migrations are referring to models introduced in migrations that haven't been run yet.