### PR TITLE
Fix/stop email logging

### DIFF
--- a/deploy/webapp_settings/production.py
+++ b/deploy/webapp_settings/production.py
@@ -15,8 +15,6 @@ try:
 except requests.exceptions.RequestException:
     pass
 
-# A list of tuples containing (Full name, email address)
-ADMINS = [("YNR Prod Developers", "developers+ynr-prod@democracyclub.org.uk")]
 
 CELERY_BROKER_URL = "redis://localhost:6379/0"
 

--- a/deploy/webapp_settings/staging.py
+++ b/deploy/webapp_settings/staging.py
@@ -17,8 +17,6 @@ DATABASES = {
     },
 }
 
-# A tuple of tuples containing (Full name, email address)
-ADMINS = ("YNR Stage Developers", "developers+ynr-stage@democracyclub.org.uk")
 
 # **** Other settings that might be useful to change locally
 

--- a/ynr/settings/base.py
+++ b/ynr/settings/base.py
@@ -424,19 +424,6 @@ IMAGE_PROXY_URL = ""
 
 RESULTS_FEATURE_ACTIVE = False
 
-LOGGING = {
-    "version": 1,
-    "disable_existing_loggers": False,
-    "filters": {
-        "require_debug_false": {"()": "django.utils.log.RequireDebugFalse"}
-    },
-    "handlers": {
-        "console": {
-            "level": "ERROR",
-            "class": "logging.StreamHandler",
-        },
-    },
-}
 
 CANDIDATE_BOT_USERNAME = "CandidateBot"
 RESULTS_BOT_USERNAME = "ResultsBot"

--- a/ynr/settings/base.py
+++ b/ynr/settings/base.py
@@ -43,8 +43,6 @@ TWITTER_USERNAME = "democlub"
 # support email to:
 SUPPORT_EMAIL = "candidates@democracyclub.org.uk"
 
-# Email addresses that error emails are sent to when DEBUG = False
-ADMINS = [()]
 
 # The From: address for all emails except error emails
 DEFAULT_FROM_EMAIL = "candidates@democracyclub.org.uk"
@@ -68,8 +66,6 @@ AWS_ACCESS_KEY_ID = os.environ.get("AWS_ACCESS_KEY_ID", None)
 AWS_SECRET_ACCESS_KEY = os.environ.get("AWS_SECRET_ACCESS_KEY", None)
 AWS_SESSION_TOKEN = os.environ.get("AWS_SESSION_TOKEN", None)
 
-# The From: address for error emails
-SERVER_EMAIL = "candidates@democracyclub.org.uk"
 EMAIL_BACKEND = "django.core.mail.backends.console.EmailBackend"
 
 # SECURITY WARNING: keep the secret key used in production secret!


### PR DESCRIPTION
This PR removes the settings that cause us to receive unwanted error message emails from Django.

It doesn't address the error emails sent by cron jobs: https://github.com/DemocracyClub/yournextrepresentative/blob/584b278e924d43ec5fa17326b064d50d36fb9533/deploy/crontab.yml#L14-L18

I think we could stop those emails just by removing the above code. However:
1. Those errors aren't picked up by sentry
2. I'm not sure yet how to make them be picked up

Sentry has a [way to monitor](https://docs.sentry.io/platforms/python/crons/) crons; but, our jobs are defined in the ansible yaml, and the Sentry cron monitoring uses their python SDK so I think it would take a decent amount of refactoring work to use it.

EE gets Sentry errors when its cron jobs fail, but it's deployed differently from YNR, so I was having trouble cribbing off of it.

So, I've made this PR to at least address 1/2 of the email logging problems for now, and we can decide if it's worth addressing the cron error emails as separate issue before or after the local elections.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1208714863410832