### PR TITLE
pin httpx==0.27.0

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -63,6 +63,7 @@ ndg-httpsclient==0.5.1
 numpy==1.24.2
 oauthlib==3.2.2
 openai==1.30.3
+httpx==0.27.0
 path.py==12.5.0
 pexpect==4.8.0
 pickleshare==0.7.5


### PR DESCRIPTION
Refs https://app.asana.com/1/1204880536137786/project/1204880927741389/task/1211625866372331?focus=true

It is worth quickly explaining why this has happened:

First off: This project doesn't have a proper lockfile, just requirements.txt

Secondly: We've made a change in how we deploy this.
With the old setup, our virtualenv in production persisted across deploys. So when we ran `pip install` as part of the old ansible deploy, pip would detect that an in-range version of httpx is installed and not upgrade it. In moving to a docker-based deploy, we now build a new image for each deploy so we're always starting from a blank slate. That's why we ended up on a different version of this unpinned package on ECS than we had on EC2.

In terms of fixing this problem: Pinning httpx back to a version that is compatible with `openai==1.30.3` is lower friction than upgrading the OpenAI client lib. So lets just do that for now. The proxy arg is removed in 0.28.0 https://github.com/encode/httpx/blob/master/CHANGELOG.md#0280-28th-november-2024

More widely, one of the thing we plan to do in the medium-term on this project is move to UV (which will give us a lockfile) and as part of that we'll also need to do a bit of a review of our dependency tree also.