### PR TITLE
remove redundant click event

### DIFF
--- a/ynr/apps/official_documents/templates/official_documents/sopn_upload_widget.html
+++ b/ynr/apps/official_documents/templates/official_documents/sopn_upload_widget.html
@@ -65,11 +65,6 @@
             }
         }
 
-        // Click on drop area to trigger file input click
-        dropArea.addEventListener('click', function () {
-            fileInput.click();
-        });
-
         // File input change
         fileInput.addEventListener('change', function (e) {
             if (fileInput.files.length > 0) {


### PR DESCRIPTION
In some browsers (chrome, edge), clicking on the drop_area was causing the file input click event to fire twice. This PR fixes that.

`drop_area` is a label element associated with a file input element. When a label element is clicked it automatically passes focus to the associated input element and raises the click event for the input (https://developer.mozilla.org/en-US/docs/Web/HTML/Element/label) so I think the event listener that I deleted was happening over top of that default behavior.

I did try adding `e.preventDefault()` to the click event, and it did prevent the redundant input box, but then I decided the less code the better in this case.

Why this wasn't happening in firefox, I have no idea, but I did check to make sure I hadn't broken anything in firefox 137.0 and it seems fine. Would be nice to have confirmation that it works for someone else too.