### PR TITLE
Only include parl results in results progress

### DIFF
--- a/ynr/apps/elections/uk/templatetags/home_page_tags.py
+++ b/ynr/apps/elections/uk/templatetags/home_page_tags.py
@@ -193,7 +193,9 @@ def results_progress(context):
 
         # TODO: Remove after the General election
         context["parl_marked_elected"] = MaterializedMemberships.objects.filter(
-            ballot_paper__election__election_date=election_date, elected=True
+            ballot_paper__election__election_date=election_date,
+            ballot_paper__election__slug="parl.2024-07-04",
+            elected=True,
         ).count()
         context["parl_elected_by_party"] = (
             MaterializedMemberships.objects.filter(

--- a/ynr/apps/uk_results/views/parl_winners.py
+++ b/ynr/apps/uk_results/views/parl_winners.py
@@ -166,11 +166,11 @@ class ParlBallotsWinnerEntryView(LoginRequiredMixin, TemplateView):
         if not is_elected:
             action_type = ActionType.RETRACT_WINNER
             message = (
-                f"Thanks for confirming {membership.person.name} as the winner"
+                f"Thanks for unsetting{membership.person.name} as the winner"
             )
         if membership.elected:
             message = (
-                f"Thanks for unsetting {membership.person.name} as the winner"
+                f"Thanks for confirming {membership.person.name} as the winner"
             )
             action_type = ActionType.SET_CANDIDATE_ELECTED
 


### PR DESCRIPTION
This change excludes any non parl elections that may be occuring on 4 July from the results progress tracker. This is necessary to avoid confusion against the total 650 parl seats mentioned in the tracker. 

This also corrects the messages to user when unsetting/marking elected candidates. 