### PR TITLE
Fix/edit results

### DIFF
--- a/ynr/apps/uk_results/templates/uk_results/ballot_paper_results_form.html
+++ b/ynr/apps/uk_results/templates/uk_results/ballot_paper_results_form.html
@@ -51,7 +51,7 @@
             Spoilt ballots
           </th>
           <td>
-            {{ version.spoilt_ballots }}
+            {{ version.spoilt_ballots|default_if_none:"" }}
           </td>
         </tr>
         <tr>
@@ -59,7 +59,7 @@
             Turnout
           </th>
           <td>
-            {{ version.turnout }}
+            {{ version.turnout|default_if_none:"" }}
           </td>
         </tr>
       </tbody>

--- a/ynr/apps/utils/widgets.py
+++ b/ynr/apps/utils/widgets.py
@@ -45,7 +45,11 @@ class DCIntegerInput(TextInput):
             {
                 "pattern": r"[0-9\s\.]*",
                 "oninvalid": "this.setCustomValidity('Enter a number')",
-                "onchange": "this.value = Math.round(this.value.replace(/\D/g, '')).toString()",
+                "onchange": """
+                if (this.value !== "") {
+                    this.value = Math.round(this.value.replace(/\D/g, '')).toString()
+                }
+                """,
             }
         )
         return attrs
@@ -62,7 +66,9 @@ class DCPercentageInput(TextInput):
                 let value = this.value.replace(",", ".");
                 value = value.replace("%", "");
                 value = value.trim();
-                value = Math.round(parseFloat(value)).toString();
+                if (value !== "") {
+                    value = Math.round(parseFloat(value)).toString();
+                }
                 this.value = value;
             """,
             }


### PR DESCRIPTION
This PR:
- Fixes an issue where removing an existing value in `DCIntegerInput` and `DCPercentageInput`  fields would set the widget value to NaN or 0 instead of setting the value to an empty string,
- Makes the older versions list display nothing instead of "None" for spoilt ballots and turnout percentage with Null values in the database.

Closes #2300 

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1209159152080104
 