### PR TITLE
Help users identify gaps in results data

### DIFF
--- a/ynr/apps/elections/filters.py
+++ b/ynr/apps/elections/filters.py
@@ -311,11 +311,23 @@ class CurrentOrFutureBallotFilter(BaseBallotFilter):
 
     def has_results_filter(self, queryset, name, value):
         """
-        Filter queryset by if they have results or not
+        Filter queryset by if they have candidate results or not
         """
         mapping = {1: "has_results", 0: "no_results"}
         has_results_or_not = getattr(queryset, mapping[int(value)])
         return has_results_or_not()
+
+    def has_result_set_filter(self, queryset, name, value):
+        """
+        Filter queryset by if they have a result set or not
+        """
+        mapping = {
+            1: "has_result_set",
+            0: "no_result_set",
+            2: "incomplete_result_set",
+        }
+        has_result_set_or_not = getattr(queryset, mapping[int(value)])
+        return has_result_set_or_not()
 
     election_type = django_filters.ChoiceFilter(
         widget=DSLinkWidget(),
@@ -325,10 +337,17 @@ class CurrentOrFutureBallotFilter(BaseBallotFilter):
     )
 
     has_results = django_filters.ChoiceFilter(
-        label="Has Results",
+        label="Has Candidate Results",
         method="has_results_filter",
         widget=DSLinkWidget(),
         choices=[(1, "Yes"), (0, "No")],
+    )
+
+    has_result_set = django_filters.ChoiceFilter(
+        label="Has Result Set",
+        method="has_result_set_filter",
+        widget=DSLinkWidget(),
+        choices=[(1, "Yes"), (0, "No"), (2, "Incomplete")],
     )
 
 

--- a/ynr/apps/elections/templates/elections/election_list.html
+++ b/ynr/apps/elections/templates/elections/election_list.html
@@ -82,8 +82,12 @@
           <th>Ballot</th>
           <th>Candidates known</th>
           <th>Status</th>
-          {% if group.list.0.polls_closed %}
-            <th>Has Results</th>
+          {% if group.list.0.polls_closed %} 
+            <th>Results Complete?</th>
+            <th>Winner(s) marked</th>
+            <th>Has Number of Ballots</th>
+            <th>Has Turnout Reported</th>
+            <th>Has Spoilt Ballots</th>
           {% endif %}
 
         </tr>
@@ -124,16 +128,28 @@
 
             {% endif %}
           </td>
-          {% if ballot.polls_closed %}
-          <td>
-              {% if ballot.elected_count >= ballot.winner_count %}
-                Completed
-              {% elif user_can_record_results %}
+          {% if ballot.polls_closed %} 
+            <td>
+            {% if ballot.resultset.resultset_complete %}
+              <i style="text-align:center;">✓</i>
+            {% else %}
+              {% if user_can_record_results %}
                 <a href="{{ ballot.get_results_url }}" class="button tiny">{{ ballot.results_button_text }}</a>
               {% else %}
-                No results
+                Incomplete
               {% endif %}
-          </td>
+            {% endif %}
+            </td>
+            <td>
+              {% if ballot.elected_count >= ballot.winner_count %}
+                <i style="text-align:center;">✓</i>
+              {% else %}
+                No
+              {% endif %}
+            </td>
+            <td>{% if ballot.resultset.total_electorate %}{{ ballot.resultset.total_electorate }}{% else %}No{% endif %}</td>
+            <td>{% if ballot.resultset.num_turnout_reported %}{{ ballot.resultset.num_turnout_reported }}{% else %}No{% endif %}</td>
+            <td>{% if ballot.resultset.num_spoilt_ballots %}{{ ballot.resultset.num_spoilt_ballots }}{% else %}No{% endif %}</td>
           {% endif %}
         </tr>
       {% endfor %}

--- a/ynr/apps/elections/views.py
+++ b/ynr/apps/elections/views.py
@@ -76,6 +76,7 @@ class ElectionListView(TemplateView):
         qs = (
             Ballot.objects.current_or_future()
             .select_related("election", "post")
+            .select_related("resultset")
             .prefetch_related("suggestedpostlock_set")
             .prefetch_related("officialdocument_set")
             .annotate(memberships_count=Count("membership", distinct=True))

--- a/ynr/apps/uk_results/models.py
+++ b/ynr/apps/uk_results/models.py
@@ -40,6 +40,25 @@ class ResultSet(TimeStampedModel):
         return "Result for {}".format(self.ballot.ballot_paper_id)
 
     @property
+    def resultset_complete(self):
+        """
+        Check if the result set has all the required fields filled in
+        """
+        if (
+            all(
+                [
+                    self.num_turnout_reported,
+                    self.total_electorate,
+                    self.num_spoilt_ballots,
+                    self.turnout_percentage,
+                ]
+            )
+            and self.ballot.elected_count
+        ):
+            return True
+        return False
+
+    @property
     def rank(self):
         self.ballot.result_sets.order_by("-num_turnout_reported").index(self)
 


### PR DESCRIPTION
Add `turnout`,  `electorate` and `spoilt_ballot` columns and resultset filters to help users identify gaps. 

User requested fields: 

- [x] spoilt_ballots
- [x] Reported votes cast (aka turnout)
- [x] electorate
- [ ] population
- [ ] reported turnout (%)
- [ ] declaration time
- [ ] total valid votes (calculated)
- [ ] electorate turnout % 

This change also separates the logic of 'has results' that includes both a resultset and candidate results.

<img width="788" alt="Screenshot 2024-07-10 at 10 15 49 AM" src="https://github.com/DemocracyClub/yournextrepresentative/assets/7017118/23c6157b-0f92-46d6-ba10-d5f5802618f4">

With Incomplete filter
<img width="787" alt="Screenshot 2024-07-10 at 10 16 00 AM" src="https://github.com/DemocracyClub/yournextrepresentative/assets/7017118/1e89f129-6351-46a8-9674-5e4765475af8">

With No resultset filter 
<img width="793" alt="Screenshot 2024-07-10 at 10 17 59 AM" src="https://github.com/DemocracyClub/yournextrepresentative/assets/7017118/271bacb4-a1a7-45dd-a8c8-240bb0c059a2">

And with user permissions to add results
<img width="742" alt="Screenshot 2024-07-10 at 10 20 46 AM" src="https://github.com/DemocracyClub/yournextrepresentative/assets/7017118/96b2c019-eeef-47ef-bad2-c8be6c78db90">

---

- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207728627893392