### PR TITLE
fix ajax requests that rely on x-requested-with header

### DIFF
--- a/cdk/stack/ynr.py
+++ b/cdk/stack/ynr.py
@@ -601,6 +601,7 @@ class YnrStack(Stack):
                     header_behavior=cloudfront.CacheHeaderBehavior.allow_list(
                         "x-csrfmiddlewaretoken",
                         "X-CSRFToken",
+                        "x-requested-with",
                         "Accept",
                         "Accept-Language",
                         "Authorization",
@@ -631,6 +632,7 @@ class YnrStack(Stack):
             header_behavior=cloudfront.CacheHeaderBehavior.allow_list(
                 "x-csrfmiddlewaretoken",
                 "X-CSRFToken",
+                "x-requested-with",
                 "Accept",
                 "Authorization",
                 "Cache-Control",
@@ -654,6 +656,7 @@ class YnrStack(Stack):
             header_behavior=cloudfront.CacheHeaderBehavior.allow_list(
                 "x-csrfmiddlewaretoken",
                 "X-CSRFToken",
+                "x-requested-with",
                 "Accept",
                 "Authorization",
                 "Cache-Control",


### PR DESCRIPTION
Refs https://app.asana.com/1/1204880536137786/project/1204880927741389/task/1213241339587891?focus=true

This PR fixes the issue where we get stuck on "locking.." behind a CDN
I've tested this works by deploying to dev, but I reverted the "deploy to dev" commit

This PR will also fix some other bugs we haven't noticed yet:
https://github.com/search?q=repo%3ADemocracyClub%2Fyournextrepresentative%20x-requested-with&type=code

I did have a look to see if I could spot any other places where the application's behaviour is conditional on a header we are dropping, but this was the only one I can find.