### PR TITLE
Email config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -256,6 +256,7 @@ jobs:
       - when:
           condition:
             or:
+              - equal: [ "email-config", << pipeline.git.branch >> ]
               - equal: [ "ci/test", << pipeline.git.branch >> ]
               - equal: [ "staging", << pipeline.git.branch >> ]
               - equal: [ "master", << pipeline.git.branch >> ]
@@ -429,7 +430,7 @@ workflows:
             - static_tests
             - container_build_and_test
           context: [ deployment-ecs-development-ynr ]
-          filters: { branches: { only: [ "ci/test"] } }
+          filters: { branches: { only: [ "ci/test", "email-config"] } }
           dc-environment: development
       - deploy_cdk_environment:
           name: DEV cdk deploy
@@ -437,20 +438,20 @@ workflows:
           requires:
             - cdk_test
             - DEV push container
-          filters: { branches: { only: [ "ci/test"] } }
+          filters: { branches: { only: [ "ci/test", "email-config"] } }
           dc-environment: development
       - db_migrate:
           name: DEV db migrate
           requires:
             - DEV cdk deploy
           context: [ deployment-ecs-development-ynr ]
-          filters: { branches: { only: [ "ci/test"] } }
+          filters: { branches: { only: [ "ci/test", "email-config"] } }
       - post_deploy_checks:
           name: DEV post deploy checks
           requires:
             - DEV db migrate
           dc-environment: development
-          filters: { branches: { only: [ "ci/test"] } }
+          filters: { branches: { only: [ "ci/test", "email-config"] } }
 
       #########
       # Staging

--- a/cdk/stack/ynr.py
+++ b/cdk/stack/ynr.py
@@ -171,6 +171,34 @@ class YnrStack(Stack):
                     "POSTGRES_HOST",
                 )
             ),
+            "EMAIL_HOST": ecs.Secret.from_ssm_parameter(
+                ssm.StringParameter.from_string_parameter_name(
+                    self,
+                    "EMAIL_HOST",
+                    "EMAIL_HOST",
+                )
+            ),
+            "EMAIL_HOST_USER": ecs.Secret.from_ssm_parameter(
+                ssm.StringParameter.from_string_parameter_name(
+                    self,
+                    "EMAIL_HOST_USER",
+                    "EMAIL_HOST_USER",
+                )
+            ),
+            "EMAIL_HOST_PASSWORD": ecs.Secret.from_ssm_parameter(
+                ssm.StringParameter.from_string_parameter_name(
+                    self,
+                    "EMAIL_HOST_PASSWORD",
+                    "EMAIL_HOST_PASSWORD",
+                )
+            ),
+            "DEFAULT_FROM_EMAIL": ecs.Secret.from_ssm_parameter(
+                ssm.StringParameter.from_string_parameter_name(
+                    self,
+                    "DEFAULT_FROM_EMAIL",
+                    "DEFAULT_FROM_EMAIL",
+                )
+            ),
         }
         if self.dc_environment == "production":
             common_secrets["SLACK_TOKEN"] = ecs.Secret.from_ssm_parameter(

--- a/ynr/settings/base_from_environment.py
+++ b/ynr/settings/base_from_environment.py
@@ -51,10 +51,12 @@ ENABLE_SCHEDULED_JOBS = str_bool_to_bool(os.environ["ENABLE_SCHEDULED_JOBS"])  #
 
 EMAIL_BACKEND = "django.core.mail.backends.smtp.EmailBackend"
 EMAIL_PORT = 587
-EMAIL_HOST = "email-smtp.eu-west-2.amazonaws.com"
+EMAIL_HOST = os.environ["EMAIL_HOST"]
 EMAIL_USE_TLS = True
-EMAIL_HOST_USER = "TODO"  # TODO os.environ["SMTP_USERNAME"]
-EMAIL_HOST_PASSWORD = "TODO"  # TODO os.environ["SMTP_PASSWORD"]
+EMAIL_HOST_USER = os.environ["EMAIL_HOST_USER"]
+EMAIL_HOST_PASSWORD = os.environ["EMAIL_HOST_PASSWORD"]
+DEFAULT_FROM_EMAIL = os.environ["DEFAULT_FROM_EMAIL"]
+
 
 if DC_ENVIRONMENT == "production":  # noqa: F405
     SLACK_TOKEN = os.environ["SLACK_TOKEN"]


### PR DESCRIPTION
This PR adds `os.environ` calls for all the SMTP settings we need, including `DEFAULT_FROM_EMAIL`. This last one is to enable us to have different FROM addresses per account, to make it easier to know where we're getting emails from. (obviously).

I'm suggesting we use a shared SMTP server for dev and stage, and a dedicated production one. I've set up dev and done a dev deploy for testing, but we still need to add the settings to the stage and prod parameter store.