### PR TITLE
Use DB cache

### DIFF
--- a/deploy/deploy.yml
+++ b/deploy/deploy.yml
@@ -66,6 +66,12 @@
         virtualenv: "{{ project_root }}/env"
       when: (application_git_repo.changed) or (application_config.changed)
 
+    - name: Create django cache table
+      django_manage:
+        command: createcachetable
+        app_path: "{{ project_root }}/code"
+        virtualenv: "{{ project_root }}/env"
+
     - name: Install packages based on package.json.
       npm:
         path: "{{ project_root }}/code"

--- a/deploy/webapp_settings/production.py
+++ b/deploy/webapp_settings/production.py
@@ -40,13 +40,7 @@ CACHES = {
         "BACKEND": "django.core.cache.backends.memcached.PyMemcacheCache",
         "LOCATION": "127.0.0.1:11211",
         "KEY_PREFIX": DATABASES["default"]["NAME"],  # noqa
-    },
-    "thumbnails": {
-        "TIMEOUT": 60 * 60 * 24 * 2,  # expire after two days
-        "BACKEND": "django.core.cache.backends.memcached.PyMemcacheCache",
-        "LOCATION": "127.0.0.1:11211",
-        "KEY_PREFIX": DATABASES["default"]["NAME"] + "-thumbnails",  # noqa
-    },
+    }
 }
 
 # **** Settings that might be useful in production

--- a/deploy/webapp_settings/production.py
+++ b/deploy/webapp_settings/production.py
@@ -37,9 +37,8 @@ INTERNAL_IPS = [
 CACHES = {
     "default": {
         "TIMEOUT": None,  # cache keys never expire; we invalidate them
-        "BACKEND": "django.core.cache.backends.memcached.PyMemcacheCache",
-        "LOCATION": "127.0.0.1:11211",
-        "KEY_PREFIX": DATABASES["default"]["NAME"],  # noqa
+        "BACKEND": "django.core.cache.backends.db.DatabaseCache",
+        "LOCATION": "ynr_cache",
     }
 }
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -25,6 +25,8 @@ a containerised database as follows:
    ```
 1. Apply any pending migrations:
    `./scripts/container.run.bash python manage.py migrate`
+1. Ensure the cache table exists:
+   `./scripts/container.manage-py.bash createcachetable`
 1. Shut down the database container:
    `podman compose down`
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -211,3 +211,27 @@ index).
 ```
 ./scripts/container.image.build.bash test --no-cache
 ```
+
+
+# Podman [compose] fails
+
+If there are problems using the `podman compose` (with space) command, first 
+check you have `podman-compose==v1.2.0` installed:
+
+`podman-compose --version`
+
+If you're still having problems, one 
+option is to burn everything down and start again:
+
+```shell
+podman down
+podman system migrate
+podman system reset
+podman system disable
+systemctl stop podman.socket
+systemctl disable podman.socket
+systemctl --user start podman.socket
+systemctl --user start podman
+```
+
+Once this is done, try running the `podman compose` commands again.

--- a/scripts/ci/dbmigrate.bash
+++ b/scripts/ci/dbmigrate.bash
@@ -11,4 +11,4 @@ CLUSTER=$(aws ecs list-clusters | jq -r  .clusterArns[0])
 TASK_LIST=$(aws ecs list-tasks --cluster "${CLUSTER}" | jq -r .taskArns[])
 
 # Pick one of the web containers
-aws ecs describe-tasks --include TAGS --cluster "${CLUSTER}" --tasks "${TASK_LIST}" | jq -r '.tasks|map({arn: .containers[].taskArn, role: .overrides.containerOverrides[].name}) | map(select(.role == "web"))[0].arn|split("/") | "unbuffer aws ecs execute-command --cluster " + .[1] + " --command \"python manage.py migrate\" --interactive --task " + .[2]' | sh
+aws ecs describe-tasks --include TAGS --cluster "${CLUSTER}" --tasks "${TASK_LIST}" | jq -r '.tasks|map({arn: .containers[].taskArn, role: .overrides.containerOverrides[].name}) | map(select(.role == "web"))[0].arn|split("/") | "unbuffer aws ecs execute-command --cluster " + .[1] + " --command \"python manage.py migrate && python manage.py createcachetable\" --interactive --task " + .[2]' | sh

--- a/ynr/settings/base.py
+++ b/ynr/settings/base.py
@@ -346,13 +346,7 @@ CACHES = {
         "BACKEND": "django.core.cache.backends.memcached.PyMemcacheCache",
         "LOCATION": "127.0.0.1:11211",
         "KEY_PREFIX": DATABASES["default"]["NAME"],
-    },
-    "thumbnails": {
-        "TIMEOUT": 60 * 60 * 24 * 2,  # expire after two days
-        "BACKEND": "django.core.cache.backends.memcached.PyMemcacheCache",
-        "LOCATION": "127.0.0.1:11211",
-        "KEY_PREFIX": DATABASES["default"]["NAME"] + "-thumbnails",
-    },
+    }
 }
 
 # sorl-thumbnail settings:

--- a/ynr/settings/base.py
+++ b/ynr/settings/base.py
@@ -343,9 +343,8 @@ Q_CLUSTER = {
 CACHES = {
     "default": {
         "TIMEOUT": None,  # cache keys never expire; we invalidate them
-        "BACKEND": "django.core.cache.backends.memcached.PyMemcacheCache",
-        "LOCATION": "127.0.0.1:11211",
-        "KEY_PREFIX": DATABASES["default"]["NAME"],
+        "BACKEND": "django.core.cache.backends.db.DatabaseCache",
+        "LOCATION": "ynr_cache",
     }
 }
 


### PR DESCRIPTION
I think this is all that's needed. The cache interface should be such that we don't need to change the application code. 

I've called `createcachetable` on every deploy. [The docs](https://docs.djangoproject.com/en/5.2/topics/cache/#creating-the-cache-table) suggest this is fine, but we can make it a one time call if we think it's not needed. 

This is going to be tricky to test in current legacy production, but we can see if this works in the new envs.  