### PR TITLE
run on 2 instances in prod

### DIFF
--- a/cdk/stack/ynr.py
+++ b/cdk/stack/ynr.py
@@ -278,7 +278,7 @@ class YnrStack(Stack):
 
         web_desired_count = 1
         if self.dc_environment == "production":
-            web_desired_count = 3
+            web_desired_count = 2
 
         web_service = ecs_patterns.ApplicationLoadBalancedFargateService(
             self,


### PR DESCRIPTION
Since merging https://github.com/DemocracyClub/yournextrepresentative/pull/2626 we are no longer maxing out on CPU or RAM. We can start looking at scaling down to save costs.
My gut instinct is that for "peacetime" 2 instances at cpu=512/memory=1024 will probably not be quite enough. We probably either want:

- 2 instances at cpu=1024/memory=2048 **or**
- 3 instances at cpu=512/memory=1024

Lets try 2 instances at cpu=1024/memory=2048 for a bit and see how that goes.