### PR TITLE
add results summary table to ballot page

### DIFF
--- a/ynr/apps/candidates/tests/test_record_winner.py
+++ b/ynr/apps/candidates/tests/test_record_winner.py
@@ -4,6 +4,7 @@ from django_webtest import WebTest
 from people.models import Person
 from people.tests.factories import PersonFactory
 from results.models import ResultEvent
+from uk_results.models import ResultSet
 
 from .auth import TestUserMixin
 from .dates import mock_in_past
@@ -31,6 +32,7 @@ class TestRecordWinner(TestUserMixin, UK2015ExamplesMixin, WebTest):
             party=self.labour_party,
             ballot=self.dulwich_post_ballot_earlier,
         )
+        ResultSet.objects.create(ballot=self.ballot)
 
     @mock.patch("django.utils.timezone.now")
     def test_record_winner_link_present(self, mock_now):
@@ -169,6 +171,7 @@ class TestRetractWinner(TestUserMixin, UK2015ExamplesMixin, WebTest):
             elected=True,
             ballot=self.ballot,
         )
+        ResultSet.objects.create(ballot=self.ballot)
 
     def test_retract_winner_link_present(self):
         response = self.app.get(

--- a/ynr/apps/elections/templates/elections/ballot_view.html
+++ b/ynr/apps/elections/templates/elections/ballot_view.html
@@ -230,7 +230,7 @@
       {% include "elections/includes/_ballot_candidates_might_stand.html" %}
       {% include "elections/includes/_ballot_candidates_not_standing.html" %}
     {% endif %}
-  {% if ballot.has_results %}
+  {% if ballot.has_results and ballot.resultset %}
     {% include "elections/includes/_ballot_results_table.html" with results=ballot.resultset %}
   {% endif %}
   </div>

--- a/ynr/apps/elections/templates/elections/ballot_view.html
+++ b/ynr/apps/elections/templates/elections/ballot_view.html
@@ -230,7 +230,9 @@
       {% include "elections/includes/_ballot_candidates_might_stand.html" %}
       {% include "elections/includes/_ballot_candidates_not_standing.html" %}
     {% endif %}
-
+  {% if ballot.has_results %}
+    {% include "elections/includes/_ballot_results_table.html" with results=ballot.resultset %}
+  {% endif %}
   </div>
   <div class="columns large-3">
       {% include "uk/data_timeline.html" %}

--- a/ynr/apps/elections/templates/elections/includes/_ballot_results_table.html
+++ b/ynr/apps/elections/templates/elections/includes/_ballot_results_table.html
@@ -1,0 +1,35 @@
+<div>
+<table class="table">
+    <thead>
+        <tr>
+        <th colspan="2">Results Summary</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td>Reported Turnout</td>
+            <td>{{ results.num_turnout_reported|default_if_none:"Unknown" }}</td>
+        </tr>
+        <tr>
+            <td>Total Electorate</td>
+            <td>{{ results.total_electorate|default_if_none:"Unknown" }}</td>
+        <tr>
+            <td>Number of Spoilt Ballots</td>
+            <td>{{ results.num_spoilt_ballots|default_if_none:"Unknown" }}</td>
+        </tr>
+        <tr>
+            <td>Turnout Percentage</td>
+            <td>
+                {% if results.turnout_percentage is not None %}
+                    {{ results.turnout_percentage }}%
+                {% else %}
+                    Unknown
+                {% endif %}
+            </td>
+        </tr>
+    </tbody>
+</table>
+<p style="font-size: x-small;">
+    Result Source: {{ results.source|default:"Unknown" }}
+</p>
+</div>

--- a/ynr/apps/elections/tests/test_ballot_view.py
+++ b/ynr/apps/elections/tests/test_ballot_view.py
@@ -347,6 +347,7 @@ class TestBallotView(
         self.ballot.election.save()
         self.create_memberships(self.ballot, self.parties)
         self.ballot.membership_set.update(elected=True)
+        ResultSet.objects.create(ballot=self.ballot)
         response = self.app.get(
             self.ballot.get_absolute_url(),
             user=self.user_who_can_record_results,


### PR DESCRIPTION
Inspired by  #175 

Whilst we show the votes cast on the ballots page, we don't show any of the fields on ResultSet. This PR adds a Results summary table to the ballot page with said fields so that users can tell more easily what still needs to be added.

![image](https://github.com/user-attachments/assets/03a4fbc7-6865-45fc-bb21-7e937d954b3e)