### PR TITLE
Disable Camelot parsing by default

### DIFF
--- a/ynr/apps/official_documents/models.py
+++ b/ynr/apps/official_documents/models.py
@@ -276,8 +276,10 @@ class BallotSOPN(BaseBallotSOPN):
             # There's a cron job that should pick up the result and carry on parsing later.
             textract_helper.start_detection()
 
-        # Camelot
-        if self.uploaded_file.name.endswith(".pdf"):
+        if getattr(
+            settings, "CAMELOT_ENABLED", False
+        ) and self.uploaded_file.name.endswith(".pdf"):
+            # Camelot
             extract_ballot_table(self.ballot)
 
 

--- a/ynr/apps/sopn_parsing/helpers/textract_helpers.py
+++ b/ynr/apps/sopn_parsing/helpers/textract_helpers.py
@@ -44,6 +44,7 @@ class TextractSOPNHelper:
         self.upload_path = upload_path
         if not any((self.bucket_name, self.upload_path)):
             raise NotUsingAWSException()
+
         self.extractor = Textractor(region_name="eu-west-2")
 
     def start_detection(self, replace=False) -> Optional[AWSTextractParsedSOPN]:

--- a/ynr/apps/sopn_parsing/management/commands/sopn_parsing_process_unparsed.py
+++ b/ynr/apps/sopn_parsing/management/commands/sopn_parsing_process_unparsed.py
@@ -1,3 +1,4 @@
+from django.conf import settings
 from django.core.management.base import BaseCommand
 from sopn_parsing.helpers.parse_tables import parse_raw_data_for_ballot
 from sopn_parsing.helpers.textract_helpers import (
@@ -44,13 +45,14 @@ class Command(BaseCommand):
             "sopn__ballot__candidates_locked": False,
         }
 
-        # Camelot first
-        qs = (
-            CamelotParsedSOPN.objects.filter(parsed_data=None)
-            .exclude(raw_data="")
-            .filter(**current_ballot_kwargs)
-        )
-        self.parse_tables_for_qs(qs)
+        if getattr(settings, "CAMELOT_ENABLED", False):
+            # Camelot first
+            qs = (
+                CamelotParsedSOPN.objects.filter(parsed_data=None)
+                .exclude(raw_data="")
+                .filter(**current_ballot_kwargs)
+            )
+            self.parse_tables_for_qs(qs)
 
         # Textract
         qs = AWSTextractParsedSOPN.objects.exclude(


### PR DESCRIPTION
The reason for this is that Camelot seems to have more basic errors than Textract (like adding spaces or newlines). 

We're likely to get a load of new people on GE SOPN day, so the fewer errors we can have the better. The feature flag means we can add it to the settings and run a management command to re-parse everything if Textract doesn't work for whatever reason.