### PR TITLE
add validation to person form birth_date field

### DIFF
--- a/ynr/apps/bulk_adding/forms.py
+++ b/ynr/apps/bulk_adding/forms.py
@@ -1,3 +1,5 @@
+from datetime import date
+
 from bulk_adding.fields import PersonIdentifierFieldSet
 from django import forms
 from django.core.exceptions import ValidationError
@@ -277,6 +279,14 @@ class BulkAddByPartyForm(NameOnlyPersonForm):
             [line.strip() for line in bio.split("\n\n") if line.strip()]
         )
 
+    def clean_birth_date(self):
+        bd = self.cleaned_data["birth_date"]
+        if bd:
+            current_year = date.today().year
+            min_year = str(current_year - 19)
+            if not "1900" < bd <= min_year:
+                raise ValidationError("Please enter a valid year of birth")
+        return bd
 
 class QuickAddSinglePersonForm(PopulatePartiesMixin, NameOnlyPersonForm):
     source = forms.CharField(required=True)

--- a/ynr/apps/bulk_adding/forms.py
+++ b/ynr/apps/bulk_adding/forms.py
@@ -1,5 +1,3 @@
-from datetime import date
-
 from bulk_adding.fields import PersonIdentifierFieldSet
 from django import forms
 from django.core.exceptions import ValidationError
@@ -17,6 +15,7 @@ from people.forms.fields import (
     StrippedCharField,
     ValidBallotField,
 )
+from people.helpers import clean_biography, clean_birth_date
 from popolo.models import Membership
 from search.utils import search_person_by_name
 
@@ -272,21 +271,12 @@ class BulkAddByPartyForm(NameOnlyPersonForm):
 
     def clean_biography(self):
         bio = self.cleaned_data["biography"]
-        if bio.find("\r"):
-            bio = bio.replace("\r", "")
-        # Reduce > 2 newlines to 2 newlines
-        return "\n\n".join(
-            [line.strip() for line in bio.split("\n\n") if line.strip()]
-        )
+        return clean_biography(bio)
 
     def clean_birth_date(self):
         bd = self.cleaned_data["birth_date"]
-        if bd:
-            current_year = date.today().year
-            min_year = str(current_year - 19)
-            if not "1900" < bd <= min_year:
-                raise ValidationError("Please enter a valid year of birth")
-        return bd
+        return clean_birth_date(bd)
+
 
 class QuickAddSinglePersonForm(PopulatePartiesMixin, NameOnlyPersonForm):
     source = forms.CharField(required=True)

--- a/ynr/apps/candidates/tests/test_update_view.py
+++ b/ynr/apps/candidates/tests/test_update_view.py
@@ -87,13 +87,24 @@ class TestUpdatePersonView(TestUserMixin, UK2015ExamplesMixin, WebTest):
         self.assertEqual("/person/2009", split_location.path)
         self.assertEqual(memberships_before, membership_id_set(person))
 
+    def test_update_invalid_birth_date(self):
+        response = self.app.get(
+            "/person/2009/update", user=self.user_who_can_lock
+        )
+        form = response.forms["person-details"]
+        form["birth_date"] = "952"
+        form["source"] = "An update for testing purposes"
+        response = form.submit()
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "Please enter a valid year of birth")
+
     def test_update_birth_date(self):
         memberships_before = membership_id_set(Person.objects.get(pk=2009))
         response = self.app.get(
             "/person/2009/update", user=self.user_who_can_lock
         )
         form = response.forms["person-details"]
-        form["birth_date"] = "1875"
+        form["birth_date"] = "1952"
         form["source"] = "An update for testing purposes"
         response = form.submit()
 
@@ -102,7 +113,7 @@ class TestUpdatePersonView(TestUserMixin, UK2015ExamplesMixin, WebTest):
         self.assertEqual("/person/2009", split_location.path)
 
         person = Person.objects.get(id="2009")
-        self.assertEqual(person.birth_date, "1875")
+        self.assertEqual(person.birth_date, "1952")
         self.assertEqual(memberships_before, membership_id_set(person))
 
     def test_update_person_extra_fields(self):
@@ -112,7 +123,7 @@ class TestUpdatePersonView(TestUserMixin, UK2015ExamplesMixin, WebTest):
             "/person/2009/update", user=self.user_who_can_lock
         )
         form = response.forms["person-details"]
-        form["birth_date"] = "1875"
+        form["birth_date"] = "1952"
         form["source"] = "An update for testing purposes"
         response = form.submit()
 
@@ -121,7 +132,7 @@ class TestUpdatePersonView(TestUserMixin, UK2015ExamplesMixin, WebTest):
         self.assertEqual("/person/2009", split_location.path)
 
         person = Person.objects.get(id="2009")
-        self.assertEqual(person.birth_date, "1875")
+        self.assertEqual(person.birth_date, "1952")
         versions_data = person.versions
         self.assertEqual(
             versions_data[0]["data"]["extra_fields"], {"favourite_biscuits": ""}

--- a/ynr/apps/people/forms/forms.py
+++ b/ynr/apps/people/forms/forms.py
@@ -1,5 +1,3 @@
-from datetime import date
-
 import sentry_sdk
 from candidates.models import PartySet
 from candidates.models.popolo_extra import Ballot
@@ -23,6 +21,8 @@ from people.forms.fields import (
     UnlockedBallotsField,
 )
 from people.helpers import (
+    clean_biography,
+    clean_birth_date,
     clean_instagram_url,
     clean_linkedin_url,
     clean_mastodon_username,
@@ -381,21 +381,11 @@ class BasePersonForm(forms.ModelForm):
 
     def clean_biography(self):
         bio = self.cleaned_data["biography"]
-        if bio.find("\r"):
-            bio = bio.replace("\r", "")
-        # Reduce > 2 newlines to 2 newlines
-        return "\n\n".join(
-            [line.strip() for line in bio.split("\n\n") if line.strip()]
-        )
+        return clean_biography(bio)
 
     def clean_birth_date(self):
         bd = self.cleaned_data["birth_date"]
-        if bd:
-            current_year = date.today().year
-            min_year = str(current_year - 19)
-            if not "1900" < bd <= min_year:
-                raise ValidationError("Please enter a valid year of birth")
-        return bd
+        return clean_birth_date(bd)
 
     def save(self, commit=True, user=None):
         suggested_name = self.cleaned_data["name"]

--- a/ynr/apps/people/forms/forms.py
+++ b/ynr/apps/people/forms/forms.py
@@ -1,3 +1,5 @@
+from datetime import date
+
 import sentry_sdk
 from candidates.models import PartySet
 from candidates.models.popolo_extra import Ballot
@@ -385,6 +387,15 @@ class BasePersonForm(forms.ModelForm):
         return "\n\n".join(
             [line.strip() for line in bio.split("\n\n") if line.strip()]
         )
+
+    def clean_birth_date(self):
+        bd = self.cleaned_data["birth_date"]
+        if bd:
+            current_year = date.today().year
+            min_year = str(current_year - 19)
+            if not "1900" < bd <= min_year:
+                raise ValidationError("Please enter a valid year of birth")
+        return bd
 
     def save(self, commit=True, user=None):
         suggested_name = self.cleaned_data["name"]


### PR DESCRIPTION
This PR adds a simple validation to the `birth_date` field on the BasePersonForm. The field must now be a year after 1900 and at least 19 years before the current year. 

 This closes #2494 because 0 is now an invalid input. (I've also checked prod RDS for any existing Person records with birth_date = 0 and there weren't any)

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1209555329072500