### PR TITLE
fix N+1 on results API endpoint

### DIFF
--- a/ynr/apps/uk_results/api/next/api_views.py
+++ b/ynr/apps/uk_results/api/next/api_views.py
@@ -14,6 +14,8 @@ class ResultViewSet(viewsets.ReadOnlyModelViewSet):
     lookup_url_kwarg = "ballot_paper_id"
     queryset = (
         ResultSet.objects.select_related("ballot")
+        .prefetch_related("candidate_results__membership__person")
+        .prefetch_related("candidate_results__membership__party")
         .prefetch_related("ballot__membership_set")
         .order_by("-ballot__election__election_date", "ballot__ballot_paper_id")
     )


### PR DESCRIPTION
This PR fixes a N+1 error on the results endpoint.
Right now a call like `/api/next/results/?page=3&page_size=200` on prod makes thousands of DB queries and takes ~10-15 seconds to return a response. This means you can page over results and completely hammer us while staying under the anonymous rate limit.
This gets it down to under 10 DB queries and a second or two to return a response. That's still not fast, but it is an order of magnitude improvement.