### PR TITLE
fix postgres healthcheck

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -55,7 +55,7 @@ services:
     ports:
       - 54321:5432
     healthcheck:
-      test: pg_isready
+      test: [ "CMD-SHELL", "pg_isready -d $${POSTGRES_DB} -U $${POSTGRES_USER}" ]
       interval: 30s
       timeout: 60s
       retries: 5


### PR DESCRIPTION
Currently if you run YNR in a container, you get a lot of `FATAL:  role "root" does not exist` in the logs.

This is because we're trying to run the healthcheck as root.
This PR switches to running the healthcheck as the YNR user, silencing that noise