### PR TITLE
fix test settings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,6 @@ norecursedirs =[
     "__pycache__",
 
 ]
-DJANGO_SETTINGS_MODULE = "ynr.settings.testing"
 addopts =[
     "--ignore=*/__pycache__",
     "--ignore=.*",
@@ -42,6 +41,7 @@ addopts =[
     "--ignore=cdk",
     "--ignore=node_modules",
     "--ruff",
+    "--ds=ynr.settings.testing"
 ]
 FAIL_INVALID_TEMPLATE_VARS = 1
 


### PR DESCRIPTION
Similar change to the one we made in
https://github.com/DemocracyClub/EveryElection/pull/2398

`DJANGO_SETTINGS_MODULE` env var takes precedence over `tool.pytest.ini_options.DJANGO_SETTINGS_MODULE` so we have to switch to `--ds`, which takes higher precedence than both of them