### PR TITLE
remove some packages we don't need

### DIFF
--- a/container/build/system-packages
+++ b/container/build/system-packages
@@ -1,5 +1,4 @@
 build-essential
-ruby-bundler
 cmake
 curl
 gettext
@@ -19,7 +18,7 @@ libxslt1-dev
 libyaml-dev
 npm
 opencv-data
-postgis
+postgresql-client-16
 poppler-utils
 python-is-python3
 python3-tk
@@ -28,7 +27,6 @@ python3-pip
 python3-psycopg2
 python3-setuptools
 python3-venv
-s3cmd
 texlive-latex-base
 texlive-latex-extra
 unzip


### PR DESCRIPTION
ruby-bundler should not be needed. I think this might date back to installing libsass via a gem?

We don't need the full postgres server and postgis extensions in our web server image. I've switched that to `postgresql-client-16` so we have `psql` if we shell in

s3cmd seems unnecessary as all our interaction with s3 should be via boto

I did start digging into some of the other bits but I realised I don't have a good enough handle on the current PDF parsing setup to know exactly what we do/don't need at this point. I suspect there may be more cruft here but I think just getting postgis out of the image and not breaking anything is good anyway. Maybe lets keep the others under review.