### PR TITLE
Add MVP CloudFront

### DIFF
--- a/cdk/stack/ynr.py
+++ b/cdk/stack/ynr.py
@@ -31,7 +31,7 @@ class YnrStack(Stack):
     def __init__(self, scope: Construct, construct_id: str, **kwargs) -> None:
         super().__init__(scope, construct_id, **kwargs)
 
-        self.dc_environment = self.node.try_get_context("dc-environment")
+        self.dc_environment = self.node.get_context("dc-environment")
 
         default_vpc = ec2.Vpc.from_lookup(self, "YnrVpc", is_default=True)
         cluster = ecs.Cluster(self, "YnrCluster", vpc=default_vpc)

--- a/cdk/tests/test_ynr_stack.py
+++ b/cdk/tests/test_ynr_stack.py
@@ -1,20 +1,16 @@
-import os
-
-import aws_cdk as core
 import aws_cdk.assertions as assertions
-from stack.ynr import YnrStack
 
 
-def test_template_components():
-    app = core.App()
-    stack = YnrStack(
-        app,
-        "YnrStack",
-        env={
-            "account": os.getenv("CDK_DEFAULT_ACCOUNT"),
-            "region": os.getenv("CDK_DEFAULT_REGION"),
-        },
-    )
+def test_template_components(monkeypatch):
+    monkeypatch.setenv("DC_ENVIRONMENT", "development")
+    monkeypatch.setenv("CDK_DEFAULT_ACCOUNT", "123")
+    monkeypatch.setenv("CDK_DEFAULT_REGION", "eu-west-2")
+
+    # Import here to ensure env is patched
+    from app import app
+
+    stack = app.node.find_child("YnrStack")
+
     template = assertions.Template.from_stack(stack)
 
     # We're managing the ECS Cluster in-stack, instead of taking a cluster ID

--- a/docs/AWS_ENVIRONMENTS.md
+++ b/docs/AWS_ENVIRONMENTS.md
@@ -102,6 +102,7 @@ Add parameter store (https://eu-west-2.console.aws.amazon.com/systems-manager/pa
 * `postgres_host`, type SecureString - the RDS instance, as previous section
 * `postgres_username` type SecureString - be sure to use the app credentials and not the master postgres role
 * `postgres_password` type SecureString
+* `FQDN`: type String - The domain name to use for this environment
 
 # Environment build / update
 
@@ -111,3 +112,16 @@ Deployments go to an environment depending on the branch name being used.
 
 * `ci/test` - this goes to the development environment.
 * `staging` - this goes to the staging environment.
+
+
+# Domains and certificates 
+
+For each new environment we need to manually create a hosted zone that 
+matches the `FQDN` value in the parameter store. 
+
+This domain needs an ACM certificate to be manually created in the `us-east-1` 
+region. Once created, add the ARN against the environment to the `cert_arns` 
+dict in cdk/stack/ynr.py.
+
+A new deployment will create a CloudFront distribution and set up the 
+required DNS. 


### PR DESCRIPTION
This PR adds CloudFront in front of the existing ALB. It also links the DNS up, assuming a hosted zone matching the FQDN already exists in the given account. 

I've manually deployed this to the dev account using `cdk deploy` and I can verify it's working. There is some manual steps to get this working in the stage account that I've not attempted yet. 