### PR TITLE
specify env in emails if not prod/testing

### DIFF
--- a/ynr/apps/elections/notifications.py
+++ b/ynr/apps/elections/notifications.py
@@ -6,9 +6,12 @@ from utils.mail import send_mail
 
 
 def get_ballot_lock_notification_message(ballot, username):
+    prefix = ""
+    if settings.DC_ENVIRONMENT not in ["production", "testing"]:
+        prefix = f"This email was sent from the {settings.DC_ENVIRONMENT.upper()} environment.\n\n"
     return textwrap.dedent(
         f"""\
-        Hello,
+        {prefix}Hello,
         
         The user {username} re-locked the ballot {ballot.ballot_paper_id}.
         
@@ -19,8 +22,13 @@ def get_ballot_lock_notification_message(ballot, username):
 
 
 def send_ballot_lock_notification(ballot, username):
+    prefix = ""
+    if settings.DC_ENVIRONMENT not in ["production", "testing"]:
+        prefix = f"[{settings.DC_ENVIRONMENT.upper()}] "
+    subject = f"{prefix}Ballot re-locked"
+
     return send_mail(
-        "Ballot re-locked",
+        subject,
         get_ballot_lock_notification_message(ballot, username),
         settings.SOPN_UPDATE_NOTIFICATION_EMAILS,
     )

--- a/ynr/apps/official_documents/notifications.py
+++ b/ynr/apps/official_documents/notifications.py
@@ -7,9 +7,13 @@ from .models import BallotSOPN
 
 
 def send_ballot_sopn_update_notification(ballot_sopn: BallotSOPN, request):
+    message_prefix = ""
+    if settings.DC_ENVIRONMENT not in ["production", "testing"]:
+        message_prefix = f"This email was sent from the {settings.DC_ENVIRONMENT.upper()} environment.\n\n"
+
     message = textwrap.dedent(
         f"""\
-    Hello,
+    {message_prefix}Hello,
     
     The user {request.user.username} has updated the SOPN for the ballot with ID {ballot_sopn.ballot.ballot_paper_id}.
     
@@ -24,8 +28,15 @@ def send_ballot_sopn_update_notification(ballot_sopn: BallotSOPN, request):
     """
     )
 
+    subject_prefix = ""
+    if settings.DC_ENVIRONMENT not in ["production", "testing"]:
+        subject_prefix = f"[{settings.DC_ENVIRONMENT.upper()}] "
+    subject = (
+        f"{subject_prefix}SOPN for {ballot_sopn.ballot.ballot_paper_id} updated"
+    )
+
     send_mail(
-        f"SOPN for {ballot_sopn.ballot.ballot_paper_id} updated",
+        subject,
         message,
         settings.SOPN_UPDATE_NOTIFICATION_EMAILS,
     )

--- a/ynr/apps/people/notifications.py
+++ b/ynr/apps/people/notifications.py
@@ -9,9 +9,14 @@ def get_name_change_notification_message(
     person, prev_name, new_name, ballots, username
 ):
     person_url = urljoin(settings.BASE_URL, person.get_absolute_url())
+
+    prefix = ""
+    if settings.DC_ENVIRONMENT not in ["production", "testing"]:
+        prefix = f"This email was sent from the {settings.DC_ENVIRONMENT.upper()} environment.\n\n"
+
     message = textwrap.dedent(
         f"""\
-        Hello,
+        {prefix}Hello,
         
         The user {username} changed the name of {person_url} from {prev_name} to {new_name}.
         
@@ -29,8 +34,13 @@ def get_name_change_notification_message(
 def send_name_change_notification(
     person, prev_name, new_name, ballots, username
 ):
+    prefix = ""
+    if settings.DC_ENVIRONMENT not in ["production", "testing"]:
+        prefix = f"[{settings.DC_ENVIRONMENT.upper()}] "
+    subject = f"{prefix}Name for candidate updated"
+
     return send_mail(
-        "Name for candidate updated",
+        subject,
         get_name_change_notification_message(
             person, prev_name, new_name, ballots, username
         ),


### PR DESCRIPTION
Refs https://app.asana.com/1/1204880536137786/project/1204880927741389/task/1212899340384206?focus=true

This should make it clearer if we receive an email sent from the dev/staging/training envs