### PR TITLE
Feature/cdk resource tagging

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -221,24 +221,66 @@ jobs:
               \
               ynr:test \
               pytest -x --ignore=node_modules
+
       - run:
-          name: Tag and push the image
+          name: Save the deterministic tag for later
           command: |
-              TAG="${CIRCLE_SHA1:0:7}"
+            echo "Determine the tag"
+            docker inspect --format="{{index .RepoDigests 0}}" ynr:prod | cut -d: -f 2 | tee manifest-tag
+
+      - persist_to_workspace:
+          root: .
+          paths:
+            - manifest-tag
+
+      - run:
+          name: Push the image with a deterministic tag
+          command: |
+              TAG=$(cat manifest-tag)
               echo Using the tag ${TAG}
               docker tag ynr:prod public.ecr.aws/h3q9h5r7/dc-test/ynr:${TAG}
               aws ecr-public get-login-password --profile default --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws/h3q9h5r7/dc-test/ynr
               docker push public.ecr.aws/h3q9h5r7/dc-test/ynr:${TAG}
 
-  service_update:
-    working_directory: ~/repo
+  deploy_cdk_environment:
     docker:
-      - image: cimg/base:current
+      - image: cimg/python:3.8.15-node
+    working_directory: ~/repo/
+    parameters:
+        dc-environment:
+          type: enum
+          enum: [ development, staging, production ]
+    environment:
+      DC_ENVIRONMENT: "<<parameters.dc-environment>>"
     steps:
       - checkout
       - aws-cli/setup
       - run:
-          name: Update the task definition to the newly pushed image
+          name: Create CDK venv and install Python and Node dependencies
+          command: |
+            python -m venv ./cdk/venv
+            . ./cdk/venv/bin/activate
+            pip install -r requirements/cdk.txt
+            npm install --save=false .
+      - run:
+          name: Show would-be changes in the stack
+          command: |
+            . ./cdk/venv/bin/activate
+            npx cdk diff
+
+      - when:
+          condition:
+            equal: [ "ci/test", << pipeline.git.branch >> ]
+          steps:
+            - run:
+                name: Deploy CDK stack infra
+                command: |
+                  . ./cdk/venv/bin/activate
+                  npx cdk deploy --verbose --require-approval never --progress events
+      # Because we use stable image tags we need to force a redeploy of the
+      # service when the container is updated
+      - run:
+          name: Force deploy the service to pick up the new image
           command: |
               IMAGE_TAG="${CIRCLE_SHA1:0:7}"
               ./scripts/ci/update-ecs-task.sh $IMAGE_TAG
@@ -246,7 +288,35 @@ jobs:
           name: Wait for the service to stabilise
           command: ./scripts/ci/wait-for-stable-ecs-service.sh
 
-  cdk_test_and_deploy:
+  tag_container_for_environment:
+    docker:
+      - image: cimg/python:3.8.15-node
+    working_directory: ~/repo/
+    parameters:
+        dc-environment:
+          type: enum
+          enum: [ development, staging, production ]
+    environment:
+      DC_ENVIRONMENT: "<<parameters.dc-environment>>"
+    steps:
+      - checkout
+      - aws-cli/setup
+      - setup_remote_docker:
+          docker_layer_caching: true
+
+      - attach_workspace:
+          at: .
+
+      - run:
+          name: Push the image with a stable tag for the environment
+          command: |
+              TAG=$(cat manifest-tag)
+              docker pull public.ecr.aws/h3q9h5r7/dc-test/ynr:${TAG}
+              docker tag public.ecr.aws/h3q9h5r7/dc-test/ynr:${TAG} public.ecr.aws/h3q9h5r7/dc-test/ynr:<< parameters.dc-environment>>
+              aws ecr-public get-login-password --profile default --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws/h3q9h5r7/dc-test/ynr
+              docker push public.ecr.aws/h3q9h5r7/dc-test/ynr:<< parameters.dc-environment>>
+
+  cdk_test:
     docker:
       - image: cimg/python:3.8.15-node
     working_directory: ~/repo/
@@ -275,20 +345,7 @@ jobs:
           command: |
             . ./cdk/venv/bin/activate
             pytest ./cdk
-      - run:
-          name: Show would-be changes in the stack
-          command: |
-            . ./cdk/venv/bin/activate
-            npx cdk diff
-      - when:
-          condition:
-            equal: [ "ci/test", << pipeline.git.branch >> ]
-          steps:
-            - run:
-                name: Deploy CDK stack infra
-                command: |
-                  . ./cdk/venv/bin/activate
-                  npx cdk deploy --verbose --require-approval never --progress events
+
 
 workflows:
   test_build_deploy:
@@ -306,28 +363,33 @@ workflows:
       ##########
       - static_tests:
           context: [ deployment-ecs-development-ynr ]
+      - cdk_test:
+          context: [ deployment-ecs-development-ynr ]
+          dc-environment: development
 
       #############
       # Development
       #############
-      - cdk_test_and_deploy:
-          context: [ deployment-ecs-development-ynr ]
-          requires:
-            - static_tests
-          filters: { branches: { only: [ "ci/test"] } }
-          dc-environment: development
       - container_test_build_and_push:
           requires:
-            - cdk_test_and_deploy
+            - static_tests
           context: [ deployment-ecs-development-ynr ]
           filters: { branches: { only: [ "ci/test"] } }
-      - service_update:
+      - tag_container_for_environment:
+          context: [ deployment-ecs-development-ynr ]
           requires:
             - container_test_build_and_push
-          context: [ deployment-ecs-development-ynr ]
           filters: { branches: { only: [ "ci/test"] } }
+          dc-environment: development
+      - deploy_cdk_environment:
+          context: [ deployment-ecs-development-ynr ]
+          requires:
+            - cdk_test
+            - tag_container_for_environment
+          filters: { branches: { only: [ "ci/test"] } }
+          dc-environment: development
       - db_migrate:
           requires:
-            - service_update
+            - deploy_cdk_environment
           context: [ deployment-ecs-development-ynr ]
           filters: { branches: { only: [ "ci/test"] } }

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -250,6 +250,12 @@ jobs:
     docker:
       - image: cimg/python:3.8.15-node
     working_directory: ~/repo/
+    parameters:
+        dc-environment:
+          type: enum
+          enum: [ development, staging, production ]
+    environment:
+      DC_ENVIRONMENT: "<<parameters.dc-environment>>"
     steps:
       - checkout
       - run:
@@ -309,6 +315,7 @@ workflows:
           requires:
             - static_tests
           filters: { branches: { only: [ "ci/test"] } }
+          dc-environment: development
       - container_test_build_and_push:
           requires:
             - cdk_test_and_deploy

--- a/cdk/app.py
+++ b/cdk/app.py
@@ -33,4 +33,7 @@ YnrStack(
     ),
 )
 
+cdk.Tags.of(app).add("dc-product", "ynr")
+cdk.Tags.of(app).add("dc-environment", dc_environment)
+
 app.synth()

--- a/cdk/app.py
+++ b/cdk/app.py
@@ -5,7 +5,26 @@ import os
 import aws_cdk as cdk
 from stack.ynr import YnrStack
 
-app = cdk.App()
+valid_environments = (
+    "development",
+    "staging",
+    "production",
+)
+
+app_wide_context = {}
+if dc_env := os.environ.get("DC_ENVIRONMENT"):
+    app_wide_context["dc-environment"] = dc_env
+
+app = cdk.App(context=app_wide_context)
+
+# Set the DC Environment early on. This is important to be able to conditionally
+# change the stack configurations
+dc_environment = app.node.try_get_context("dc-environment") or None
+assert (
+    dc_environment in valid_environments
+), f"context `dc-environment` must be one of {valid_environments}"
+
+
 YnrStack(
     app,
     "YnrStack",

--- a/scripts/ci/update-ecs-task.sh
+++ b/scripts/ci/update-ecs-task.sh
@@ -2,25 +2,8 @@
 
 set -ex
 
-if [[ $# -eq 0 ]]; then
-    cat <<EOT
-Usage: $0 <image_tag>
-
-    <image_tag> is the tag for the container image to be used for the new service definition.
-EOT
-    exit 1
-fi
-
-IMAGE_NAME=ynr
 CLUSTER_APP_TAG=ynr
 SERVICE_ROLE_TAG=web
-REGION=eu-west-2
-IMAGE_TAG=$1
-shift
-
-
-REPO="public.ecr.aws/h3q9h5r7/dc-test"
-echo "Using Repo: ${REPO}, Image: ${IMAGE_NAME}, Tag: ${IMAGE_TAG}"
 
 CLUSTER_LIST=$(aws ecs list-clusters | jq -r '.clusterArns|map(split("/")[1])[]')
 
@@ -31,14 +14,6 @@ SERVICE_LIST=$(aws ecs list-services  --cluster "${CLUSTER_NAME}" | jq -r '.serv
 # Force an error if we have a count of matching services that differs from 1
 SERVICE_NAME=$(aws ecs describe-services  --cluster "${CLUSTER_NAME}" --service "${SERVICE_LIST}" --include TAGS | jq -r --arg TAG "${SERVICE_ROLE_TAG}" '.services|map(.tags = (.tags|from_entries)) | map(select(.tags.role == $TAG ))|map(.serviceName)| if .|length != 1 then halt_error else .[0] end ')
 
-NEW_IMAGE="${REPO}/$IMAGE_NAME:$IMAGE_TAG"
-TASK_NAME=$(aws ecs describe-services --cluster "${CLUSTER_NAME}" --services "${SERVICE_NAME}" | jq -r '.services[0].taskDefinition|split("/")[1]|split(":")[0]')
-TASK_DEFINITION=$(aws ecs describe-task-definition --task-definition "$TASK_NAME" --region "$REGION")
-NEW_TASK_DEFINITION=$(echo "$TASK_DEFINITION" | jq --arg IMAGE "$NEW_IMAGE" '.taskDefinition | .containerDefinitions[0].image = $IMAGE | del(.taskDefinitionArn) | del(.revision) | del(.status) | del(.requiresAttributes) | del(.compatibilities) | del(.registeredAt) | del(.registeredBy)')
-NEW_REVISION=$(aws ecs register-task-definition --region "$REGION" --cli-input-json "$NEW_TASK_DEFINITION")
-NEW_REVISION_DATA=$(echo "$NEW_REVISION" | jq '.taskDefinition.revision')
-
-aws ecs update-service --cluster "$CLUSTER_NAME" --service "$SERVICE_NAME" --task-definition "$TASK_NAME" --force-new-deployment
+aws ecs update-service --cluster "$CLUSTER_NAME" --service "$SERVICE_NAME" --force-new-deployment
 
 echo "done"
-echo "${TASK_NAME}, Revision: ${NEW_REVISION_DATA}, Image: ${NEW_IMAGE}"


### PR DESCRIPTION
Here we add the standard Democracy Club tags to the AWS resources in the stack (`dc-product`: `ynr`, and `dc-environment`).

We also change our approach to container image labelling. We now use a stable tag for the environment. This means that the stack does not need to be updated when only the app image changes.