### PR TITLE
ci: Only update the dev stack for named branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -295,16 +295,25 @@ workflows:
         context: [ deployment-production-ynr, slack-secrets ]
   container:
     jobs:
+      ##########
+      # All envs
+      ##########
       - static_tests:
           context: [ deployment-ecs-development-ynr ]
+
+      #############
+      # Development
+      #############
       - cdk_test_and_deploy:
           context: [ deployment-ecs-development-ynr ]
           requires:
             - static_tests
+          filters: { branches: { only: [ "ci/test"] } }
       - container_test_build_and_push:
           requires:
             - cdk_test_and_deploy
           context: [ deployment-ecs-development-ynr ]
+          filters: { branches: { only: [ "ci/test"] } }
       - service_update:
           requires:
             - container_test_build_and_push


### PR DESCRIPTION
In accordance with the plan outlined in the document "YNR Deployments" we wish to only deploy to the CDK-driven dev environment upon a push to the specially named branch `ci/test`
