### PR TITLE
only query fields we need in election detail template

### DIFF
--- a/ynr/apps/elections/views.py
+++ b/ynr/apps/elections/views.py
@@ -50,6 +50,22 @@ class ElectionView(DetailView):
                     Membership.objects.select_related(
                         "party", "person", "result"
                     )
+                    # Only request the fields we need to render the template
+                    # fetching a lot of unnecessary fields can making rendering
+                    # elections with a lot of ballots (e.g: a general election)
+                    # very slow. Add any new fields we add to the template here
+                    # to avoid introducing N+1 issues
+                    .only(
+                        "party_list_position",
+                        "elected",
+                        "ballot_id",
+                        "person_id",
+                        "party_id",
+                        "person__name",
+                        "person__sort_name",
+                        "party__name",
+                        "result__num_ballots",
+                    )
                     .annotate(last_name=LastWord("person__name"))
                     .annotate(
                         name_for_ordering=Coalesce(


### PR DESCRIPTION
In this PR, I am just keeping the query as-is and only selecting the fields we actually need from the membership, party, person and name fields.

On its own, this makes a huge difference in how long it takes to render a large election page and how much memory is needed. I think this addresses the core problem with this page, which is that we were selecting a lot of data we didn't need. This was than taking a long time to transfer over the network and a lot of memory to hydrate into python objects.