### PR TITLE
Make it easier for users to enter results

### DIFF
--- a/ynr/apps/uk_results/README.md
+++ b/ynr/apps/uk_results/README.md
@@ -6,7 +6,8 @@ The ResultSet object relates to the ballot results (not elected candidates which
 - accepts a positive integer
 - verbose_name="Reported Turnout (Number, not required)
 - help_text="The number of people who voted in this election"
-- `TO DO`: this field only accepts a whole number, but should be able to accept commas and clean them for the user
+- This field only accepts a whole number, but accepts commas and cleans them 
+on input for the user
 
 #### `turnout_percentage`: 
 - accepts an Integer
@@ -20,13 +21,15 @@ The ResultSet object relates to the ballot results (not elected candidates which
 - accepts a postive integer
 - verbose_name="Spoilt Ballots"
 - help_text="The number of spoilt ballots in this election"
-- `TO DO`: this field only accepts a whole number, but should be able to accept commas and clean them for the user
+- This field only accepts a whole number, but accepts commas and cleans them 
+on input for the user
 
 #### `total_electorate`: 
 - acceptes a positive integer
 - verbose_name="Total Electorate", aka `num_ballots`
 - help_text="The total number of people eligible to vote in this election"
-- `TO DO`: this field only accepts a whole number, but should be able to accept commas and clean them for the user
+- This field only accepts a whole number, but accepts commas and cleans them 
+on input for the user
 
 
 #### `source`: 

--- a/ynr/apps/uk_results/README.md
+++ b/ynr/apps/uk_results/README.md
@@ -1,0 +1,36 @@
+### ResultSet
+
+The ResultSet object relates to the ballot results (not elected candidates which is on the Candidate model) is created through a form populated with data from a user with permissions. The ResultSet form is used to collect the following data:
+
+#### `num_turnout_reported`: 
+- accepts a positive integer
+- verbose_name="Reported Turnout (Number, not required)
+- help_text="The number of people who voted in this election"
+- `TO DO`: this field only accepts a whole number, but should be able to accept commas and clean them for the user
+
+#### `turnout_percentage`: 
+- accepts an Integer
+- validates a minimum value of 0 and a max of 100
+- verbose_name="Turnout Percentage"
+- help_text="The percentage of the electorate who voted in this election"
+- this is automatically calculated by dividing the number of ballots cast by the total electorate if those fields are populated, otherwise accepts a whole number
+- `TO DO`: this field should accept a float and round to 2 decimal places
+
+#### `num_spoilt_ballots`: 
+- accepts a postive integer
+- verbose_name="Spoilt Ballots"
+- help_text="The number of spoilt ballots in this election"
+- `TO DO`: this field only accepts a whole number, but should be able to accept commas and clean them for the user
+
+#### `total_electorate`: 
+- acceptes a positive integer
+- verbose_name="Total Electorate", aka `num_ballots`
+- help_text="The total number of people eligible to vote in this election"
+- `TO DO`: this field only accepts a whole number, but should be able to accept commas and clean them for the user
+
+
+#### `source`: 
+- accepts text 
+- verbose_name="Source"
+- help_text="The source of the data for this result"
+- this is a free text field that is required (validation included) to verify the above data

--- a/ynr/apps/uk_results/forms.py
+++ b/ynr/apps/uk_results/forms.py
@@ -9,7 +9,7 @@ from django.db import transaction
 from django.db.models.functions import Coalesce
 from uk_results.helpers import RecordBallotResultsHelper
 from utils.db import LastWord, NullIfBlank
-from utils.widgets import DCIntegerInput
+from utils.widgets import DCIntegerInput, DCPercentageInput
 
 from .models import CandidateResult, ResultSet
 
@@ -34,7 +34,7 @@ class ResultSetForm(forms.ModelForm):
                 }
             ),
             "num_turnout_reported": DCIntegerInput(),
-            "turnout_percentage": DCIntegerInput(),
+            "turnout_percentage": DCPercentageInput(),
             "num_spoilt_ballots": DCIntegerInput(),
             "total_electorate": DCIntegerInput(),
         }

--- a/ynr/apps/uk_results/tests/test_smoke_test_views.py
+++ b/ynr/apps/uk_results/tests/test_smoke_test_views.py
@@ -48,7 +48,7 @@ class TestUKResults(TestUserMixin, UK2015ExamplesMixin, WebTest, TestCase):
         )
         resp = self.app.get(url, user=self.user_who_can_record_results)
         self.assertEqual(resp.status_code, 200)
-        self.assertContains(resp, r'pattern="[0-9\s,]*"')
+        self.assertContains(resp, r'pattern="[0-9\s\.]*"')
         form = resp.forms[1]
         form["memberships_13"] = 1000
         form["memberships_14"] = 2000

--- a/ynr/apps/utils/widgets.py
+++ b/ynr/apps/utils/widgets.py
@@ -58,8 +58,7 @@ class DCPercentageInput(TextInput):
             {
                 "pattern": r"[0-9\s\.]*",
                 "oninvalid": "this.setCustomValidity('Enter a percentage or a whole number')",
-                # round to the nearest whole number and remove the decimal
-                "onchange": "this.value = Math.round(this.value).toString().replace(/,/g, '')",
+                "onchange": "this.value = Math.round(this.value.replace(/\D/g, '')).toString()",
             }
         )
         return attrs

--- a/ynr/apps/utils/widgets.py
+++ b/ynr/apps/utils/widgets.py
@@ -1,6 +1,7 @@
 """
 For storing custom Django form widgets
 """
+
 from django.forms.widgets import Select, TextInput
 
 
@@ -42,8 +43,23 @@ class DCIntegerInput(TextInput):
         attrs = super().build_attrs(base_attrs, extra_attrs)
         attrs.update(
             {
-                "pattern": r"[0-9\s,]*",
+                "pattern": r"[0-9\s\.]*",
                 "oninvalid": "this.setCustomValidity('Enter a number')",
+                "onchange": "this.value = Math.round(this.value.replace(/\D/g, '')).toString()",
+            }
+        )
+        return attrs
+
+
+class DCPercentageInput(TextInput):
+    def build_attrs(self, base_attrs, extra_attrs=None):
+        attrs = super().build_attrs(base_attrs, extra_attrs)
+        attrs.update(
+            {
+                "pattern": r"[0-9\s\.]*",
+                "oninvalid": "this.setCustomValidity('Enter a percentage or a whole number')",
+                # round to the nearest whole number and remove the decimal
+                "onchange": "this.value = Math.round(this.value).toString().replace(/,/g, '')",
             }
         )
         return attrs


### PR DESCRIPTION
Demo https://vimeo.com/984319731/d05951fa88?share=copy

In response to requests for an improved UX for entering results, this PR: 

- [x] Audits results form fields for consistency and expectations
- [x] Adds a README.md explaining why we have certain validations for future us
- [x] Accepts and clean commas
- [x] Accepts and cleans decimals and rounds to nearest whole number
- [x] Fixes the pesky error described below 

> For reference, with two decimal places another electorate is between 71519 and 71531
> ps. [@Virginia](https://democracyclub.slack.com/team/U01HUAQV6NA) if you end up looking at the ! Enter a number errors, please double check what happens after changing it to a valid value, as I think the error message persists and I've had to re-load that page (then re-enter the value/s)



---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1207749999719967