### PR TITLE
Hotfix/ec emblem import

### DIFF
--- a/ynr/apps/parties/importer.py
+++ b/ynr/apps/parties/importer.py
@@ -385,6 +385,13 @@ class ECParty(dict):
                 emblem.active = False
                 emblem.save()
 
+        # if the length of the emblem list is 1,
+        # then we should import the emblem just in case it has change
+        # but the id has not
+        if len(ec_emblem_id_list) == 1:
+            emblem = ECEmblem(self.model, self["PartyEmblems"][0])
+            emblem.save()
+
     def mark_inactive_descriptions(self):
         ec_description_list = []
 


### PR DESCRIPTION
Peter reported that the logo hadn't updated to match the EC register: https://whocanivotefor.co.uk/parties/party:17545/party-of-women

I checked the `import-parties` job on WCIVF and it was running as expected. 

I moved to YNR to debug and found that the emblem wasn't updating bc the id had not changed and an emblem version history did not exist. I added a way to update the emblem when only one image exists on the register. 

To test this, 
run the local server and visit the endpoint for `api/next/parties/PP17545/`
Click the s3 image link and notice the old logo

run the command for the ec importer and refresh: 
`python manage.py parties_import_from_ec`

The logo should match the one shown here: 
https://search.electoralcommission.org.uk/English/Registrations/PP17545




---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207463772623482