### PR TITLE
WIP add more important settings to ECS

### DIFF
--- a/ynr/settings/base.py
+++ b/ynr/settings/base.py
@@ -47,13 +47,15 @@ SUPPORT_EMAIL = "candidates@democracyclub.org.uk"
 # The From: address for all emails except error emails
 DEFAULT_FROM_EMAIL = "candidates@democracyclub.org.uk"
 
+DC_ENVIRONMENT = os.environ.get("DC_ENVIRONMENT", "development")
+
 # Sentry config
 sentry_sdk.init(
     dsn=os.environ.get("SENTRY_DSN"),
     integrations=[
         django.DjangoIntegration(),
     ],
-    environment=os.environ.get("DC_ENVIRONMENT"),
+    environment=DC_ENVIRONMENT,
     traces_sample_rate=0,
     profiles_sample_rate=0,
 )

--- a/ynr/settings/base_from_environment.py
+++ b/ynr/settings/base_from_environment.py
@@ -5,17 +5,22 @@ import os
 
 from .base import *  # noqa
 
+INTERNAL_IPS = [
+    "127.0.0.1",
+    "localhost",
+]
+
+SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
+ACCOUNT_DEFAULT_HTTP_PROTOCOL = "https"
+CSRF_TRUSTED_ORIGINS = [
+    f"https://{os.environ.get('FQDN')}",
+]
+USE_X_FORWARDED_HOST = True
+
+RUNNING_TESTS = False
+
 SECRET_KEY = os.environ["YNR_DJANGO_SECRET_KEY"]
-# DATABASES = {
-#    "default": {
-#        "ENGINE": "django.db.backends.postgresql",
-#        "HOST": os.environ["YNR_POSTGRES_HOSTNAME"],
-#        "NAME": os.environ["YNR_POSTGRES_DATABASE"],
-#        "USER": os.environ["YNR_POSTGRES_USERNAME"],
-#        "PASSWORD": os.environ["YNR_POSTGRES_PASSWORD"],
-#        "OPTIONS": {"sslmode": "require"},
-#    }
-# }
+
 
 # In an AWS-ECS-behind-ALB context, the ALB's health checks don't yet arrive
 # with a meaningful HTTP host header. We currently rely on the ALB to route
@@ -24,9 +29,38 @@ SECRET_KEY = os.environ["YNR_DJANGO_SECRET_KEY"]
 # module.
 ALLOWED_HOSTS = ["*"]
 
+
+STATICFILES_STORAGE = "ynr.storages.StaticStorage"
+DEFAULT_FILE_STORAGE = "ynr.storages.MediaStorage"
 AWS_STORAGE_BUCKET_NAME = os.environ["YNR_AWS_S3_MEDIA_BUCKET"]
 AWS_S3_REGION_NAME = os.environ["YNR_AWS_S3_MEDIA_REGION"]
+STATICFILES_LOCATION = "static"
+MEDIAFILES_LOCATION = "media"
+AWS_DEFAULT_ACL = "public-read"
+AWS_BUCKET_ACL = AWS_DEFAULT_ACL
+AWS_QUERYSTRING_AUTH = False
+
 
 TEXTRACT_S3_BUCKET_NAME = os.environ["YNR_AWS_S3_SOPN_BUCKET"]
 TEXTRACT_S3_BUCKET_REGION = os.environ["YNR_AWS_S3_SOPN_REGION"]
 TEXTRACT_S3_BUCKET_URL = f"https://{TEXTRACT_S3_BUCKET_NAME}.s3.{TEXTRACT_S3_BUCKET_REGION}.amazonaws.com"
+
+
+EMAIL_BACKEND = "django.core.mail.backends.smtp.EmailBackend"
+EMAIL_PORT = 587
+EMAIL_HOST = "email-smtp.eu-west-2.amazonaws.com"
+EMAIL_USE_TLS = True
+EMAIL_HOST_USER = "TODO"  # TODO os.environ["SMTP_USERNAME"]
+EMAIL_HOST_PASSWORD = "TODO"  # TODO os.environ["SMTP_PASSWORD"]
+
+if DC_ENVIRONMENT == "production":  # noqa: F405
+    SLACK_TOKEN = os.environ["SLACK_TOKEN"]
+else:
+    SLACK_TOKEN = None
+
+ALWAYS_ALLOW_RESULT_RECORDING = True
+EDITS_ALLOWED = True
+
+# If set to False, new users won't be allowed to make accounts
+# Useful for pre-election anti-vandalism
+NEW_USER_ACCOUNT_CREATION_ALLOWED = True


### PR DESCRIPTION
Refs https://app.asana.com/1/1204880536137786/project/1210977222661714/task/1210977222661717?focus=true
Refs https://app.asana.com/1/1204880536137786/project/1204880927741389/task/1210977222661722?focus=true

The point of this PR is broadly to get the copies of the app deployed on ECS more into line with the version on ECS and closer to a fully configured working application.

What is set in which config file and where we're setting "constant" settings vs reading things from env vars is a bit of a mess at this point. The approach I'm taking at this point is: Lets get to a stage where we can bin the EC2 setup and then restructure. I don't want to be doing refactoring that we have to account for in 2 different places. Lets get it working first and then improve the structure when we only have to account for that in one place.