### PR TITLE
Don't pin the hurl version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,9 +21,8 @@ jobs:
       - run:
          name: Run hurl tests
          command: |
-            VERSION=6.1.1
             sudo apt-add-repository -y ppa:lepapareil/hurl
-            sudo apt install -y jq hurl="${VERSION}"*
+            sudo apt install -y jq hurl
             cd hurl-tests
             hurl --test -m 10 --variable host=$(jq -r '.YnrStack|to_entries|map(select(.key|startswith("YnrServiceServiceURL"))|.value)[0]' ../ynr-${DC_ENVIRONMENT}-stack-out.json) *.hurl
 


### PR DESCRIPTION
hurl had a new release, and the old version was removed from the PPA. We remove the version pin to prevent subsequent releases from causing a CI failure during the post-deploy checks.