### PR TITLE
Create staging env

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -405,11 +405,17 @@ workflows:
           name: "STAGING build container"
           requires:
             - static_tests
-          context: [ deployment-ecs-staging-ynr ]
+          # One might expect to see the staging context here, but the
+          # development one is required because that's the account where the
+          # AWS ECR registry is found
+          context: [ deployment-ecs-development-ynr ]
           filters: { branches: { only: [ "staging", "feature/create_staging_env" ] } }
       - tag_container_for_environment:
           name: STAGING container tag
-          context: [ deployment-ecs-staging-ynr ]
+          # One might expect to see the staging context here, but the
+          # development one is required because that's the account where the
+          # AWS ECR registry is found
+          context: [ deployment-ecs-development-ynr ]
           requires:
             - STAGING build container
           filters: { branches: { only: [ "staging", "feature/create_staging_env" ] } }

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -406,13 +406,13 @@ workflows:
           requires:
             - static_tests
           context: [ deployment-ecs-staging-ynr ]
-          filters: { branches: { only: [ "staging"] } }
+          filters: { branches: { only: [ "staging", "feature/create_staging_env" ] } }
       - tag_container_for_environment:
           name: STAGING container tag
           context: [ deployment-ecs-staging-ynr ]
           requires:
             - STAGING build container
-          filters: { branches: { only: [ "staging"] } }
+          filters: { branches: { only: [ "staging", "feature/create_staging_env" ] } }
           dc-environment: staging
       - deploy_cdk_environment:
           name: STAGING cdk deploy
@@ -420,11 +420,11 @@ workflows:
           requires:
             - cdk_test
             - STAGING container tag
-          filters: { branches: { only: [ "staging"] } }
+          filters: { branches: { only: [ "staging", "feature/create_staging_env" ] } }
           dc-environment: staging
       - db_migrate:
           name: STAGING db migrate
           requires:
             - STAGING cdk deploy
           context: [ deployment-ecs-staging-ynr ]
-          filters: { branches: { only: [ "staging"] } }
+          filters: { branches: { only: [ "staging", "feature/create_staging_env" ] } }

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -267,6 +267,11 @@ jobs:
             pip install -r requirements/cdk.txt
             npm install --save=false .
       - run:
+          name: Bootstrap the CDK environment
+          command: |
+            . ./cdk/venv/bin/activate
+            npx cdk bootstrap
+      - run:
           name: Show would-be changes in the stack
           command: |
             . ./cdk/venv/bin/activate

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -225,6 +225,10 @@ jobs:
       - run:
           name: Save the deterministic tag for later
           command: |
+            # We need to push the image in order for the digest to be calculated
+            docker tag ynr:prod public.ecr.aws/h3q9h5r7/dc-test/ynr:temp
+            aws ecr-public get-login-password --profile default --region us-east-1 | docker login --username AWS --password-stdin public.ecr.aws/h3q9h5r7/dc-test/ynr
+            docker push public.ecr.aws/h3q9h5r7/dc-test/ynr:temp
             echo "Determine the tag"
             docker inspect --format="{{index .RepoDigests 0}}" ynr:prod | cut -d: -f 2 | tee manifest-tag
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -272,15 +272,11 @@ jobs:
             . ./cdk/venv/bin/activate
             npx cdk diff
 
-      - when:
-          condition:
-            equal: [ "ci/test", << pipeline.git.branch >> ]
-          steps:
-            - run:
-                name: Deploy CDK stack infra
-                command: |
-                  . ./cdk/venv/bin/activate
-                  npx cdk deploy --verbose --require-approval never --progress events
+      - run:
+          name: Deploy CDK stack infra
+          command: |
+            . ./cdk/venv/bin/activate
+            npx cdk deploy --verbose --require-approval never --progress events
       # Because we use stable image tags we need to force a redeploy of the
       # service when the container is updated
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -371,25 +371,60 @@ workflows:
       # Development
       #############
       - container_test_build_and_push:
+          name: "DEV build container"
           requires:
             - static_tests
           context: [ deployment-ecs-development-ynr ]
           filters: { branches: { only: [ "ci/test"] } }
       - tag_container_for_environment:
+          name: DEV container tag
           context: [ deployment-ecs-development-ynr ]
           requires:
-            - container_test_build_and_push
+            - DEV build container
           filters: { branches: { only: [ "ci/test"] } }
           dc-environment: development
       - deploy_cdk_environment:
+          name: DEV cdk deploy
           context: [ deployment-ecs-development-ynr ]
           requires:
             - cdk_test
-            - tag_container_for_environment
+            - DEV container tag
           filters: { branches: { only: [ "ci/test"] } }
           dc-environment: development
       - db_migrate:
+          name: DEV db migrate
           requires:
-            - deploy_cdk_environment
+            - DEV cdk deploy
           context: [ deployment-ecs-development-ynr ]
           filters: { branches: { only: [ "ci/test"] } }
+
+      #########
+      # Staging
+      #########
+      - container_test_build_and_push:
+          name: "STAGING build container"
+          requires:
+            - static_tests
+          context: [ deployment-ecs-staging-ynr ]
+          filters: { branches: { only: [ "staging"] } }
+      - tag_container_for_environment:
+          name: STAGING container tag
+          context: [ deployment-ecs-staging-ynr ]
+          requires:
+            - STAGING build container
+          filters: { branches: { only: [ "staging"] } }
+          dc-environment: staging
+      - deploy_cdk_environment:
+          name: STAGING cdk deploy
+          context: [ deployment-ecs-staging-ynr ]
+          requires:
+            - cdk_test
+            - STAGING container tag
+          filters: { branches: { only: [ "staging"] } }
+          dc-environment: staging
+      - db_migrate:
+          name: STAGING db migrate
+          requires:
+            - STAGING cdk deploy
+          context: [ deployment-ecs-staging-ynr ]
+          filters: { branches: { only: [ "staging"] } }

--- a/cdk/stack/ynr.py
+++ b/cdk/stack/ynr.py
@@ -26,11 +26,9 @@ class YnrStack(Stack):
     def __init__(self, scope: Construct, construct_id: str, **kwargs) -> None:
         super().__init__(scope, construct_id, **kwargs)
 
-        vpc = ec2.Vpc.from_lookup(self, "YnrVpc",
-            vpc_id = ssm.StringParameter.value_from_lookup(self, "vpcid")
-        )
+        default_vpc = ec2.Vpc.from_lookup(self, "YnrVpc", is_default=True)
+        cluster = ecs.Cluster(self, "YnrCluster", vpc=default_vpc)
 
-        cluster = ecs.Cluster(self, "YnrCluster", vpc=vpc)
         encryption_key = kms.Alias.from_alias_name(
             self, "SSMKey", "alias/aws/ssm"
         )

--- a/cdk/stack/ynr.py
+++ b/cdk/stack/ynr.py
@@ -26,12 +26,8 @@ class YnrStack(Stack):
     def __init__(self, scope: Construct, construct_id: str, **kwargs) -> None:
         super().__init__(scope, construct_id, **kwargs)
 
-        vpc = ec2.Vpc.from_lookup(
-            self,
-            "YnrVpc",
-            vpc_id=ssm.StringParameter.value_from_lookup(
-                self, "/dc/ynr/dev/1/vpcid"
-            ),
+        vpc = ec2.Vpc.from_lookup(self, "YnrVpc",
+            vpc_id = ssm.StringParameter.value_from_lookup(self, "vpcid")
         )
 
         cluster = ecs.Cluster(self, "YnrCluster", vpc=vpc)
@@ -64,35 +60,35 @@ class YnrStack(Stack):
                         ssm.StringParameter.from_string_parameter_name(
                             self,
                             "DSM",
-                            "/dc/ynr/dev/1/web/DJANGO_SETTINGS_MODULE",
+                            "DJANGO_SETTINGS_MODULE",
                         )
                     ),
                     "YNR_AWS_S3_MEDIA_BUCKET": ecs.Secret.from_ssm_parameter(
                         ssm.StringParameter.from_string_parameter_name(
                             self,
                             "MediaBucketName",
-                            "/dc/ynr/dev/1/YNR_AWS_S3_MEDIA_BUCKET",
+                            "YNR_AWS_S3_MEDIA_BUCKET",
                         )
                     ),
                     "YNR_AWS_S3_MEDIA_REGION": ecs.Secret.from_ssm_parameter(
                         ssm.StringParameter.from_string_parameter_name(
                             self,
                             "MediaBucketRegion",
-                            "/dc/ynr/dev/1/YNR_AWS_S3_MEDIA_REGION",
+                            "YNR_AWS_S3_MEDIA_REGION",
                         )
                     ),
                     "YNR_AWS_S3_SOPN_BUCKET": ecs.Secret.from_ssm_parameter(
                         ssm.StringParameter.from_string_parameter_name(
                             self,
                             "SopnBucketName",
-                            "/dc/ynr/dev/1/YNR_AWS_S3_SOPN_BUCKET",
+                            "YNR_AWS_S3_SOPN_BUCKET",
                         )
                     ),
                     "YNR_AWS_S3_SOPN_REGION": ecs.Secret.from_ssm_parameter(
                         ssm.StringParameter.from_string_parameter_name(
                             self,
                             "SopnBucketRegion",
-                            "/dc/ynr/dev/1/YNR_AWS_S3_SOPN_REGION",
+                            "YNR_AWS_S3_SOPN_REGION",
                         )
                     ),
                     "POSTGRES_USERNAME": ecs.Secret.from_ssm_parameter(
@@ -100,7 +96,7 @@ class YnrStack(Stack):
                             self,
                             "DBUSER",
                             encryption_key=encryption_key,
-                            parameter_name="/dc/ynr/dev/1/postgres_username",
+                            parameter_name="postgres_username",
                         )
                     ),
                     "POSTGRES_PASSWORD": ecs.Secret.from_ssm_parameter(
@@ -108,7 +104,7 @@ class YnrStack(Stack):
                             self,
                             "DBPASSWD",
                             encryption_key=encryption_key,
-                            parameter_name="/dc/ynr/dev/1/postgres_password",
+                            parameter_name="postgres_password",
                         )
                     ),
                     "POSTGRES_HOST": ecs.Secret.from_ssm_parameter(
@@ -116,7 +112,7 @@ class YnrStack(Stack):
                             self,
                             "DBHOST",
                             encryption_key=encryption_key,
-                            parameter_name="/dc/ynr/dev/1/postgres_host",
+                            parameter_name="postgres_host",
                         )
                     ),
                 },

--- a/docs/AWS_ENVIRONMENTS.md
+++ b/docs/AWS_ENVIRONMENTS.md
@@ -1,0 +1,113 @@
+# Description
+
+This document explains how the AWS environments are configured and attempts to
+identify (where relevant) the sequencing of events and resources, and which of
+these are manual and which are automated.
+
+The Democracy Club convention is to have one AWS account per app per
+environment insofar as is possible, and we follow that convention for this app.
+One outlier which is worthy of mention is the Development account, which also
+holds the public container registry.
+
+# CI Deploy user
+Note: This section is written with the assumption that we use CircleCI for
+deployments.
+
+* Authenticate with the CircleCI web interface and create a context
+for the environment. Ideally use a name of the form
+`deployment-ecs-development-ynr`, replacing the penultimate component with the
+environment name.
+* In the AWS web console, create an IAM User called `CircleCIDeployer`
+(https://us-east-1.console.aws.amazon.com/iam/home?region=eu-west-2#/users).
+* Create an access key / token pair for this user and add it to the CircleCI
+context for the YNR app in this environment.
+* Create a UserGroup called CircleCIDeployer and add the user you've just
+created to that group.
+* Add the following permission policies to that UserGroup:
+  * `AmazonEC2ContainerRegistryFullAccess`
+  * `AmazonECS_FullAccess`
+  * `AmazonElasticContainerRegistryPublicFullAccess`
+  * `AmazonS3FullAccess`
+  * `AmazonSSMFullAccess`
+  * `AmazonVPCReadOnlyAccess`
+  * `AWSCloudFormationFullAccess`
+  * `IAMFullAccess`
+
+Note that you'll need to do this for each new environment / AWS account.
+
+# VPC
+
+Because we have an AWS account on a per-app, per-environment basis, we are able
+to use the default VPC to hold the relevant infrastructure.
+
+# Shared Docker Registry
+
+We use AWS Elastic Container Registry Public to host the container images. We
+use the same registry for each environment, intentionally so, such that we can
+be confident the same image will be promoted between environments.
+
+At the time of writing the registry is in the account used by the development
+environment. If it gets moved to another account then some likely steps will be:
+
+* Create a context in which there are variables exposed containing AWS access credentials for the correct account.
+* Add this CircleCI context to the .circleci/config.yml file in the workflows calling jobs which perform the docker push/tag operations.
+
+# Database creation
+
+The database is intentionally managed outside of the stack automation, such
+that the database remains in the event of stack deletion.
+
+The simplest approach (from a networking point of view) is to create the RDS
+instance where the app will be, i.e. inside the default VPC.  If you create the
+datbase elsewhere (or perhaps have an existing database but wish to create a
+CDK-driven application layer) then you will need to configure VPC peering and
+ensure that there are relevant security group rules to allow the app to connect.
+
+Here is the recommended RDS configuration:
+* Size: t3 Micro
+* Single AZ
+* Name: `ynr-environment-db` (e.g. `ynr-development-db`)
+* Engine: 16.8
+* Option group: default
+* 1G RAM, 2 vCPUs
+* Storage: gp3, 20G, 3000 iops
+* Master username: postgres
+* Public access: Yes
+* VPC: Default
+* Security group: Create a new one with the name `ynr-development-db` (or `staging` or `production`)
+* Add the customary Democracy club tags of: `dc-product`: `ynr` and `dc-environment`: `development` (or `staging` or `production`)
+
+The reason for public internet access is that it allows developers to perform
+investigation and diagnostic operations. But note that though the instance is
+theoretically open, security group rules are used to keep access tight.
+
+The recommended security group rules are as follows:
+
+* Port 5432, address range 172.31.0.0/16, Description: Application (NB the default VPC uses this address space whereas user-created VPC typically use 10.0.0.0/16)
+* Plus rule(s) for individual developer home IP addresses. Give any such rules a sensible description, in order to make it easier to keep these rules pruned.
+
+You will need to connect to the database and either import a dump file or
+manually create a postgres role (called e.g. `djangouser`) for the application and then a database owned
+by that role (called e.g. `ynr`)
+
+# Parameter store
+
+Add parameter store (https://eu-west-2.console.aws.amazon.com/systems-manager/parameters) entries as follows:
+
+* `DJANGO_SETTINGS_MODULE`, type String - the value `ynr.settings.deploy`
+* `YNR_AWS_S3_MEDIA_BUCKET`, type String - the name of the bucket being used for images etc
+* `YNR_AWS_S3_MEDIA_REGION`, type String - the region for this bucket
+* `YNR_AWS_S3_SOPN_BUCKET`, type String - the bucket used for SOPN uploads
+* `YNR_AWS_S3_SOPN_REGION`, type String - the region for this bucket
+* `postgres_host`, type SecureString - the RDS instance, as previous section
+* `postgres_username` type SecureString - be sure to use the app credentials and not the master postgres role
+* `postgres_password` type SecureString
+
+# Environment build / update
+
+Initial build and update are done in the same way as each other.
+
+Deployments go to an environment depending on the branch name being used.
+
+* `ci/test` - this goes to the development environment.
+* `staging` - this goes to the staging environment.


### PR DESCRIPTION
Although the eventual goal is to have deployments to the staging environment (and subsequently production)  be triggered by pushes to the `master` branch, this PR uses the branch name `staging` in order to give a mechanism to validate the new environment without risk of disrupting the existing EC2 environment.
