### PR TITLE
allow web/worker to use textract/rekognition

### DIFF
--- a/cdk/stack/ynr.py
+++ b/cdk/stack/ynr.py
@@ -296,6 +296,27 @@ class YnrStack(Stack):
         )
         web_service.task_definition.task_role.add_to_policy(s3_policy_statement)
 
+        worker_service.task_definition.task_role.add_managed_policy(
+            iam.ManagedPolicy.from_aws_managed_policy_name(
+                "AmazonRekognitionFullAccess"
+            )
+        )
+        worker_service.task_definition.task_role.add_managed_policy(
+            iam.ManagedPolicy.from_aws_managed_policy_name(
+                "AmazonTextractFullAccess"
+            )
+        )
+        web_service.task_definition.task_role.add_managed_policy(
+            iam.ManagedPolicy.from_aws_managed_policy_name(
+                "AmazonRekognitionFullAccess"
+            )
+        )
+        web_service.task_definition.task_role.add_managed_policy(
+            iam.ManagedPolicy.from_aws_managed_policy_name(
+                "AmazonTextractFullAccess"
+            )
+        )
+
         # Create CloudFront and related DNS records
         self.create_cloudfront(web_service)
 


### PR DESCRIPTION
So one thing here is: Is this good code?
The other is: Does it work.

In order to test this, first I shelled into dev and ran this code in a repl:

```py
import boto3

image_bytes = b"\x89PNG"  # not a valid image, but valid enough for this

rekognition = boto3.client("rekognition", region_name="eu-west-1")
textract = boto3.client("textract", region_name="eu-west-1")

rekognition.detect_faces(Image={"Bytes": image_bytes})
textract.detect_document_text(Document={"Bytes": image_bytes})
```

those calls threw

`AccessDeniedException: An error occurred (AccessDeniedException) when calling the DetectFaces operation`

and

`AccessDeniedException: An error occurred (AccessDeniedException) when calling the DetectDocumentText operation`

first time round.

Then I deployed this code to dev, shelled in and did the same thing again in a repl

This time, they threw

`InvalidImageFormatException: An error occurred (InvalidImageFormatException) when calling the DetectFaces operation: Request has invalid image format`

and

`UnsupportedDocumentException: An error occurred (UnsupportedDocumentException) when calling the DetectDocumentText operation: Request has unsupported document format`

which indicates they got past the permissions check and attempted to do something with the (invalid) "image".