### PR TITLE
Improve sopn parsing party matching

### DIFF
--- a/ynr/apps/sopn_parsing/helpers/parse_tables.py
+++ b/ynr/apps/sopn_parsing/helpers/parse_tables.py
@@ -48,7 +48,7 @@ NAME_FIELDS = (
     + WELSH_NAME_FIELDS
 )
 
-INDEPENDENT_VALUES = ["Independent", "", "Annibynnol"]
+INDEPENDENT_VALUES = ["independent", "", "annibynnol", "independents"]
 
 WELSH_DESCRIPTION_VALUES = [
     "disgrifiad",
@@ -200,7 +200,7 @@ def get_description(description, sopn):
 
     if not description:
         return None
-    if description in INDEPENDENT_VALUES:
+    if description.lower() in INDEPENDENT_VALUES:
         return None
 
     register = sopn.sopn.ballot.post.party_set.slug.upper()
@@ -284,7 +284,7 @@ def get_party(description_model, description_str, sopn):
         .active_for_date(date=sopn.sopn.ballot.election.election_date)
         .annotate(search_text=Replace("name", Value("&"), Value("and")))
     )
-    if not party_name or party_name in INDEPENDENT_VALUES:
+    if not party_name or party_name.lower() in INDEPENDENT_VALUES:
         return Party.objects.get(ec_id="ynmp-party:2")
 
     try:

--- a/ynr/apps/sopn_parsing/tests/data/edge_case_description_data.json
+++ b/ynr/apps/sopn_parsing/tests/data/edge_case_description_data.json
@@ -1,0 +1,36 @@
+{
+    "0": {
+        "0": "Candidate Name",
+        "1": "SMITH \nJohn",
+        "2": "BLOGGS \nJoe",
+        "3": "DOE \nJon",
+        "4": "BROWN \nJane",
+        "5": "JOHNSON \nJudy",
+        "6": "WILLIAMS \nJulie"
+    },
+    "1": {
+        "0": "Description of\ncandidate \n(if any)",
+        "1": "Conservative Party",
+        "2": "Labour Party",
+        "3": "Liberal Democrat",
+        "4": "INDEPENDENT",
+        "5": "Plaid Cymru - The Party of Wales",
+        "6": "Annibynnol"
+    },
+    "2": {
+        "0": "Address of \ncandidate or \nsuch relevant \ninformation as \nprovided in the \nhome address \nform",
+        "1": "1 Example Road",
+        "2": "2 Example Road",
+        "3": "3 Example Road",
+        "4": "4 Example Road",
+        "5": "5 Example Road",
+        "6": "6 Example Road"
+    },
+    "3": {
+        "0": "Reason why\n candidate no \nlonger nominated",
+        "1": "",
+        "2": "",
+        "3": "",
+        "4": ""
+    }
+}


### PR DESCRIPTION
This change does a couple of things:

1. Makes independant matching a little better, meaning we should avoid matching "Independent Dickens Heath Residents Action Group" when the party is "Independant" 
2. Uses "Levenshtein" distance queries before "starts with" queries, to avoid matching longer descriptions that happen to start with the search text. 

Hopefully this will prevent a couple of the most common problems with SOPN parsing