### PR TITLE
allow result form to be used for non fptp elections

### DIFF
--- a/ynr/apps/elections/uk/templates/uk/data_timeline.html
+++ b/ynr/apps/elections/uk/templates/uk/data_timeline.html
@@ -91,6 +91,12 @@
                       Edit the results
                     </a>
                   </p>
+                {% else %}
+                  <p>
+                    <a href="{% url "ballot_paper_results_form" ballot.ballot_paper_id %}">
+                      Edit Result Info
+                    </a>
+                  </p>
                 {% endif %}
             </div>
           {% elif ballot.uncontested %}

--- a/ynr/apps/uk_results/forms.py
+++ b/ynr/apps/uk_results/forms.py
@@ -55,39 +55,39 @@ class ResultSetForm(forms.ModelForm):
         ].label += " (Not required)<br>Calculated on save if turnout and electorate are added"
         existing_fields = self.fields
         fields = OrderedDict()
-        memberships = (
-            ballot.membership_set.all()
-            .annotate(last_name=LastWord("person__name"))
-            .annotate(
-                name_for_ordering=Coalesce(
-                    NullIfBlank("person__sort_name"), "last_name"
+        if ballot.can_enter_votes_cast:
+            memberships = (
+                ballot.membership_set.all()
+                .annotate(last_name=LastWord("person__name"))
+                .annotate(
+                    name_for_ordering=Coalesce(
+                        NullIfBlank("person__sort_name"), "last_name"
+                    )
                 )
+                .order_by("name_for_ordering")
             )
-            .order_by("name_for_ordering")
-        )
 
-        for membership in memberships:
-            name = f"memberships_{membership.person.pk}"
-            try:
-                initial = {
-                    "num_ballots": membership.result.num_ballots,
-                    "tied_vote_winner": membership.result.tied_vote_winner,
-                }
-            except CandidateResult.DoesNotExist:
-                initial = {}
-
-            fields[name] = forms.CharField(
-                label=membership.name_and_party,
-                initial=initial.get("num_ballots"),
-                required=True,
-                widget=DCIntegerInput,
-            )
-            fields[f"tied_vote_{name}"] = forms.BooleanField(
-                required=False,
-                label="Coin toss winner?",
-                initial=initial.get("tied_vote_winner"),
-            )
-            self.memberships.append((membership, name))
+            for membership in memberships:
+                name = f"memberships_{membership.person.pk}"
+                try:
+                    initial = {
+                        "num_ballots": membership.result.num_ballots,
+                        "tied_vote_winner": membership.result.tied_vote_winner,
+                    }
+                except CandidateResult.DoesNotExist:
+                    initial = {}
+                fields[name] = forms.CharField(
+                    label=membership.name_and_party,
+                    initial=initial.get("num_ballots"),
+                    required=self.ballot.can_enter_votes_cast,
+                    widget=DCIntegerInput,
+                )
+                fields[f"tied_vote_{name}"] = forms.BooleanField(
+                    required=False,
+                    label="Coin toss winner?",
+                    initial=initial.get("tied_vote_winner"),
+                )
+                self.memberships.append((membership, name))
 
         self.fields = fields
         self.fields.update(existing_fields)
@@ -116,15 +116,15 @@ class ResultSetForm(forms.ModelForm):
         Validates that there not more coin toss winners than seats up
         """
         cleaned_data = super().clean()
+        if self.ballot.can_enter_votes_cast:
+            for field_name, value in cleaned_data.items():
+                if field_name.startswith("memberships_"):
+                    cleaned_data[field_name] = int(value.replace(",", ""))
 
-        for field_name, value in cleaned_data.items():
-            if field_name.startswith("memberships_"):
-                cleaned_data[field_name] = int(value.replace(",", ""))
-
-        if len(self._tied_vote_winners) > self.ballot.winner_count:
-            raise forms.ValidationError(
-                "Can't have more coin toss winners than seats up!"
-            )
+            if len(self._tied_vote_winners) > self.ballot.winner_count:
+                raise forms.ValidationError(
+                    "Can't have more coin toss winners than seats up!"
+                )
 
         return cleaned_data
 
@@ -137,34 +137,37 @@ class ResultSetForm(forms.ModelForm):
             )
             instance.ip_address = get_client_ip(request)
             instance.save()
-            winners = self.get_winners()
-            if winners:
-                # we have winners so initially mark all candidates not elected
-                # before we record result and mark the winners as elected below
-                self.ballot.membership_set.update(elected=False)
-            else:
-                #  otherwise we cant be sure who was elected
-                self.ballot.membership_set.update(elected=None)
+            if self.ballot.can_enter_votes_cast:
+                winners = self.get_winners()
+                if winners:
+                    # we have winners so initially mark all candidates not elected
+                    # before we record result and mark the winners as elected below
+                    self.ballot.membership_set.update(elected=False)
+                else:
+                    #  otherwise we cant be sure who was elected
+                    self.ballot.membership_set.update(elected=None)
 
-            recorder = RecordBallotResultsHelper(self.ballot, instance.user)
-            for membership, field_name in self.memberships:
-                tied_vote_winner = self.cleaned_data[f"tied_vote_{field_name}"]
-                num_votes = self.cleaned_data[field_name]
-                rank = self.get_candidate_rank(num_votes)
-                winner = field_name in winners
+                recorder = RecordBallotResultsHelper(self.ballot, instance.user)
+                for membership, field_name in self.memberships:
+                    tied_vote_winner = self.cleaned_data[
+                        f"tied_vote_{field_name}"
+                    ]
+                    num_votes = self.cleaned_data[field_name]
+                    rank = self.get_candidate_rank(num_votes)
+                    winner = field_name in winners
 
-                instance.candidate_results.update_or_create(
-                    membership=membership,
-                    defaults={
-                        "num_ballots": num_votes,
-                        "tied_vote_winner": tied_vote_winner,
-                        "rank": rank,
-                    },
-                )
-                if winner:
-                    recorder.mark_person_as_elected(
-                        membership.person, source=instance.source
+                    instance.candidate_results.update_or_create(
+                        membership=membership,
+                        defaults={
+                            "num_ballots": num_votes,
+                            "tied_vote_winner": tied_vote_winner,
+                            "rank": rank,
+                        },
                     )
+                    if winner:
+                        recorder.mark_person_as_elected(
+                            membership.person, source=instance.source
+                        )
 
             instance.record_version()
 

--- a/ynr/apps/uk_results/templates/uk_results/includes/ballot_paper_results_form.html
+++ b/ynr/apps/uk_results/templates/uk_results/includes/ballot_paper_results_form.html
@@ -3,22 +3,29 @@
   {{ form.errors }}
   {% csrf_token %}
   <table>
-    <tbody>
-      {% for membership_field, tied_vote_field in form.membership_fields %}
-      <tr>
-        <td>{{ membership_field.label }}</td>
-        <td>
-          {{ membership_field.errors }}
-          {{ membership_field }}
-            <div id="coin-toss" style="display: none">
-              {{ tied_vote_field }} 
-              {{ tied_vote_field.label_tag }}
-              <h3 id="coin-emoji" class="flip">🪙</h3> 
-            </div>
-        </td>
-      </tr>
-      {% endfor %}
-    </tbody>
+      <tbody>
+        {% for membership_field, tied_vote_field in form.membership_fields %}
+        <tr>
+          <td>{{ membership_field.label }}</td>
+          <td>
+            {{ membership_field.errors }}
+            {{ membership_field }}
+              <div id="coin-toss" style="display: none">
+                {{ tied_vote_field }}
+                {{ tied_vote_field.label_tag }}
+                <h3 id="coin-emoji" class="flip">🪙</h3>
+              </div>
+          </td>
+        </tr>
+        {% empty %}
+        <tr>
+          <td>
+            <strong>We don't collect individual candidate's result data for non-FPTP elections,
+            but we do collect the following statistical information, as well as a link to the result source.</stromg>
+          </td>
+        </tr>
+        {% endfor %}
+      </tbody>
     <tbody>
       <tr>
         <td>{{ results_form.num_spoilt_ballots.label }}</td>

--- a/ynr/apps/uk_results/tests/test_forms.py
+++ b/ynr/apps/uk_results/tests/test_forms.py
@@ -13,6 +13,7 @@ class TestResultSetForm(TestUserMixin, UK2015ExamplesMixin, WebTest, TestCase):
     def setUp(self):
         super().setUp()
         self.ballot = self.local_post.ballot_set.get()
+        self.ballot.voting_system = self.ballot.VOTING_SYSTEM_FPTP
 
         # Create three people:
         self.people = [

--- a/ynr/apps/uk_results/tests/test_smoke_test_views.py
+++ b/ynr/apps/uk_results/tests/test_smoke_test_views.py
@@ -60,6 +60,34 @@ class TestUKResults(TestUserMixin, UK2015ExamplesMixin, WebTest, TestCase):
         winner = Membership.objects.get(person_id=15)
         self.assertTrue(winner.elected)
 
+    def test_form_view_creates_result_non_fptp(self):
+        self.ballot.voting_system = "STV"
+        self.ballot.save()
+        url = reverse(
+            "ballot_paper_results_form",
+            kwargs={
+                "ballot_paper_id": "local.maidstone.DIW:E05005004.2016-05-05"
+            },
+        )
+        resp = self.app.get(url, user=self.user_who_can_record_results)
+        self.assertEqual(resp.status_code, 200)
+        self.assertContains(resp, r'pattern="[0-9\s\.]*"')
+        form = resp.forms["ballot_paper_results_form"]
+        # Check that membership fields are not present for non-FPTP
+        self.assertNotIn("memberships_13", form.fields)
+        self.assertNotIn("memberships_14", form.fields)
+        self.assertNotIn("memberships_15", form.fields)
+
+        form["source"] = "Example ResultSet for testing"
+        form["num_turnout_reported"] = 1000
+        form["total_electorate"] = 2000
+        form.submit()
+        self.assertEqual(CandidateResult.objects.count(), 0)
+        self.assertEqual(ResultSet.objects.count(), 1)
+        self.assertEqual(ResultSet.objects.first().num_turnout_reported, 1000)
+        self.assertEqual(ResultSet.objects.first().total_electorate, 2000)
+        self.assertEqual(ResultSet.objects.first().turnout_percentage, 50.0)
+
     def test_partial_result_not_saved(self):
         url = reverse(
             "ballot_paper_results_form",

--- a/ynr/apps/uk_results/views/base_views.py
+++ b/ynr/apps/uk_results/views/base_views.py
@@ -36,7 +36,6 @@ class BallotPaperResultsUpdateView(LoginRequiredMixin, FormView):
         self.ballot = get_object_or_404(
             Ballot,
             cancelled=False,
-            voting_system=Ballot.VOTING_SYSTEM_FPTP,
             ballot_paper_id=self.kwargs["ballot_paper_id"],
         )
 


### PR DESCRIPTION
This PR allows users to enter result info for non-FPTP ballots, but not individual candidate results.

I've basically just removed the bits of code that prevented users from accessing the ResultSet form and made the candidate votes fields conditional based on the ballot voting system.

I haven't touched the source field on the ResultSet, because I'm planning to remove non-URLs on the WCIVF side. Would be good to have a second opinion on this, though.