### PR TITLE
Correct sopn deadline date

### DIFF
--- a/deploy/webapp_settings/production.py
+++ b/deploy/webapp_settings/production.py
@@ -77,7 +77,7 @@ SOPN_DATES = [
     # ("Scotland", date(year=2023, month=3, day=30)),
     # ("England and Wales", date(year=2024, month=4, day=5)),
     # ("Northern Ireland", date(year=2023, month=4, day=24)),
-    ("Great Britain", date(year=2024, month=7, day=4)),
+    ("Great Britain", date(year=2024, month=6, day=7)),
 ]
 
 DATA_DOWNLOAD_INFO = {

--- a/ynr/apps/elections/uk/templates/includes/sopn_import_progress.html
+++ b/ynr/apps/elections/uk/templates/includes/sopn_import_progress.html
@@ -19,7 +19,7 @@
 
   {% if SOPN_DATES %}
     <p>
-    The SOPN publication dates this year are:
+    The SOPN publication date for the 2024 General Election is:
     </p>
     <ul style="list-style: none;">
       {% for nation, date in SOPN_DATES %}


### PR DESCRIPTION
In https://github.com/DemocracyClub/yournextrepresentative/pull/2346, the `SOPN_DATES` for the GE were incorrectly set to the election date. This change fixes that to 7 June 2024. 

![Screenshot 2024-06-06 at 9 28 55 AM](https://github.com/DemocracyClub/yournextrepresentative/assets/7017118/1e0925ad-1d62-4efe-b0bc-93dc12a06eb2)
