### PR TITLE
Allow editing ballots when unlocked and not current

### DIFF
--- a/ynr/apps/elections/tests/test_ballot_lock.py
+++ b/ynr/apps/elections/tests/test_ballot_lock.py
@@ -187,6 +187,8 @@ class TestBallotLockWorks(TestUserMixin, UK2015ExamplesMixin, WebTest):
 
     def test_add_when_unlocked_allowed(self):
         self.camberwell_post_ballot.candidates_locked = False
+        self.camberwell_post_ballot.election.current = False
+        self.camberwell_post_ballot.election.save()
         self.camberwell_post_ballot.save()
         response = self.app.get(
             self.camberwell_post_ballot.get_absolute_url(),

--- a/ynr/apps/people/forms/fields.py
+++ b/ynr/apps/people/forms/fields.py
@@ -68,7 +68,7 @@ class ValidBallotField(forms.CharField):
             raise ValidationError("Unknown ballot paper ID")
 
 
-class CurrentUnlockedBallotsField(ValidBallotField):
+class UnlockedBallotsField(ValidBallotField):
     def clean(self, value):
         ballot = super().clean(value)
 
@@ -76,14 +76,22 @@ class CurrentUnlockedBallotsField(ValidBallotField):
             raise ValidationError("Ballot not selected")
 
         if ballot.candidates_locked:
-            raise ValidationError("Cannot add candidates to a locked " "ballot")
-        if not ballot.election.current:
-            raise ValidationError(
-                "Cannot update an election that isn't 'current'"
-            )
+            raise ValidationError("Cannot add candidates to a locked ballot")
+
         if ballot.cancelled and not self.user.is_staff:
             raise ValidationError(
                 "Cannot add candidates to a cancelled election"
+            )
+        return ballot
+
+
+class CurrentUnlockedBallotsField(UnlockedBallotsField):
+    def clean(self, value):
+        ballot = super().clean(value)
+
+        if not ballot.election.current:
+            raise ValidationError(
+                "Cannot update an election that isn't 'current'"
             )
         return ballot
 

--- a/ynr/apps/people/forms/forms.py
+++ b/ynr/apps/people/forms/forms.py
@@ -17,6 +17,7 @@ from parties.models import Party
 from people.forms.fields import (
     CurrentUnlockedBallotsField,
     StrippedCharField,
+    UnlockedBallotsField,
 )
 from people.helpers import (
     clean_instagram_url,
@@ -244,7 +245,7 @@ class PersonMembershipForm(PopulatePartiesMixin, forms.ModelForm):
     party_identifier = PartyIdentifierField(
         require_all_fields=False, required=True
     )
-    ballot_paper_id = CurrentUnlockedBallotsField(label="Ballot")
+    ballot_paper_id = UnlockedBallotsField(label="Ballot")
 
     party_list_position = forms.IntegerField(
         max_value=20,
@@ -418,7 +419,7 @@ class NewPersonForm(PopulatePartiesMixin, BasePersonForm):
         widget=forms.NumberInput(attrs={"class": "party-list-position"}),
     )
 
-    ballot_paper_id = CurrentUnlockedBallotsField(widget=forms.HiddenInput)
+    ballot_paper_id = UnlockedBallotsField(widget=forms.HiddenInput)
 
     def save(self, commit=True):
         person = super().save(commit)


### PR DESCRIPTION
As reported by @pmk01, if we have unlocked a ballot we should be able to add or remove memberships even if it's no longer current. 

This change keeps `CurrentUnlockedBallotsField` in case there _are_ times when we want to only add current ballots (bulk adding, for example, might get confusing if there are non-current ballots floating about), but adds `UnlockedBallotsField` to allow adding any unlocked ballot.

This should unlock better editing of past elections.