### PR TITLE
Display new user count on leaderboard

### DIFF
--- a/ynr/apps/candidates/templates/candidates/leaderboard.html
+++ b/ynr/apps/candidates/templates/candidates/leaderboard.html
@@ -13,6 +13,7 @@
 
 
 <div class="row">
+  <p>Since the 4 July 2024 General Election announcement, we've had {{num_new_users}} sign up to help crowdsource election data.
   {% for leaderboard in leaderboards %}
 
     <div class="leaderboard" id="{{ leaderboard.title|slugify }}">

--- a/ynr/apps/candidates/views/mixins.py
+++ b/ynr/apps/candidates/views/mixins.py
@@ -1,6 +1,7 @@
 from datetime import timedelta
 
 from dateutil.parser import parse
+from django.contrib.auth.models import User
 from django.db.models import Count, F
 from django.utils import timezone
 
@@ -63,3 +64,8 @@ class ContributorsMixin(object):
             .select_related("user", "person", "ballot", "ballot__post")
             .order_by("-created")
         )
+
+    def get_num_new_users(self):
+        """Return the number of new users
+        created since the GE 2024 announcement."""
+        return User.objects.filter(date_joined__gt=parse("2024-05-22")).count()  # noqa

--- a/ynr/apps/candidates/views/users.py
+++ b/ynr/apps/candidates/views/users.py
@@ -41,6 +41,7 @@ class LeaderboardView(ContributorsMixin, TemplateView):
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         context["leaderboards"] = self.get_leaderboards()
+        context["num_new_users"] = self.get_num_new_users()
         return context
 
 


### PR DESCRIPTION
<img width="935" alt="Screenshot 2024-06-03 at 7 23 25 PM" src="https://github.com/DemocracyClub/yournextrepresentative/assets/7017118/76eeae01-8334-4438-b246-beb41cb58b22">

So Peter can know the number without asking anyone or having to customise admin. 
So other noobs can see they aren't alone. 