### PR TITLE
update docker-compose volume mounts

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,8 +15,6 @@ services:
       volumes:
         - ./ynr/:/dc/ynr/code/ynr/
         - ./data/:/dc/ynr/code/data/
-        - ./requirements/:/dc/ynr/code/requirements/
-        - ./requirements.txt:/dc/ynr/code/requirements.txt
         - ./manage.py:/dc/ynr/code/manage.py
         - ./Makefile:/dc/ynr/code/Makefile
         - ./scripts/:/dc/ynr/code/scripts/
@@ -24,6 +22,7 @@ services:
         - ./package.json:/dc/ynr/code/package.json
         - ./package-lock.json:/dc/ynr/code/package-lock.json
         - ./pyproject.toml:/dc/ynr/code/pyproject.toml
+        - ./uv.lock:/dc/ynr/code/uv.lock
       depends_on:
         dbpsql:
           condition: service_healthy


### PR DESCRIPTION
This is something I overlooked in https://github.com/DemocracyClub/yournextrepresentative/pull/2612

The other thing noted in https://app.asana.com/1/1204880536137786/project/1204880927741389/task/1211863843813157?focus=true is that https://github.com/DemocracyClub/yournextrepresentative/tree/master/lambdas/data_exporter/data_export_function uses a requirements.txt

I don't mind also converting that to use UV (maybe as a workspace?), but I'm also not totally convinced that doing so buys us a huge amount. It is a totally isolated lambda (i.e: it doesn't matter if that lambda were to have conflicting requirements with the base project) and depends on two packages.