### PR TITLE
Count current elections after check current

### DIFF
--- a/ynr/apps/elections/uk/every_election.py
+++ b/ynr/apps/elections/uk/every_election.py
@@ -352,6 +352,16 @@ class EveryElectionImporter(object):
         query_args["exclude_election_id_regex"] = r"^ref\..*"
         self.query_args = query_args
 
+    def count_results(self) -> int:
+        """
+        Return the count for a given set of filters
+        """
+
+        url = self.build_url_with_query_args()
+        req = requests.get(url)
+        req.raise_for_status()
+        return int(req.json().get("count", 0))
+
     def build_url_with_query_args(self):
         params = urlencode(OrderedDict(sorted(self.query_args.items())))
         return f"{self.url}?{params}"


### PR DESCRIPTION
To attempt to catch elections not importing sooner than someone else noticing. This should alert us (via Sentry) if the current election counts don't match.

Note that I'm doing this in the nightly checks because of the need to un-mark current elections in YNR. We check the counts match _after_ removing non-current elections from the YNR side. 

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1208507996613688