### PR TITLE
fix migrations CI step, implement healthcheck endpoint

### DIFF
--- a/cdk/stack/ynr.py
+++ b/cdk/stack/ynr.py
@@ -266,6 +266,11 @@ class YnrStack(Stack):
             ),
         )
 
+        web_service.target_group.configure_health_check(
+            path="/status_check/",
+            healthy_http_codes="200",
+        )
+
         Tags.of(cluster).add("app", "ynr")
         Tags.of(web_service).add("role", "web")
         Tags.of(worker_service).add("role", "worker")

--- a/scripts/ci/dbmigrate.bash
+++ b/scripts/ci/dbmigrate.bash
@@ -1,6 +1,6 @@
 #!/usr/bin/bash
 
-set -ex
+set -euxo pipefail
 
 curl "https://s3.amazonaws.com/session-manager-downloads/plugin/latest/ubuntu_64bit/session-manager-plugin.deb" -o "/tmp/session-manager-plugin.deb"
 sudo dpkg -i /tmp/session-manager-plugin.deb
@@ -11,4 +11,43 @@ CLUSTER=$(aws ecs list-clusters | jq -r  .clusterArns[0])
 mapfile -t TASK_LIST < <(aws ecs list-tasks --cluster "${CLUSTER}" | jq -r '.taskArns[]')
 
 # Pick one of the web containers
-aws ecs describe-tasks --include TAGS --cluster "${CLUSTER}" --tasks "${TASK_LIST[@]}" | jq -r '.tasks|map({arn: .containers[].taskArn, role: .overrides.containerOverrides[].name}) | map(select(.role == "web"))[0].arn|split("/") | "unbuffer aws ecs execute-command --cluster " + .[1] + " --command \"python manage.py migrate && python manage.py createcachetable && python manage.py setup_periodic_tasks\" --interactive --task " + .[2]' | sh
+read -r _ CLUSTER_NAME TASK_ID < <(
+  aws ecs describe-tasks --include TAGS \
+    --cluster "${CLUSTER}" \
+    --tasks "${TASK_LIST[@]}" \
+  | jq -r '.tasks
+            | map({arn: .containers[].taskArn, role: .overrides.containerOverrides[].name})
+            | map(select(.role == "web"))[0].arn
+            | split("/") 
+            | @tsv'
+)
+
+# We have to do a bit of a silly dance to see if these jobs worked or not
+# https://github.com/aws/amazon-ecs-agent/issues/2846
+
+MIGRATE_OUTPUT=$(unbuffer aws ecs execute-command --cluster "${CLUSTER_NAME}" --task "${TASK_ID}" --interactive --command "sh -c 'python manage.py migrate && echo SUCCESS'" 2>&1)
+echo "$MIGRATE_OUTPUT"
+if echo "$MIGRATE_OUTPUT" | grep -q 'SUCCESS'; then
+  echo "✔ Migrations applied"
+else
+  echo "✖ Migrations failed"
+  exit 1
+fi
+
+CACHE_OUTPUT=$(unbuffer aws ecs execute-command --cluster "${CLUSTER_NAME}" --task "${TASK_ID}" --interactive --command "sh -c 'python manage.py createcachetable && echo SUCCESS'"2>&1)
+echo "$CACHE_OUTPUT"
+if echo "$CACHE_OUTPUT" | grep -q 'SUCCESS'; then
+    echo "✔ Cache table created"
+else
+    echo "✖ Cache table creation failed"
+    exit 1
+fi
+
+TASKS_OUTPUT=$(unbuffer aws ecs execute-command --cluster "${CLUSTER_NAME}" --task "${TASK_ID}" --interactive --command "sh -c 'python manage.py setup_periodic_tasks && echo SUCCESS'"2>&1)
+echo "$TASKS_OUTPUT"
+if echo "$TASKS_OUTPUT" | grep -q 'SUCCESS'; then
+    echo "✔ Periodic tasks updated"
+else
+    echo "✖ Periodic tasks setup failed"
+    exit 1
+fi

--- a/scripts/ci/dbmigrate.bash
+++ b/scripts/ci/dbmigrate.bash
@@ -8,7 +8,7 @@ sudo apt update
 sudo apt install -y expect
 
 CLUSTER=$(aws ecs list-clusters | jq -r  .clusterArns[0])
-TASK_LIST=$(aws ecs list-tasks --cluster "${CLUSTER}" | jq -r .taskArns[])
+mapfile -t TASK_LIST < <(aws ecs list-tasks --cluster "${CLUSTER}" | jq -r '.taskArns[]')
 
 # Pick one of the web containers
-aws ecs describe-tasks --include TAGS --cluster "${CLUSTER}" --tasks "${TASK_LIST}" | jq -r '.tasks|map({arn: .containers[].taskArn, role: .overrides.containerOverrides[].name}) | map(select(.role == "web"))[0].arn|split("/") | "unbuffer aws ecs execute-command --cluster " + .[1] + " --command \"python manage.py migrate && python manage.py createcachetable && python manage.py setup_periodic_tasks\" --interactive --task " + .[2]' | sh
+aws ecs describe-tasks --include TAGS --cluster "${CLUSTER}" --tasks "${TASK_LIST[@]}" | jq -r '.tasks|map({arn: .containers[].taskArn, role: .overrides.containerOverrides[].name}) | map(select(.role == "web"))[0].arn|split("/") | "unbuffer aws ecs execute-command --cluster " + .[1] + " --command \"python manage.py migrate && python manage.py createcachetable && python manage.py setup_periodic_tasks\" --interactive --task " + .[2]' | sh

--- a/ynr/apps/utils/views.py
+++ b/ynr/apps/utils/views.py
@@ -1,0 +1,16 @@
+from django.db import connection
+from django.db.utils import OperationalError
+from django.http import HttpResponse
+
+
+def trigger_error(request):
+    return 1 / 0
+
+
+def status_check(request):
+    try:
+        connection.cursor()
+    except OperationalError:
+        return HttpResponse("service unavailable", status=503)
+
+    return HttpResponse("OK", status=200)

--- a/ynr/settings/base.py
+++ b/ynr/settings/base.py
@@ -184,7 +184,7 @@ SESAME_ONE_TIME = False
 SESAME_TOKEN_NAME = "login_token"
 
 BASIC_AUTH_ALLOWLIST = [
-    "/",  # load balancer health check
+    "/status_check/",  # load balancer health check
     "/api/next/*",  # Allow next API
 ]
 

--- a/ynr/urls.py
+++ b/ynr/urls.py
@@ -5,13 +5,10 @@ from django.contrib.staticfiles.urls import staticfiles_urlpatterns
 from django.urls import include, path, re_path
 from django.views.generic import TemplateView
 from sesame.views import LoginView as SesameLoginView
-
-
-def trigger_error(request):
-    return 1 / 0
-
+from utils.views import status_check, trigger_error
 
 urlpatterns = [
+    re_path(r"^status_check/$", status_check, name="status_check"),
     re_path(r"^parties/", include("parties.urls")),
     re_path(r"^", include("api.urls")),
     re_path(r"^", include("elections.urls")),


### PR DESCRIPTION
Refs https://app.asana.com/1/1204880536137786/project/1204880927741389/task/1211207595108864?focus=true

This took longer than I wanted it to, but I got there eventually.

There's a few things going on here:

1. Implement a dedicated healthcheck endpoint so we mark an instance "healthy" if we can bootstrap django and ping the DB. That allows us to move to the next step and apply migrations when there are schema changes
2. Once I started digging into this script I realised there were several problems that meant this wasn't doing what we thought it was. These are all fixed. I've also tried to make this code a lot more clear.
3. Speaking of which.. another issue we had here was that we broke this script and it wasn't failing the CI build. One of the issues here was https://github.com/aws/amazon-ecs-agent/issues/2846 (`aws ecs execute-command` doesn't pass through the exit code of the command you ran) so I've implemented a similar solution to https://github.com/DemocracyClub/Website/blob/676468bd704b091f9ac5e9367704f96a7f5cf158/.circleci/config.yml#L117-L130 It is not ideal, but it is a lot better than what we had.

**TODO**: revert https://github.com/DemocracyClub/yournextrepresentative/pull/2584/commits/0154d18632349c10cc9491616edb26ac21298230 before merging