### PR TITLE
Handle non-numeric symbols before rounding

### DIFF
--- a/ynr/apps/utils/widgets.py
+++ b/ynr/apps/utils/widgets.py
@@ -58,7 +58,13 @@ class DCPercentageInput(TextInput):
             {
                 "pattern": r"[0-9\s\.]*",
                 "oninvalid": "this.setCustomValidity('Enter a percentage or a whole number')",
-                "onchange": "this.value = Math.round(this.value.replace(/\D/g, '')).toString()",
+                "onchange": """
+                let value = this.value.replace(",", ".");
+                value = value.replace("%", "");
+                value = value.trim();
+                value = Math.round(parseFloat(value)).toString();
+                this.value = value;
+            """,
             }
         )
         return attrs


### PR DESCRIPTION
This fixes a previous PR that sought to remove decimals and round percentages to the nearest whole number. [This commit ](https://github.com/DemocracyClub/yournextrepresentative/commit/3422e6962021772005ae608f21ebdd4b07808696) rounded before removing, resulting in a greater than expected result such as 50.55 becomes 5055.

This change refactors the order of operations and handles non-numeric symbols before rounding percentages to the nearest whole number 

- 50,55
- 50.55%
- 50,55%
- 50%

