### PR TITLE
Header change to match data

### DIFF
--- a/ynr/apps/elections/templates/elections/election_list.html
+++ b/ynr/apps/elections/templates/elections/election_list.html
@@ -85,7 +85,7 @@
           {% if group.list.0.polls_closed %} 
             <th>Results Complete?</th>
             <th>Winner(s) marked</th>
-            <th>Has Number of Ballots</th>
+            <th>Has Electorate</th>
             <th>Has Turnout Reported</th>
             <th>Has Spoilt Ballots</th>
           {% endif %}


### PR DESCRIPTION
> it looks like you're showing the electorate figure but with the wrong header - changing the header text from "Has Number of Ballots" to "Has electorate" would sort that

Before https://candidates.democracyclub.org.uk/elections/

After 
<img width="822" alt="Screenshot 2024-07-18 at 2 40 26 PM" src="https://github.com/user-attachments/assets/b47a7908-c81f-4859-ba2d-8408b02056b4">
