### PR TITLE
Fix/markdown lists

### DIFF
--- a/ynr/apps/frontend/templatetags/markdown_filter.py
+++ b/ynr/apps/frontend/templatetags/markdown_filter.py
@@ -1,3 +1,4 @@
+import bleach
 import markdown
 from django import template
 from django.utils.safestring import mark_safe
@@ -7,7 +8,8 @@ register = template.Library()
 
 @register.filter(name="markdown")
 def markdown_filter(text):
-    return mark_safe(markdown.markdown(text, extensions=["nl2br"]))
+    cleaned_text = bleach.clean(text)
+    return mark_safe(markdown.markdown(cleaned_text, extensions=["nl2br"]))
 
 
 markdown_filter.is_safe = True

--- a/ynr/apps/frontend/templatetags/markdown_filter.py
+++ b/ynr/apps/frontend/templatetags/markdown_filter.py
@@ -7,7 +7,7 @@ register = template.Library()
 
 @register.filter(name="markdown")
 def markdown_filter(text):
-    return mark_safe(markdown.markdown(text))
+    return mark_safe(markdown.markdown(text, extensions=["nl2br"]))
 
 
 markdown_filter.is_safe = True

--- a/ynr/apps/frontend/tests/test_markdown_filter.py
+++ b/ynr/apps/frontend/tests/test_markdown_filter.py
@@ -1,0 +1,39 @@
+import pytest
+from django.utils.safestring import SafeString
+from frontend.templatetags.markdown_filter import markdown_filter
+
+
+@pytest.mark.parametrize(
+    "input_text, expected_output",
+    [
+        # newline to linebreak
+        (
+            "This is a test.\nNew line.",
+            "<p>This is a test.<br />\nNew line.</p>",
+        ),
+        # double newline to paragraph
+        (
+            "This is a test.\n\nNew paragraph.",
+            "<p>This is a test.</p>\n<p>New paragraph.</p>",
+        ),
+        # list with newlines to list with linebreaks
+        (
+            """ 
+    This is a list:
+    - Item 1
+    - Item 2
+    - Item 3
+    Text after a list.
+    """,
+            """<p>This is a list:<br />
+    - Item 1<br />
+    - Item 2<br />
+    - Item 3<br />
+    Text after a list.</p>""",
+        ),
+    ],
+)
+def test_markdown_filter(input_text, expected_output):
+    result = markdown_filter(input_text)
+    assert isinstance(result, SafeString)
+    assert result == expected_output

--- a/ynr/apps/people/forms/forms.py
+++ b/ynr/apps/people/forms/forms.py
@@ -364,15 +364,12 @@ class BasePersonForm(forms.ModelForm):
     )
 
     def clean_biography(self):
-        if self.cleaned_data["biography"].find("\r"):
-            self.cleaned_data["biography"] = self.cleaned_data[
-                "biography"
-            ].replace("\r", "")
+        bio = self.cleaned_data["biography"]
+        if bio.find("\r"):
+            bio = bio.replace("\r", "")
+        # Reduce > 2 newlines to 2 newlines
         return "\n\n".join(
-            [
-                line.replace("\n", " ")
-                for line in self.cleaned_data["biography"].split("\n\n")
-            ]
+            [line.strip() for line in bio.split("\n\n") if line.strip()]
         )
 
     def save(self, commit=True, user=None):

--- a/ynr/apps/people/tests/test_person_view_format.py
+++ b/ynr/apps/people/tests/test_person_view_format.py
@@ -5,12 +5,22 @@ from people.forms.forms import BasePersonForm
 
 
 class PersonFormsTestCase(TestUserMixin, WebTest, TestCase):
-    def test_clean_biography(self):
+    def test_clean_biography_returns(self):
         test_biography = "I am delighted to have been selected to be the Liberal Democrat candidate for the upcoming\r Trull, Pitminster and Corfe by-election. This\r comes after the resignation of Cllr Martin Hill for\r personal reasons; we’d like to thank Martin for\r his efforts.\r \r I am a member of Trull Parish Council and have\r enjoyed working with my colleagues there to\r achieve much on behalf of the village.\r I am well- known in Trull for my performances\r with Trull Players, my work with the Trull Party in\r the Park and for my walks through the fields and\r lanes with my rather noisy Labradoodle Poppy. I\r have lived in Staplehay since 1999 where my 3\r children attended local schools, scouts and clubs.\r Other voluntary work has been as Chair of the\r Trull Primary PTA, Social Secretary for Trull Tennis\r Club and Secretary for Trull Players.\r \r Local councillor Sarah Wakefield and I have\r known our existing for 20 years. We hold each\r other in great respect and believe working as a\r team we will serve this community well.\r \r I am thrilled to have this opportunity to represent you on the\r council. I have campaigned for this community\r on many local issues and have much experience\r in acting as a village representative through work\r on the developments at Comeytrowe and\r Broadlands, work on Canonsgrove and work on\r the Trull Neighbourhood Plan. I believe\r passionately in listening to the community and\r can be trusted to listen and act on your behalf."
         form = BasePersonForm(data={"biography": test_biography})
         cleaned_data = {}
         cleaned_data["biography"] = test_biography
         form.cleaned_data = cleaned_data
         cleaned_bio_text = "I am delighted to have been selected to be the Liberal Democrat candidate for the upcoming Trull, Pitminster and Corfe by-election. This comes after the resignation of Cllr Martin Hill for personal reasons; we’d like to thank Martin for his efforts.  I am a member of Trull Parish Council and have enjoyed working with my colleagues there to achieve much on behalf of the village. I am well- known in Trull for my performances with Trull Players, my work with the Trull Party in the Park and for my walks through the fields and lanes with my rather noisy Labradoodle Poppy. I have lived in Staplehay since 1999 where my 3 children attended local schools, scouts and clubs. Other voluntary work has been as Chair of the Trull Primary PTA, Social Secretary for Trull Tennis Club and Secretary for Trull Players.  Local councillor Sarah Wakefield and I have known our existing for 20 years. We hold each other in great respect and believe working as a team we will serve this community well.  I am thrilled to have this opportunity to represent you on the council. I have campaigned for this community on many local issues and have much experience in acting as a village representative through work on the developments at Comeytrowe and Broadlands, work on Canonsgrove and work on the Trull Neighbourhood Plan. I believe passionately in listening to the community and can be trusted to listen and act on your behalf."
+        cleaned_bio = form.clean_biography()
+        self.assertEqual(cleaned_bio, cleaned_bio_text)
+
+    def test_clean_biography_many_newlines(self):
+        test_biography = "paragraph with more than two newlines at the end\n\n\n\n\n\n\n\n\n\n\n\nFollowed by another paragraph with just two newlines.\n\nFollowed by a final paragraph."
+        form = BasePersonForm(data={"biography": test_biography})
+        cleaned_data = {}
+        cleaned_data["biography"] = test_biography
+        form.cleaned_data = cleaned_data
+        cleaned_bio_text = "paragraph with more than two newlines at the end\n\nFollowed by another paragraph with just two newlines.\n\nFollowed by a final paragraph."
         cleaned_bio = form.clean_biography()
         self.assertEqual(cleaned_bio, cleaned_bio_text)

--- a/ynr/settings/base.py
+++ b/ynr/settings/base.py
@@ -411,21 +411,6 @@ CORS_ORIGIN_ALLOW_ALL = True
 CORS_URLS_REGEX = r"^/(api|upcoming-elections)/.*$"
 CORS_ALLOW_METHODS = ("GET", "OPTIONS")
 
-MARKDOWN_DEUX_STYLES = {
-    "default": {
-        "extras": {
-            "code-friendly": True,
-            "markdown-in-html": True,
-            "footnotes": False,
-            "header-ids": True,
-            "smarty-pants": True,
-            "toc": {},
-            "fenced-code-blocks": True,
-        },
-        "safe_mode": None,
-    }
-}
-
 # TODO Delete this once election specific import are gone
 ELECTION_APP = "uk"
 ELECTION_APP_FULLY_QUALIFIED = "elections.uk"


### PR DESCRIPTION
This PR addresses how we render candidate statements in html. It:
- Changes the markdown filter that [renders candidate statements](https://github.com/DemocracyClub/yournextrepresentative/blob/5cb35bd719cd799102d753cfe3eb357020b00173/ynr/apps/elections/uk/templates/candidates/person-view.html#L132) to convert `\n` to `<br />` using a built-in [Markdown extension](https://python-markdown.github.io/extensions/nl2br/).
- Refactors the `clean_biography` method on the `BasePersonForm` to stop removing single newlines between paragraph breaks (`\n\n`) in order to preserve lists in user input.
- Removes some unused config



Closes #2490 

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1209252620895032