### PR TITLE
quick hack: add a way to disable slack notifications in prod

### DIFF
--- a/ynr/settings/base_from_environment.py
+++ b/ynr/settings/base_from_environment.py
@@ -59,7 +59,11 @@ DEFAULT_FROM_EMAIL = os.environ["DEFAULT_FROM_EMAIL"]
 
 
 if DC_ENVIRONMENT == "production":  # noqa: F405
+    # TODO: remove this hack and make an ENABLE_SLACK_NOTIFICATIONS setting
+    # this exists because we can't set a var to empty string in param store
     SLACK_TOKEN = os.environ["SLACK_TOKEN"]
+    if SLACK_TOKEN == "DISABLED":
+        SLACK_TOKEN = None
 else:
     SLACK_TOKEN = None
 


### PR DESCRIPTION
I have gone ahead and set the value to DISABLED in the temp-prod Param Store