### PR TITLE
Fix form by replacing rotate buttons

### DIFF
--- a/ynr/apps/moderation_queue/templates/moderation_queue/photo-review.html
+++ b/ynr/apps/moderation_queue/templates/moderation_queue/photo-review.html
@@ -90,6 +90,56 @@
       </p>
     </div>
 
+    <h3>Rotate the image as needed</h3>
+    <input type="hidden" name="queued_image_id" value="{{ queued_image.id }}">
+    <button name="rotate" type="submit" value="left">Anti-clockwise ⟲</button>
+    <button name="rotate" type="submit" value="right">Clockwise ⟳</button>
+
+    <p>
+    {% if queued_image.detection_metadata and queued_image.user.is_superuser %}
+      <details>
+        <summary>Facial recognition data (click to expand)</summary>
+        <pre>{{ queued_image.detection_metadata | pprint}}<pre>
+      </details>
+    {% elif not queued_image.detection_metadata %}
+      Image analysis is not available for this photo.
+    {% endif %}
+    </p>
+ 
+  <h3>User-submitted information</h3>
+
+  <p>
+    Uploaded by user <tt>{{ username }}</tt>.
+    {% if person.get_email %}
+      {% if person.get_email == email %}
+        <strong>The uploading user's email address matches the candidate's email address</strong>
+      {% endif %}
+      (The candidate's unconfirmed email address is
+      <tt>{{ person.get_email }}</tt>.)
+    {% endif %}
+    </p>
+
+    {% if why_allowed == 'public-domain' %}
+      <p>
+        {{ username }} asserted that photo is free of copyright restrictions
+      </p>
+    {% elif why_allowed == 'copyright-assigned' %}
+      <p>
+        {{ username }} assigned the copyright to {{ settings.COPYRIGHT_HOLDER }}
+      </p>
+    {% elif why_allowed == 'profile-photo' %}
+      <p>
+        {{ username }} said that this is the candidate's photo from their official campaign page or profile photo from social media
+      </p>
+    {% endif %}
+
+    {% if justification_for_use %}
+      <p>
+        {{ username }}'s justification for use of this photo was:
+        &#8220;{{ justification_for_use|safe }}&#8221;
+      </p>
+    {% endif %}
+
     <h3>Your decision</h3>
 
     <div id="moderator-photo-decision">
@@ -155,55 +205,5 @@
 
   {% endwith %}
 </div>
-
-<h3>Rotate the image as needed</h3>
-<input type="hidden" name="queued_image_id" value="{{ queued_image.id }}">
-<button name="rotate" type="submit" value="left">Anti-clockwise ⟲</button>
-<button name="rotate" type="submit" value="right">Clockwise ⟳</button>
-
-  <p>
-    {% if queued_image.detection_metadata and queued_image.user.is_superuser %}
-      <details>
-        <summary>Facial recognition data (click to expand)</summary>
-        <pre>{{ queued_image.detection_metadata | pprint}}<pre>
-      </details>
-    {% elif not queued_image.detection_metadata %}
-      Image analysis is not available for this photo.
-    {% endif %}
-    </p>
- 
-  <h3>User-submitted information</h3>
-
-  <p>
-    Uploaded by user <tt>{{ username }}</tt>.
-    {% if person.get_email %}
-      {% if person.get_email == email %}
-        <strong>The uploading user's email address matches the candidate's email address</strong>
-      {% endif %}
-      (The candidate's unconfirmed email address is
-      <tt>{{ person.get_email }}</tt>.)
-    {% endif %}
-    </p>
-
-    {% if why_allowed == 'public-domain' %}
-      <p>
-        {{ username }} asserted that photo is free of copyright restrictions
-      </p>
-    {% elif why_allowed == 'copyright-assigned' %}
-      <p>
-        {{ username }} assigned the copyright to {{ settings.COPYRIGHT_HOLDER }}
-      </p>
-    {% elif why_allowed == 'profile-photo' %}
-      <p>
-        {{ username }} said that this is the candidate's photo from their official campaign page or profile photo from social media
-      </p>
-    {% endif %}
-
-    {% if justification_for_use %}
-      <p>
-        {{ username }}'s justification for use of this photo was:
-        &#8220;{{ justification_for_use|safe }}&#8221;
-      </p>
-    {% endif %}
 
 {% endblock %}


### PR DESCRIPTION
I broke the mod queue form when I moved the rotate and user info areas outside the form tags. 

To reduce the scrolling, I suggest we move some of the components to the right hand column, but this needs more time than I have available today.  For now, this change will unblock the photos that need rotation in the queue. 