### PR TITLE
temporarily disable CandidateCompletenessView

### DIFF
--- a/ynr/apps/cached_counts/urls.py
+++ b/ynr/apps/cached_counts/urls.py
@@ -2,11 +2,11 @@ from django.urls import re_path
 
 from .views import (
     AttentionNeededView,
-    CandidateCompletenessView,
     ConstituencyCountsView,
     ElectionReportView,
     PartyCountsView,
     ReportsHomeView,
+    TempCandidateCompletenessView,
 )
 
 urlpatterns = [
@@ -28,7 +28,7 @@ urlpatterns = [
     ),
     re_path(
         r"^election/(?P<election>[-\w\.0-9]+)/completeness$",
-        CandidateCompletenessView.as_view(),
+        TempCandidateCompletenessView.as_view(),
         name="candidate_completeness",
     ),
     re_path(

--- a/ynr/apps/cached_counts/views.py
+++ b/ynr/apps/cached_counts/views.py
@@ -174,6 +174,15 @@ class ElectionReportView(DetailView):
         return context
 
 
+class TempCandidateCompletenessView(TemplateView):
+    template_name = "candidate_completeness.html"
+
+    def get(self, *args, **kwargs):
+        response = HttpResponse("Temporarily Unavailable")
+        response.status_code = 503
+        return response
+
+
 class CandidateCompletenessView(ElectionMixin, TemplateView):
     template_name = "candidate_completeness.html"
 


### PR DESCRIPTION
We are currently suffering a DoS due to someone hitting this page (which is quite slow to generate) over and over.
Obviously this isn't a permanent solution to this issue as it disables useful functionality from the site, but converting this route to something we can serve without hitting the DB will buy us some time while we work out where next.