### PR TITLE
skip elections that already have a modgov url

### DIFF
--- a/ynr/apps/resultsbot/election_id_to_url.csv
+++ b/ynr/apps/resultsbot/election_id_to_url.csv
@@ -104,7 +104,6 @@ local.eastleigh.2019-05-02,https://meetings.eastleigh.gov.uk/mgWebService.asmx/G
 local.west-sussex.2019-05-02,https://westsussex.moderngov.co.uk/mgWebService.asmx/GetElectionResults?lElectionId=1
 local.north-west-leicestershire.2019-05-02,https://minutes-1.nwleics.gov.uk/mgWebService.asmx/GetElectionResults?lElectionId=4
 local.stoke-on-trent.2019-05-02,http://www.moderngov.stoke.gov.uk/mgWebService.asmx/GetElectionResults?lElectionId=17
-
 local.basildon.2021-05-06,https://www.basildonmeetings.info/mgWebService.asmx/GetElectionResults?lElectionId=45
 local.barking-and-dagenham.2021-05-06,https://modgov.lbbd.gov.uk/internet/mgWebService.asmx/GetElectionResults?lElectionId=7
 local.buckinghamshire.2021-05-06,https://buckinghamshire.moderngov.co.uk/mgWebService.asmx/GetElectionResults?lElectionId=1
@@ -276,18 +275,13 @@ local.newcastle-upon-tyne.2023-05-04,https://democracy.newcastle.gov.uk/mgWebSer
 local.north-kesteven.2023-05-04,https://democracy.n-kesteven.gov.uk/mgWebService.asmx/GetElectionResults?lElectionId=57
 local.nottingham.2023-05-04,https://committee.nottinghamcity.gov.uk/mgWebService.asmx/GetElectionResults?lElectionId=8
 local.thanet.2023-05-04,https://democracy.thanet.gov.uk/mgWebService.asmx/GetElectionResults?lElectionId=88
-
 local.darlington.2023-05-04,https://democracy.darlington.gov.uk/mgWebService.asmx/GetElectionResults?lElectionId=22
 local.north-devon.2023-05-04,https://democracy.northdevon.gov.uk/mgWebService.asmx/GetElectionResults?lElectionId=5
 local.west-sussex.2023-05-04,https://westsussex.moderngov.co.uk/mgWebService.asmx/GetElectionResults?lElectionId=24
-
-
 local.brighton-and-hove.2023-05-04,https://democracy.brighton-hove.gov.uk/mgWebService.asmx/GetElectionResults?lElectionId=45
 local.swale.2023-05-04,https://ws.swale.gov.uk/meetings/mgWebService.asmx/GetElectionResults?lElectionId=16
 local.west-lancashire.2023-05-04,https://democracy.westlancs.gov.uk/mgWebService.asmx/GetElectionResults?lElectionId=500000026
-
 local.rochdale.2023-05-04,https://democracy.rochdale.gov.uk/mgWebService.asmx/GetElectionResults?lElectionId=41
-
 local.basildon.2024-05-02,https://www.basildonmeetings.info/mgWebService.asmx/GetElectionResults?lElectionId=58
 local.bradford.2024-05-02,https://bradford.moderngov.co.uk/mgWebService.asmx/GetElectionResults?lElectionId=77
 local.bromley.2024-05-02,https://cds.bromley.gov.uk/mgWebService.asmx/GetElectionResults?lElectionId=13

--- a/ynr/apps/resultsbot/management/commands/resultsbot_match_elections_for_mg_url.py
+++ b/ynr/apps/resultsbot/management/commands/resultsbot_match_elections_for_mg_url.py
@@ -25,6 +25,7 @@ class Command(BaseCommand):
         path = os.path.join(
             os.path.dirname(resultsbot.__file__), "election_id_to_url.csv"
         )
+
         with open(path) as f:
             csv_file = csv.reader(f)
             for line in csv_file:
@@ -32,6 +33,8 @@ class Command(BaseCommand):
                     id_to_url[line[0]] = line[1]
                 except IndexError:
                     continue
+
+        found_elections = self.get_found_elections(path)
 
         url = "https://docs.google.com/spreadsheets/d/e/2PACX-1vQJT-XOl2ryx0crgPLj5phgeLmJ2C_jRxVJ0WQdiGNUjguQ4xgTIe_cNTNc7VIELt4XaRy6RyCJSoAo/pub?output=csv"
         data = []
@@ -43,11 +46,10 @@ class Command(BaseCommand):
             election_id = row["Election ID"]
             url = row["ModGov Install"]
             print(repr(election_id))
-            if not election_id:
+            if not election_id or election_id in found_elections:
                 continue
 
             data.append((election_id, url))
-
         for election_id, url in data:
             if election_id in id_to_url:
                 continue
@@ -75,3 +77,16 @@ class Command(BaseCommand):
                 print("\tTry the following for debugging:")
                 print("\t" + matcher.format_elections_html_url())
                 print("\t" + matcher.format_elections_api_url())
+
+    def get_found_elections(self, path):
+        found_elections = []
+        self.stdout.write(f"Reading found elections from {path}")
+        try:
+            with open(path) as f:
+                csv_file = csv.reader(f)
+                for line in csv_file:
+                    found_elections.append(line[0])
+
+        except FileNotFoundError:
+            return []
+        return found_elections


### PR DESCRIPTION
I know this command gets run about 3 times per election but I've had unexpected free time today so so I've modified `resultsbot_match_elections_for_mg_url`  to skip elections that are already matched to a url in `election_id_to_url.csv`.