### PR TITLE
Fetch missing parents from election tree

### DIFF
--- a/ynr/apps/elections/uk/every_election.py
+++ b/ynr/apps/elections/uk/every_election.py
@@ -457,7 +457,10 @@ class EveryElectionImporter(object):
         child = self.election_tree[election_id]
         if election_id[:-10] == "gla.a.":
             return child
-        try:
-            return self.election_tree[child.parent]
-        except KeyError:
-            EveryElectionImporter(election_id=child.parent)
+
+        if child.parent not in self.election_tree:
+            new_importer = EveryElectionImporter(election_id=child.parent)
+            new_importer.build_election_tree()
+            self.election_tree.update(new_importer.election_tree)
+
+        return self.election_tree[child.parent]


### PR DESCRIPTION
Test and fix the problem where a parent is missing form the election tree. 

This can happen with some combinations of looking at the modified timestamp, suggested approvals, and filtering out the parents. 

This PR deals with this by fetching single parents that are missing from the tree. 