### PR TITLE
skip tied vote counts in results bot import

### DIFF
--- a/ynr/apps/resultsbot/helpers.py
+++ b/ynr/apps/resultsbot/helpers.py
@@ -91,21 +91,14 @@ class ResultsBot(object):
             winner_count = ballot.winner_count
 
             if winner_count:
-                winners = dict(
-                    sorted(
-                        [
-                            (
-                                "{}-{}".format(
-                                    c.votes, c.ynr_membership.person.id
-                                ),
-                                c.ynr_membership,
-                            )
-                            for c in candidate_list
-                        ],
-                        reverse=True,
-                        key=lambda votes: int(votes[0].split("-")[0]),
-                    )[:winner_count]
+                # Select the top N candidates by votes as winners
+                sorted_candidates = sorted(
+                    candidate_list, key=lambda c: c.votes, reverse=True
                 )
+                winners = {
+                    f"{candidate.votes}-{candidate.ynr_membership.person.id}": candidate.ynr_membership
+                    for candidate in sorted_candidates[:winner_count]
+                }
             else:
                 winners = {}
 

--- a/ynr/apps/resultsbot/tests/mixins.py
+++ b/ynr/apps/resultsbot/tests/mixins.py
@@ -1,0 +1,27 @@
+from candidates.tests.factories import (
+    BallotPaperFactory,
+    ElectionFactory,
+    OrganizationFactory,
+    PostFactory,
+)
+
+
+class KirkleesBatleyEastMixin:
+    def populate_kirklees_election_data(self):
+        self.kirklees_council = OrganizationFactory(name="Kirklees Council")
+        self.kirklees_eletion = ElectionFactory(
+            slug="local.kirklees.2017-10-26"
+        )
+        self.batley_east_ward = PostFactory(
+            label="Batley East", organization=self.kirklees_council
+        )
+        self.batley_east_ballot = BallotPaperFactory(
+            ballot_paper_id="local.kirklees.batley-east.2017-10-26",
+            post=self.batley_east_ward,
+            election=self.kirklees_eletion,
+            winner_count=1,
+        )
+
+    def setUp(self):
+        super().setUp()
+        self.populate_kirklees_election_data()

--- a/ynr/apps/resultsbot/tests/test_modGovElection.py
+++ b/ynr/apps/resultsbot/tests/test_modGovElection.py
@@ -3,14 +3,9 @@ from decimal import Decimal
 from tempfile import NamedTemporaryFile
 
 import mock
-from candidates.tests.factories import (
-    BallotPaperFactory,
-    ElectionFactory,
-    OrganizationFactory,
-    PostFactory,
-)
 from django.test import TestCase
 from resultsbot.importers.modgov import ModGovElection, ModGovImporter
+from resultsbot.tests.mixins import KirkleesBatleyEastMixin
 
 with open(
     os.path.join(
@@ -26,27 +21,6 @@ def mock_mod_gov(*args, **kwargs):
 
 def mock_mapping_path():
     return NamedTemporaryFile(delete=False).name
-
-
-class KirkleesBatleyEastMixin:
-    def populate_kirklees_election_data(self):
-        self.kirklees_council = OrganizationFactory(name="Kirklees Council")
-        self.kirklees_eletion = ElectionFactory(
-            slug="local.kirklees.2017-10-26"
-        )
-        self.batley_east_ward = PostFactory(
-            label="Batley East", organization=self.kirklees_council
-        )
-        self.batley_east_ballot = BallotPaperFactory(
-            ballot_paper_id="local.kirklees.batley-east.2017-10-26",
-            post=self.batley_east_ward,
-            election=self.kirklees_eletion,
-            winner_count=1,
-        )
-
-    def setUp(self):
-        super().setUp()
-        self.populate_kirklees_election_data()
 
 
 @mock.patch(

--- a/ynr/apps/resultsbot/tests/test_resultsbot.py
+++ b/ynr/apps/resultsbot/tests/test_resultsbot.py
@@ -1,0 +1,108 @@
+from unittest.mock import MagicMock
+
+from candidates.tests.factories import MembershipFactory
+from django.conf import settings
+from django.contrib.auth.models import User
+from django.test import TestCase
+from parties.tests.factories import PartyFactory
+from people.tests.factories import PersonFactory
+from resultsbot.helpers import ResultsBot
+from resultsbot.tests.mixins import KirkleesBatleyEastMixin
+
+
+class ResultsBotAddResultsTest(KirkleesBatleyEastMixin, TestCase):
+    def setUp(self):
+        super().setUp()
+        self.user = User.objects.create_user(
+            username=settings.RESULTS_BOT_USERNAME
+        )
+        # mock ModGovdivision
+        self.division = MagicMock()
+        self.division.local_area = self.batley_east_ballot
+        self.division.spoiled_votes = 0
+        self.division.turnout_percentage = 50
+        self.division.numballotpapersissued = 100
+        self.division.electorate = 200
+
+        self.bot = ResultsBot()
+
+    def create_candidate_list(self, votes: list):
+        """
+        Creates a list of Mock ModGovCandidate objects from a list of votes.
+        """
+        candidate_list = []
+        for i in range(len(votes)):
+            candidate = MagicMock()
+            candidate.votes = votes[i]
+            candidate.ynr_membership = MembershipFactory(
+                ballot=self.batley_east_ballot,
+                person=PersonFactory(),
+                party=PartyFactory(),
+            )
+            candidate_list.append(candidate)
+        return candidate_list
+
+    def test_add_results_basic(self):
+        self.bot.add_results(
+            division=self.division,
+            candidate_list=self.create_candidate_list(votes=[50, 30, 0]),
+            source="test_source",
+        )
+
+        self.assertEqual(
+            self.batley_east_ballot.resultset.candidate_results.count(), 3
+        )
+
+    def test_add_results_tied_losers(self):
+        self.bot.add_results(
+            division=self.division,
+            candidate_list=self.create_candidate_list(votes=[10, 0, 0]),
+            source="test_source",
+        )
+
+        self.assertEqual(
+            self.batley_east_ballot.resultset.candidate_results.count(), 3
+        )
+
+    def test_add_results_tied_winners(self):
+        self.bot.add_results(
+            division=self.division,
+            candidate_list=self.create_candidate_list(votes=[10, 10]),
+            source="test_source",
+        )
+
+        # Result set is created, but candidate results are not
+        self.assertTrue(hasattr(self.batley_east_ballot, "resultset"))
+        self.assertEqual(
+            self.batley_east_ballot.resultset.candidate_results.count(), 0
+        )
+
+    def test_add_results_tied_winners_multiple_seats_contested(self):
+        self.batley_east_ballot.winner_count = 2
+        self.batley_east_ballot.save()
+
+        self.bot.add_results(
+            division=self.division,
+            candidate_list=self.create_candidate_list(votes=[30, 20, 20, 10]),
+            source="test_source",
+        )
+
+        # Result set is created, but candidate results are not
+        self.assertTrue(hasattr(self.batley_east_ballot, "resultset"))
+        self.assertEqual(
+            self.batley_east_ballot.resultset.candidate_results.count(), 0
+        )
+
+    def test_add_results_tied_losers_multiple_seats_contested(self):
+        self.batley_east_ballot.winner_count = 2
+        self.batley_east_ballot.save()
+
+        self.bot.add_results(
+            division=self.division,
+            candidate_list=self.create_candidate_list(votes=[30, 20, 10, 10]),
+            source="test_source",
+        )
+
+        self.assertEqual(
+            self.batley_east_ballot.resultset.candidate_results.count(), 4
+        )


### PR DESCRIPTION
Tied votes counts are rare and rather than teach Results Bot about coin flips, it's easier to just have it skip them.


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1210497274910295