### PR TITLE
resultsbot skip total electorate if 0

### DIFF
--- a/ynr/apps/resultsbot/helpers.py
+++ b/ynr/apps/resultsbot/helpers.py
@@ -71,13 +71,15 @@ class ResultsBot(object):
                 "source": source,
                 "num_spoilt_ballots": division.spoiled_votes,
                 "turnout_percentage": division.turnout_percentage,
-                "total_electorate": division.electorate,
             }
             # Only include num_turnout_reported if it was reported in Modgov
             if division.numballotpapersissued > 0:
                 defaults[
                     "num_turnout_reported"
                 ] = division.numballotpapersissued
+            # Same for total electorate
+            if division.electorate > 0:
+                defaults["total_electorate"] = division.electorate
 
             instance, _ = ResultSet.objects.update_or_create(
                 ballot=ballot,


### PR DESCRIPTION
Results bot was setting total electorate to 0 if it was reported as so in ModGov. This PR fixes that. 

There are only 22 cases in the YNR database where total electorate = 0, so I've corrected them manually rather than re-running Results bot

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1210497094981090