### PR TITLE
fix var quoting on dbmigrate script

### DIFF
--- a/scripts/ci/dbmigrate.sh
+++ b/scripts/ci/dbmigrate.sh
@@ -8,7 +8,7 @@ sudo apt update
 sudo apt install -y expect
 
 CLUSTER=$(aws ecs list-clusters | jq -r  .clusterArns[0])
-TASK_LIST=$(aws ecs list-tasks --cluster ${CLUSTER} | jq -r .taskArns[])
+TASK_LIST=$(aws ecs list-tasks --cluster "${CLUSTER}" | jq -r .taskArns[])
 
 # Pick one of the web containers
-aws ecs describe-tasks --include TAGS --cluster ${CLUSTER} --tasks ${TASK_LIST} | jq -r '.tasks|map({arn: .containers[].taskArn, role: .overrides.containerOverrides[].name}) | map(select(.role == "web"))[0].arn|split("/") | "unbuffer aws ecs execute-command --cluster " + .[1] + " --command \"python manage.py migrate\" --interactive --task " + .[2]' | sh
+aws ecs describe-tasks --include TAGS --cluster "${CLUSTER}" --tasks "${TASK_LIST}" | jq -r '.tasks|map({arn: .containers[].taskArn, role: .overrides.containerOverrides[].name}) | map(select(.role == "web"))[0].arn|split("/") | "unbuffer aws ecs execute-command --cluster " + .[1] + " --command \"python manage.py migrate\" --interactive --task " + .[2]' | sh


### PR DESCRIPTION
this fixes the shellcheck errors on the build

I think https://github.com/DemocracyClub/yournextrepresentative/pull/2565 didn't have the commits from https://github.com/DemocracyClub/yournextrepresentative/pull/2563 on the branch when I merged it. So the CI build passed on the PR branch, but then it picked up the failure when merged.