### PR TITLE
Revert to 2 instance with 2Gb memory

### DIFF
--- a/cdk/stack/ynr.py
+++ b/cdk/stack/ynr.py
@@ -278,15 +278,15 @@ class YnrStack(Stack):
 
         web_desired_count = 1
         if self.dc_environment == "production":
-            web_desired_count = 3
+            web_desired_count = 2
 
         web_service = ecs_patterns.ApplicationLoadBalancedFargateService(
             self,
             "YnrService",
             cluster=cluster,
             assign_public_ip=True,
-            cpu=512,
-            memory_limit_mib=1024,
+            cpu=1024,
+            memory_limit_mib=2048,
             desired_count=web_desired_count,
             enable_execute_command=True,
             task_subnets=ec2.SubnetSelection(


### PR DESCRIPTION
Having tried 3 instances with 512 cpu/1024 mem for a bit, we do seem to have hit 100% memory a couple of times.
I think our ideal "peacetime" configuration is 2 instances with 1024 cpu/2048 mem