### PR TITLE
add additional email notifications for interested users

### DIFF
--- a/ynr/apps/elections/notifications.py
+++ b/ynr/apps/elections/notifications.py
@@ -1,0 +1,26 @@
+import textwrap
+from urllib.parse import urljoin
+
+from django.conf import settings
+from utils.mail import send_mail
+
+
+def get_ballot_lock_notification_message(ballot, username):
+    return textwrap.dedent(
+        f"""\
+        Hello,
+        
+        The user {username} re-locked the ballot {ballot.ballot_paper_id}.
+        
+        You can see a history of changes to this ballot at
+        {urljoin(settings.BASE_URL, ballot.get_absolute_url())}#history
+        """
+    )
+
+
+def send_ballot_lock_notification(ballot, username):
+    return send_mail(
+        "Ballot re-locked",
+        get_ballot_lock_notification_message(ballot, username),
+        settings.SOPN_UPDATE_NOTIFICATION_EMAILS,
+    )

--- a/ynr/apps/elections/templates/elections/ballot_view.html
+++ b/ynr/apps/elections/templates/elections/ballot_view.html
@@ -243,7 +243,7 @@
   {% endif %}
 
   {% if user.is_authenticated and logged_actions %}
-    <h2>History for this ballot</h2>
+    <h2 id="history">History for this ballot</h2>
     {% for action in logged_actions %}
       <div class="version">
         <dl>

--- a/ynr/apps/moderation_queue/forms.py
+++ b/ynr/apps/moderation_queue/forms.py
@@ -9,7 +9,6 @@ from django import forms
 from django.conf import settings
 from django.contrib.sites.models import Site
 from django.core.exceptions import ValidationError
-from django.core.mail import send_mail
 from django.template.loader import render_to_string
 from django.urls import reverse
 from moderation_queue.helpers import (
@@ -17,6 +16,7 @@ from moderation_queue.helpers import (
 )
 from people.forms.forms import StrippedCharField
 from PIL import Image as PILImage
+from utils.mail import send_mail
 
 from .models import CopyrightOptions, QueuedImage, SuggestedPostLock
 
@@ -277,9 +277,7 @@ class PhotoReviewForm(forms.Form):
         return send_mail(
             subject,
             message,
-            settings.DEFAULT_FROM_EMAIL,
             recipients,
-            fail_silently=False,
         )
 
 

--- a/ynr/apps/moderation_queue/tests/test_queue.py
+++ b/ynr/apps/moderation_queue/tests/test_queue.py
@@ -214,7 +214,6 @@ class PhotoReviewTests(UK2015ExamplesMixin, WebTest):
         self.assertContains(response, "Photo policy")
 
     @patch("moderation_queue.forms.send_mail")
-    @override_settings(DEFAULT_FROM_EMAIL="admins@example.com")
     def test_photo_review_upload_approved_privileged(self, mock_send_mail):
         with self.settings(SITE_ID=1):
             review_url = reverse(
@@ -237,9 +236,7 @@ class PhotoReviewTests(UK2015ExamplesMixin, WebTest):
             mock_send_mail.assert_called_once_with(
                 "example.com image upload approved",
                 "Thank you for submitting a photo to example.com. It has been\nuploaded to the candidate page here:\n\n  http://testserver/person/2009/tessa-jowell\n\nMany thanks from the example.com volunteers\n",
-                "admins@example.com",
                 ["john@example.com"],
-                fail_silently=False,
             )
 
             person = Person.objects.get(id=2009)
@@ -267,7 +264,6 @@ class PhotoReviewTests(UK2015ExamplesMixin, WebTest):
             )
 
     @patch("moderation_queue.forms.send_mail")
-    @override_settings(DEFAULT_FROM_EMAIL="admins@example.com")
     @override_settings(SUPPORT_EMAIL="support@example.com")
     def test_photo_review_upload_rejected_privileged(self, mock_send_mail):
         with self.settings(SITE_ID=1):
@@ -300,9 +296,7 @@ class PhotoReviewTests(UK2015ExamplesMixin, WebTest):
                 "Thank-you for uploading a photo of Tessa Jowell to example.com,\nbut unfortunately we can't use that image because:\n\n  There's no clear source or copyright statement\n\nYou can just reply to this email if you want to discuss that\nfurther, or you can try uploading a photo with a different\nreason or justification for its use using this link:\n\n  http://testserver/moderation/photo/upload/2009\n\nMany thanks from the example.com volunteers\n\n--\nFor administrators' use: http://testserver/moderation/photo/review/{}\n".format(
                     self.q1.id
                 ),
-                "admins@example.com",
                 ["john@example.com", "support@example.com"],
-                fail_silently=False,
             )
 
             self.assertEqual(

--- a/ynr/apps/moderation_queue/views.py
+++ b/ynr/apps/moderation_queue/views.py
@@ -486,8 +486,14 @@ class PersonNameEditReviewListView(GroupRequiredMixin, ListView):
 
     def approve_name_change(self, other_name):
         person = other_name.content_object
-        person.edit_name(other_name.name, person.name, user=self.request.user)
+        person.edit_name(
+            suggested_name=other_name.name,
+            initial_name=person.name,
+            user=self.request.user,
+        )
         person.save()
+        # Note: We don't need to explicitly send a notification here
+        # it will be handled in person.edit_name()
 
     def delete_name_change(self, other_name):
         other_name.delete()

--- a/ynr/apps/official_documents/models.py
+++ b/ynr/apps/official_documents/models.py
@@ -1,12 +1,10 @@
 import contextlib
 import os
-import textwrap
 from pathlib import Path
 from typing import List
 
 from candidates.models import Ballot
 from django.conf import settings
-from django.core import mail
 from django.core.files.base import ContentFile
 from django.core.validators import FileExtensionValidator
 from django.db import models
@@ -324,30 +322,3 @@ def add_ballot_sopn(
     if parse:
         ballot_sopn.parse()
     return ballot_sopn
-
-
-def send_ballot_sopn_update_notification(ballot_sopn: BallotSOPN, request):
-    message = textwrap.dedent(
-        f"""\
-    Hello,
-    
-    The user {request.user.username} has updated the SOPN for the ballot with ID {ballot_sopn.ballot.ballot_paper_id}.
-    
-    You can see this newly uploaded SOPN here:
-    
-    {request.build_absolute_uri(ballot_sopn.get_absolute_url())}
-    
-    Their reason for the new upload was:
-    
-    > "{ballot_sopn.replacement_reason}"
-    
-    """
-    )
-
-    mail.send_mail(
-        f"SOPN for {ballot_sopn.ballot.ballot_paper_id} updated",
-        message,
-        "hello@democracyclub.org.uk",
-        settings.SOPN_UPDATE_NOTIFICATION_EMAILS,
-        fail_silently=True,
-    )

--- a/ynr/apps/official_documents/notifications.py
+++ b/ynr/apps/official_documents/notifications.py
@@ -1,0 +1,31 @@
+import textwrap
+
+from django.conf import settings
+from utils.mail import send_mail
+
+from .models import BallotSOPN
+
+
+def send_ballot_sopn_update_notification(ballot_sopn: BallotSOPN, request):
+    message = textwrap.dedent(
+        f"""\
+    Hello,
+    
+    The user {request.user.username} has updated the SOPN for the ballot with ID {ballot_sopn.ballot.ballot_paper_id}.
+    
+    You can see this newly uploaded SOPN here:
+    
+    {request.build_absolute_uri(ballot_sopn.get_absolute_url())}
+    
+    Their reason for the new upload was:
+    
+    > "{ballot_sopn.replacement_reason}"
+    
+    """
+    )
+
+    send_mail(
+        f"SOPN for {ballot_sopn.ballot.ballot_paper_id} updated",
+        message,
+        settings.SOPN_UPDATE_NOTIFICATION_EMAILS,
+    )

--- a/ynr/apps/official_documents/views.py
+++ b/ynr/apps/official_documents/views.py
@@ -26,8 +26,8 @@ from .models import (
     BallotSOPN,
     PageMatchingMethods,
     add_ballot_sopn,
-    send_ballot_sopn_update_notification,
 )
+from .notifications import send_ballot_sopn_update_notification
 
 
 class CreateOrUpdateBallotSOPNView(GroupRequiredMixin, UpdateView):

--- a/ynr/apps/people/notifications.py
+++ b/ynr/apps/people/notifications.py
@@ -1,0 +1,38 @@
+import textwrap
+from urllib.parse import urljoin
+
+from django.conf import settings
+from utils.mail import send_mail
+
+
+def get_name_change_notification_message(
+    person, prev_name, new_name, ballots, username
+):
+    person_url = urljoin(settings.BASE_URL, person.get_absolute_url())
+    message = textwrap.dedent(
+        f"""\
+        Hello,
+        
+        The user {username} changed the name of {person_url} from {prev_name} to {new_name}.
+        
+        This candidate is currently standing in the following ballots:
+        """
+    )
+    for ballot in ballots:
+        message = (
+            message
+            + f"- {urljoin(settings.BASE_URL, ballot.get_absolute_url())}\n"
+        )
+    return message
+
+
+def send_name_change_notification(
+    person, prev_name, new_name, ballots, username
+):
+    return send_mail(
+        "Name for candidate updated",
+        get_name_change_notification_message(
+            person, prev_name, new_name, ballots, username
+        ),
+        settings.SOPN_UPDATE_NOTIFICATION_EMAILS,
+    )

--- a/ynr/apps/utils/mail.py
+++ b/ynr/apps/utils/mail.py
@@ -1,0 +1,17 @@
+from django.conf import settings
+from django.core.mail import send_mail as dj_send_mail
+from django_q.tasks import async_task
+
+
+def send_mail(subject, message, recipients):
+    return async_task(
+        dj_send_mail,
+        # send_mail args
+        subject,
+        message,
+        settings.DEFAULT_FROM_EMAIL,
+        recipients,
+        fail_silently=False,
+        # django q2 args
+        timeout=15,
+    )

--- a/ynr/settings/base.py
+++ b/ynr/settings/base.py
@@ -443,6 +443,8 @@ ENABLE_SCHEDULED_JOBS = str_bool_to_bool(
     os.environ.get("ENABLE_SCHEDULED_JOBS", False)
 )
 
+BASE_URL = f"http://{os.environ.get('FQDN', 'localhost:8080')}"
+
 # import application constants
 from .constants.needs_review import *  # noqa
 from .constants.csv_fields import *  # noqa

--- a/ynr/settings/deploy.py
+++ b/ynr/settings/deploy.py
@@ -83,6 +83,9 @@ TEXTRACT_S3_BUCKET_REGION = os.environ["S3_SOPN_REGION"]
 TEXTRACT_S3_BUCKET_URL = f"https://{TEXTRACT_S3_BUCKET_NAME}.s3.{TEXTRACT_S3_BUCKET_REGION}.amazonaws.com"
 
 
+BASE_URL = f"https://{os.environ['FQDN']}"
+
+
 EMAIL_BACKEND = "django.core.mail.backends.smtp.EmailBackend"
 EMAIL_PORT = 587
 EMAIL_HOST = os.environ["EMAIL_HOST"]

--- a/ynr/settings/testing.py
+++ b/ynr/settings/testing.py
@@ -43,6 +43,9 @@ FRONT_PAGE_CTA = "BY_ELECTIONS"
 
 SOPN_UPDATE_NOTIFICATION_EMAILS = ["developers@democracyclub.org.uk"]
 
+# execute all background tasks immediately under test
+Q_CLUSTER["sync"] = True  # noqa: F405
+
 
 # override these settings to safe values if they are set from the env
 TWITTER_APP_ONLY_BEARER_TOKEN = None


### PR DESCRIPTION
Refs https://app.asana.com/1/1204880536137786/project/1204880927741389/task/1212002346773848?focus=true

There's a fair bit going on here:

- add a helper that sends mail in the background and use it when we send emails

- adopt the convention that functions which send email notifications about an action live in appname/notifications.py

- send a notification when a ballot is re-locked after having been previously locked

- send a notification when a person name is updated who is standing on a locked/current ballot

- add and update tests for all that

- execute all background tasks immediately under test
