### PR TITLE
add SOPN names to inline membership form

### DIFF
--- a/ynr/apps/elections/uk/templates/candidates/_person_form.html
+++ b/ynr/apps/elections/uk/templates/candidates/_person_form.html
@@ -103,7 +103,7 @@
 </div>
 
   <div class="form-item">
-    <h2>Candidacy:</h2>
+    <h2>Candidacies:</h2>
     {% if current_locked_ballots %}
       <table class="table">
       <caption>Current locked ballots</caption>
@@ -168,6 +168,18 @@
                 {{ membership_form.previous_party_affiliations.label }}
                 {{ membership_form.previous_party_affiliations }}
                 {{ membership_form.previous_party_affiliations.errors }}
+              </div>
+            {% endif %}
+            {% if membership_form.show_sopn_name_fields %}
+              <div class="large-12 columns">
+                {{ membership_form.sopn_last_name.label }}
+                {{ membership_form.sopn_last_name }}
+                {{ membership_form.sopn_last_name.errors }}
+              </div>
+              <div class="large-12 columns">
+                {{ membership_form.sopn_first_names.label }}
+                {{ membership_form.sopn_first_names }}
+                {{ membership_form.sopn_first_names.errors }}
               </div>
             {% endif %}
             <div class="large-12 columns">


### PR DESCRIPTION
This PR allows us to edit the SOPN names fields on the inline membership form
These forms are only available if the ballot has a SOPN

The other thing we said we wanted was a way to identify records that don't have the SOPN names set. I started off thinking I would need to implement a custom filter for this. Then after I did it, I realised that we actually kind of get this out of the box. If you add any custom fields to the builder, you automatically get boolean filters for them. So for example:

<img width="668" height="827" alt="Screenshot at 2026-02-17 13-58-11" src="https://github.com/user-attachments/assets/a27def66-f413-4105-b29e-34798f8733ae" />

I think I'm fine with just leaving it there tbh. That said, if we want a combined filter for both fields I still have the code I wrote to hand.