### PR TITLE
Container metric alerting (CPU and memory)

### DIFF
--- a/cdk/stack/ynr.py
+++ b/cdk/stack/ynr.py
@@ -446,11 +446,11 @@ class YnrStack(Stack):
 
         # Alerting / notification
         if monitor_this_env:
-            ALERT_EMAIL_RECIPIENT = (
+            alert_email_recipient = (
                 ssm.StringParameter.from_string_parameter_name(
                     self,
-                    "ALERT_EMAIL_RECIPIENT",
-                    "ALERT_EMAIL_RECIPIENT",
+                    "alert_email_recipient",
+                    "alert_email_recipient",
                 )
             )
             metric_topic = sns.Topic(
@@ -527,7 +527,7 @@ class YnrStack(Stack):
                 self,
                 "MetricSubscription",
                 topic=metric_topic,
-                endpoint=ALERT_EMAIL_RECIPIENT.string_value,
+                endpoint=alert_email_recipient.string_value,
                 protocol=sns.SubscriptionProtocol.EMAIL,
             )
 


### PR DESCRIPTION
Here we add container metric email alerts for sustained high CPU and memory usage.  Emails are sent via an SNS topic, to which an email address is subscribed.

Emails are sent when entering alarm status and when returning to ok status.

There is an extra parameter store value called ALERT_EMAIL_RECIPIENT which is of type String and should be an email address.

When the CDK stack is updated in a way which results in the email changing (e.g. because the alerting is being added for the first time, or is the address is being changed) then AWS SNS will send an email which contains a link for confirmation. No alert emails will be sent until this address is confirmed. The footer of emails sent contain a way to unsubscribe.