### PR TITLE
New tab for image searches

### DIFF
--- a/ynr/apps/moderation_queue/templates/moderation_queue/photo-review.html
+++ b/ynr/apps/moderation_queue/templates/moderation_queue/photo-review.html
@@ -33,14 +33,14 @@
     Please check that this is really <a href="{{ url }}">{{ person.name }}</a>
     (<a href="{{ person.last_candidacy.ballot.get_absolute_url }}">
       {{ person.last_party.name }}, {{ person.last_candidacy.ballot.ballot_paper_id }}
-    </a>) before approving the upload. This
-    <a href="{{ google_image_search_url }}">Google Image search for candidate
+    </a>) before approving the upload.<br>This
+    <a href="{{ google_image_search_url }} target="_blank">Google Image search for candidate
     details</a> may be a good start.
   </p>
 
   <p>
   If you're trying to find the likely <em>source</em> of this image, you can
-  also do a <a href="{{ google_reverse_image_search_url }}">reverse image
+  also do a <a href="{{ google_reverse_image_search_url }}" target="_blank">reverse image
   search</a> on the uploaded image.</p>
 
   <h4>Click and drag in the image to crop</h4>


### PR DESCRIPTION
Stops user leaving the page when working on something.

As per https://css-tricks.com/use-target_blank/#aa-a-good-reason-the-user-is-working-on-something-on-the-page-that-might-be-lost-if-the-current-page-changed

I found that I kept opening image search links in the same tab, which lost the work I was doing.

```[tasklist]
### PR Checklist
- [ ] Update changelog (ie https://keepachangelog.com/en/1.0.0/)
- [X] References a specific issue or if not, describes the bug or feature in detail
- [ ] Note what card in Trello this work relates to
- [ ] Instructions for how reviewers can test the code locally
- [ ] Tests have been added and/or updated
- [ ] Screenshot of the feature/bug fix (if applicable)
- [ ] If any new text is added, it's internationalized
- [ ] Any new elements have aria labels
- [ ] No unintentional console.logs left behind after debugging
- [ ] Did I use the clear and concise names for variables and functions?
- [X] Did I explain all possible solutions and why I chose the one I did?
- [ ] Added any comments to make new functions clearer
- [ ] Did I added or updated any new dependencies? Explain why.
- [ ] Did I update the package.json and/or Pipfile.lock version if relevant?
- [ ] Have I rebased with the latest version of master?
- [ ] Added PR labels
- [ ] Update any history/changelog file
- [ ] Update any documentation
- [ ] Update dev handbook
```
