### PR TITLE
results: clear validation error on input

### DIFF
--- a/ynr/apps/utils/widgets.py
+++ b/ynr/apps/utils/widgets.py
@@ -45,6 +45,7 @@ class DCIntegerInput(TextInput):
             {
                 "pattern": r"[0-9\s\.]*",
                 "oninvalid": "this.setCustomValidity('Enter a number')",
+                "oninput": "this.setCustomValidity('');",
                 "onchange": """
                 if (this.value !== "") {
                     this.value = Math.round(this.value.replace(/\D/g, '')).toString()
@@ -62,6 +63,7 @@ class DCPercentageInput(TextInput):
             {
                 "pattern": r"[0-9\s\.]*",
                 "oninvalid": "this.setCustomValidity('Enter a percentage or a whole number')",
+                "oninput": "this.setCustomValidity('');",
                 "onchange": """
                 let value = this.value.replace(",", ".");
                 value = value.replace("%", "");


### PR DESCRIPTION
I actually set out trying to reproduce a totally different error but immediately bumped into this.

Basically the issue here is: If any form field is invalid, we can't submit the form because we never clear the validation error. We have to set is back to `''` or we'll always throw the same error, even if the new value is valid.

To reproduce:
- Edit results for a ballot
- Clear a field
- Press save
- Now type a number into the field
- Press save again. It will still tell you the field is invalid

This PR fixes it