### PR TITLE
fix open AI moderation

### DIFF
--- a/ynr/apps/moderation_queue/review_required_helper.py
+++ b/ynr/apps/moderation_queue/review_required_helper.py
@@ -288,7 +288,7 @@ class OpenAIModerationReview(BaseReviewRequiredDecider):
         try:
             client = openai.OpenAI(api_key=api_key)
             response = client.moderations.create(
-                input=statement, model="text-moderation-latest"
+                input=statement, model="omni-moderation-latest"
             )
         except openai.APIStatusError:
             sentry_sdk.capture_exception()


### PR DESCRIPTION
As of 27 October `text-moderation-latest` has been removed. See https://platform.openai.com/docs/deprecations#2025-04-28-text-moderation
Fixes https://democracy-club-gp.sentry.io/issues/6978353730