### PR TITLE
Require tests to pass before deploying

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -153,7 +153,7 @@ workflows:
     jobs:
     - build_and_test
     - deploy:
-#        requires:
-#        - build_and_test
+        requires:
+        - build_and_test
         filters: { branches: { only: [ main, master, deployment-upgrades] } }
         context: [ deployment-production-ynr, slack-secrets ]


### PR DESCRIPTION
This was commented out on GE2024 night due to needing to deploy bug fixes quickly when the site was down. I forgot to revert it until now!