### PR TITLE
Remove email logger

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -85,7 +85,7 @@ PyYAML==6.0
 requests-oauthlib==1.3.1
 requests==2.31.0
 ruff==0.2.2
-sentry-sdk==1.25.0
+sentry-sdk[django]==2.18.0
 simplegeneric==0.8.1
 git+https://github.com/symroe/slacker.git
 sorl-thumbnail==12.9.0

--- a/ynr/settings/base.py
+++ b/ynr/settings/base.py
@@ -448,11 +448,10 @@ LOGGING = {
         "require_debug_false": {"()": "django.utils.log.RequireDebugFalse"}
     },
     "handlers": {
-        "mail_admins": {
+        "console": {
             "level": "ERROR",
-            "filters": ["require_debug_false"],
-            "class": "django.utils.log.AdminEmailHandler",
-        }
+            "class": "logging.StreamHandler",
+        },
     },
 }
 

--- a/ynr/settings/base.py
+++ b/ynr/settings/base.py
@@ -57,6 +57,7 @@ sentry_sdk.init(
     ],
     environment=os.environ.get("DC_ENVIRONMENT"),
     traces_sample_rate=0,
+    profiles_sample_rate=0,
 )
 
 # aws


### PR DESCRIPTION
I'm not 100% sure that this is the right logging config, but I think it will stop us getting emails. 

I've upgraded Sentry but not been able to test that it works. Something to keep an eye on after this is deployed. 

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1208714863410832