### PR TITLE
linked in url fixes

### DIFF
--- a/ynr/apps/people/forms/forms.py
+++ b/ynr/apps/people/forms/forms.py
@@ -105,6 +105,11 @@ class PersonIdentifierForm(forms.ModelForm):
         if not value_type:
             raise forms.ValidationError("Please select a link type.")
         if self.cleaned_data.get("value_type") in self.HTTP_IDENTIFIERS:
+            # Add https schema if missing
+            if not self.cleaned_data.get("value").startswith("http"):
+                self.cleaned_data["value"] = (
+                    f"https://{self.cleaned_data['value']}"
+                )
             URLValidator()(value=self.cleaned_data["value"])
         if (
             "value_type" in self.cleaned_data

--- a/ynr/apps/people/helpers.py
+++ b/ynr/apps/people/helpers.py
@@ -137,6 +137,9 @@ def clean_linkedin_url(url):
         user_id = "".join(id_parts[::-1])
         path = f"/in/{name}-{user_id}/"
 
+    if path.startswith("/company/"):
+        raise ValueError("LinkedIn URL must be for a person, not a company.")
+
     if not path.startswith("/in/"):
         valid = False
 

--- a/ynr/apps/people/tests/test_person_form_identifier_crud.py
+++ b/ynr/apps/people/tests/test_person_form_identifier_crud.py
@@ -259,6 +259,17 @@ class PersonFormsIdentifierCRUDTestCase(TestUserMixin, WebTest):
                         ["Please enter a valid LinkedIn URL."],
                     )
 
+    def test_company_linkedin_urls(self):
+        resp = self._submit_values(
+            "https://www.linkedin.com/company/acme/", "linkedin_url"
+        )
+        form = resp.context["identifiers_formset"]
+        self.assertFalse(form.is_valid())
+        self.assertEqual(
+            form[0].non_field_errors(),
+            ["LinkedIn URL must be for a person, not a company."],
+        )
+
     def test_bad_email_address(self):
         resp = self._submit_values("whoops", "email")
         form = resp.context["identifiers_formset"]

--- a/ynr/apps/people/tests/test_person_form_identifier_crud.py
+++ b/ynr/apps/people/tests/test_person_form_identifier_crud.py
@@ -243,6 +243,8 @@ class PersonFormsIdentifierCRUDTestCase(TestUserMixin, WebTest):
             ("https://uk.linkedin.com/in/first-last-57338a4/", True),
             ("https://ie.linkedin.com/in/first-last-57338a4/", True),
             ("https://ie.linkedin.com/in/first-last-57338a4", True),
+            ("www.linkedin.com/in/first-last-57338a4", True),
+            ("linkedin.com/in/first-last-57338a4", True),
         )
         for url, valid in urls_to_valid:
             with self.subTest(url=url, value=valid):


### PR DESCRIPTION
This PR adds `https://` to user-input LinkedIn URLs if they are missing a schema at the start. It also adds a more specific error message if a user adds a LinkedIn URL to a company profile rather than a personal profile.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1208042971092873