### PR TITLE
fix friendly description text for creating or deleting candidates

### DIFF
--- a/ynr/apps/candidates/models/db.py
+++ b/ynr/apps/candidates/models/db.py
@@ -240,7 +240,7 @@ class LoggedAction(models.Model):
                 desc = f"""reverted to an earlier version of <a href="{url}">candidate #{self.person.id}</a>"""
             if self.action_type == ActionType.CANDIDACY_CREATE:
                 desc = f"""confirmed candidacy for <a href="{url}">candidate #{self.person.id}</a>"""
-            if self.action_type == ActionType.CANDIDACY_CREATE:
+            if self.action_type == ActionType.CANDIDACY_DELETE:
                 desc = f"""removed candidacy for <a href="{url}">candidate #{self.person.id}</a>"""
             if self.action_type == ActionType.DUPLICATE_SUGGEST:
                 desc = f"""Suggested a duplicate of <a href="{url}">{self.person.name}</a>"""


### PR DESCRIPTION
This was causing candidacy create actions to appear like they were delete actions in the activity finder on the homepage:
![image](https://github.com/user-attachments/assets/607ef954-94a3-4076-87ba-292d3ec60872)


And I suppose candidacy delete actions wouldn't have the correct text either.