### PR TITLE
HOLD: Results dashboard

### DIFF
--- a/deploy/webapp_settings/production.py
+++ b/deploy/webapp_settings/production.py
@@ -67,7 +67,7 @@ RUNNING_TESTS = False
 # RESULTS_PROGRESS
 # DATA_DOWNLOAD
 # BY_ELECTIONS
-FRONT_PAGE_CTA = "DATA_DOWNLOAD"
+FRONT_PAGE_CTA = "RESULTS_PROGRESS"
 SOPN_TRACKER_INFO = {
     "election_date": "2024-07-04",
     "election_name": "2024 general election",

--- a/ynr/apps/elections/uk/templates/candidates/finder.html
+++ b/ynr/apps/elections/uk/templates/candidates/finder.html
@@ -42,15 +42,21 @@
 {% block content %}
 
   {% if front_page_cta and front_page_cta != "BY_ELECTIONS" %}
+    <div class="finder__forms cta-{{ front_page_cta }}"> 
+      <div class="finder__forms__container">
+        {% data_download %}
+      </div>
+    </div>
+
     <div class="finder__forms cta-{{ front_page_cta }}">
       <div class="finder__forms__container">
         {% sopn_import_progress %}
         {% current_election_stats %}
         {% results_progress %}
-        {% data_download %}
-        {% results_download %}
       </div>
     </div>
+
+    
   {% endif %}
 
 

--- a/ynr/apps/elections/uk/templates/candidates/finder.html
+++ b/ynr/apps/elections/uk/templates/candidates/finder.html
@@ -48,6 +48,7 @@
         {% current_election_stats %}
         {% results_progress %}
         {% data_download %}
+        {% results_download %}
       </div>
     </div>
   {% endif %}

--- a/ynr/apps/elections/uk/templates/candidates/finder.html
+++ b/ynr/apps/elections/uk/templates/candidates/finder.html
@@ -47,6 +47,13 @@
         {% data_download %}
       </div>
     </div>
+    <div class="finder__forms cta-{{ front_page_cta }}"> 
+      <div class="finder__forms__container">
+        {% results_download %}
+      </div>
+    </div>
+
+
 
     <div class="finder__forms cta-{{ front_page_cta }}">
       <div class="finder__forms__container">

--- a/ynr/apps/elections/uk/templates/includes/results_download.html
+++ b/ynr/apps/elections/uk/templates/includes/results_download.html
@@ -1,0 +1,6 @@
+<h2>Get results data</h2>
+<p>Download the CSV of all election results for the 2024 general election:</p>
+<p><a class="button" href="{% url 'data_export' %}?election_date=2024-07-04&ballot_paper_id=&election_id=&party_id=&cancelled=&locked=&has_votes_cast=&has_elected=&has_tied_vote_winner=&has_rank=&has_turnout_reported=&has_spoilt_ballots=&has_total_electorate=&has_turnout_percentage=&has_results_source=&field_group=results">Download CSV</a></p>
+<p>Or for more advance filters and more fields, try the
+    <a href="{% url 'data_home' %}?election_date=2024-07-04&ballot_paper_id=&election_id=&party_id=&cancelled=&locked=&field_group=results">custom CSV builder</a>.</p>
+<p>This data is updated every minute.</p>

--- a/ynr/apps/elections/uk/templates/includes/results_progress.html
+++ b/ynr/apps/elections/uk/templates/includes/results_progress.html
@@ -2,7 +2,7 @@
 {% if SHOW_RESULTS_PROGRESS %}
   <h3>Enter results as they come in</h3>
   <p><a href="{% url "election_list_view"%}?{{ has_results_shortcut.querystring }}" class="button">Get started</a></p>
-  <p><a href="{% url "results-home"%}" class="button">Get the data</a></p>
+  <p><a href="{% url "results-home"%}" class="button">Get the results data</a></p>
 
   <h3>{{ results_percent }}% of votes for {{ areas_total|intcomma }} areas in total have been entered</h3>
   <div class="radius progress success large-12" role="progressbar" aria-valuenow="{{ results_entered }}" aria-valuemin="0" aria-valuemax="{{ areas_total }}">

--- a/ynr/apps/elections/uk/templatetags/home_page_tags.py
+++ b/ynr/apps/elections/uk/templatetags/home_page_tags.py
@@ -274,7 +274,7 @@ def data_download(context):
 @register.inclusion_tag("includes/results_download.html", takes_context=True)
 def results_download(context):
     context["RESULTS_DOWNLOAD"] = (
-        getattr(settings, "FRONT_PAGE_CTA", False) == "RESULTS_DOWNLOAD"
+        getattr(settings, "FRONT_PAGE_CTA", True) == "RESULTS_DOWNLOAD"
     )
 
     if context["RESULTS_DOWNLOAD"]:

--- a/ynr/apps/elections/uk/templatetags/home_page_tags.py
+++ b/ynr/apps/elections/uk/templatetags/home_page_tags.py
@@ -177,7 +177,7 @@ def current_election_stats(context):
 @register.inclusion_tag("includes/results_progress.html", takes_context=True)
 def results_progress(context):
     context["SHOW_RESULTS_PROGRESS"] = (
-        getattr(settings, "FRONT_PAGE_CTA", False) == "RESULTS_PROGRESS"
+        getattr(settings, "FRONT_PAGE_CTA", True) == "RESULTS_PROGRESS"
     )
 
     if context["SHOW_RESULTS_PROGRESS"]:
@@ -259,7 +259,7 @@ def by_election_ctas(context):
 @register.inclusion_tag("includes/data_download.html", takes_context=True)
 def data_download(context):
     context["DATA_DOWNLOAD"] = (
-        getattr(settings, "FRONT_PAGE_CTA", False) == "DATA_DOWNLOAD"
+        getattr(settings, "FRONT_PAGE_CTA", True) == "DATA_DOWNLOAD"
     )
 
     if context["DATA_DOWNLOAD"]:

--- a/ynr/apps/elections/uk/templatetags/home_page_tags.py
+++ b/ynr/apps/elections/uk/templatetags/home_page_tags.py
@@ -269,3 +269,22 @@ def data_download(context):
         ]
         context["election_name"] = settings.DATA_DOWNLOAD_INFO["election_name"]
     return context
+
+
+@register.inclusion_tag("includes/results_download.html", takes_context=True)
+def results_download(context):
+    context["RESULTS_DOWNLOAD"] = (
+        getattr(settings, "FRONT_PAGE_CTA", False) == "RESULTS_DOWNLOAD"
+    )
+
+    if context["RESULTS_DOWNLOAD"]:
+        context["election_date"] = settings.RESULTS_DOWNLOAD_INFO[
+            "election_date"
+        ]
+        context["election_regex"] = settings.RESULTS_DOWNLOAD_INFO[
+            "election_regex"
+        ]
+        context["election_name"] = settings.RESULTS_DOWNLOAD_INFO[
+            "election_name"
+        ]
+    return context

--- a/ynr/settings/testing.py
+++ b/ynr/settings/testing.py
@@ -32,7 +32,7 @@ SECRET_KEY = "just here for testing"
 ALLOWED_HOSTS = ["candidates.democracyclub.org.uk"]
 
 SHOW_SOPN_TRACKER = False
-SHOW_RESULTS_PROGRESS = False
+SHOW_RESULTS_PROGRESS = True
 
 ALWAYS_ALLOW_RESULT_RECORDING = False
 


### PR DESCRIPTION
Do not merge before 1 July!

This change

- keeps the data download as a CTA
- adds a results download CTA
- adds the results tracker below it. 

![Screenshot 2024-06-26 at 7 50 26 AM](https://github.com/DemocracyClub/yournextrepresentative/assets/7017118/c4a25efd-90e1-4a38-a9a8-7a5000503446)



---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207573752057232
  - https://app.asana.com/0/0/1207644792502201