### PR TITLE
Moderated image matches saved image

### DIFF
--- a/ynr/apps/moderation_queue/helpers.py
+++ b/ynr/apps/moderation_queue/helpers.py
@@ -57,9 +57,12 @@ def convert_image_to_png(photo):
     # open it as a PillowImage object before
     # converting it to RGBA.
     if not isinstance(photo, PillowImage.Image):
-        photo = PillowImage.open(photo)
-    converted = photo.convert("RGBA")
+        photo = PillowImage.open(photo).convert("RGBA")
+    else:
+        photo = photo.convert("RGBA")
     bytes_obj = BytesIO()
+    converted = photo.copy()
+    converted = converted.convert("RGB")
     converted.save(bytes_obj, "PNG")
     return bytes_obj
 


### PR DESCRIPTION
This is an improvement on the current code which presents the user with a preview of an image that matches the uploaded image, but then saves a different version (one with a distorted/erased background) following approval.

With this change, the user moderated image matches the saved image, however neither match the uploaded image.

This also addresses https://democracy-club-gp.sentry.io/issues/4286573728/?project=162062&query=is%3Aunresolved+issue.priority%3A%5Bhigh%2C+medium%5D&referrer=issue-stream&statsPeriod=90d&stream_index=3

Uploaded image
![Ráichéal](https://github.com/DemocracyClub/yournextrepresentative/assets/7017118/56a021b7-d827-4853-84e5-0048016ddb1c)


Moderated image preview
![Screenshot 2024-06-27 at 12 10 21 PM](https://github.com/DemocracyClub/yournextrepresentative/assets/7017118/fd5a9a34-5021-41d3-900c-098d604217d9)


Saved image (thumbnail on green website background)
![Screenshot 2024-06-27 at 12 10 00 PM](https://github.com/DemocracyClub/yournextrepresentative/assets/7017118/32dc7e06-effc-43b9-bb65-99cd678acb67)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207823589000635