### PR TITLE
use manage.py runserver in local dev

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ volumes:
 services:
   frontend: &service_defaults
     image: ynr:test
-    command: gunicorn --reload --log-level=debug ynr.wsgi
+    command: python manage.py runserver 0.0.0.0:80
     env_file:
       - path: env/frontend.env
         required: false


### PR DESCRIPTION
Fixes https://app.asana.com/1/1204880536137786/project/1207876275349083/task/1210124705541020?focus=true

Gunicorn's reloader module only monitors for changes in python files. This means that at the moment the server does not reload on changes to django template files (or any other non-python files, like css, javascript, etc)

Gunicorn does have a [reload_extra_files](https://docs.gunicorn.org/en/stable/settings.html#reload-extra-files) option, which you can use to specify additional files to watch. However, reload_extra_files doesn't support globs or wildcards, so we can't just pass it `--reload-extra-files=**/*.html`, or whatever. There's an open feature request for this at https://github.com/benoitc/gunicorn/issues/1643 but this feature doesn't currently exist.

The path of least resistance here is to just use `manage.py runserver` as our dev server (which is what we do on all our other projects anyway). 