### PR TITLE
install poppler-utils

### DIFF
--- a/container/build/system-packages
+++ b/container/build/system-packages
@@ -20,6 +20,7 @@ libyaml-dev
 npm
 opencv-data
 postgis
+poppler-utils
 python-is-python3
 python-tk
 python3-dev


### PR DESCRIPTION
This will fix the errors parsing sopns.

There's a few more things that come out of this though:
- How to fix the backlog of SOPNs that failed parsing
- I'd like to have a test that would fail if this is not installed in the container, but given this is quite deep in the textract call stack I'm not immediately sure how best to do that, so lets not block the fix on it
- Looking over this list of packages, there's some stuff here that I don't think needs to be here. I've raised a ticket about it: https://app.asana.com/1/1204880536137786/project/1210977222661714/task/1211720114599057?focus=true