### PR TITLE
don't allow data entry on locked SOPNs

### DIFF
--- a/ynr/apps/bulk_adding/tests/test_bulk_add.py
+++ b/ynr/apps/bulk_adding/tests/test_bulk_add.py
@@ -263,8 +263,8 @@ class TestBulkAdding(TestUserMixin, UK2015ExamplesMixin, WebTest):
     def test_submitting_form_when_candidates_locked(self):
         """
         Tests that if candidates have been locked whilst another user
-        is completing the bulk add process to create a lock suggestion
-        that the lock suggestion is not created
+        is completing the bulk add process, navigating to the reconcile
+        page redirects them away and no lock suggestion is created.
         """
         BallotSOPN.objects.create(
             source_url="http://example.com",
@@ -293,14 +293,12 @@ class TestBulkAdding(TestUserMixin, UK2015ExamplesMixin, WebTest):
         self.dulwich_post_ballot.save()
 
         response = response.follow()
-        form = response.forms["bulk_add_reconcile_formset"]
-        form["form-0-select_person"].select("_new")
-        response = form.submit()
+        self.assertEqual(response.status_code, 302)
+        self.assertEqual(
+            response.location, self.dulwich_post_ballot.get_absolute_url()
+        )
         self.assertEqual(
             self.dulwich_post_ballot.suggestedpostlock_set.count(), 0
-        )
-        self.assertContains(
-            response, "Candidates have already been locked for this ballot"
         )
 
     def test_submitting_form_with_previous_party_affiliations(self):

--- a/ynr/apps/bulk_adding/views/sopns.py
+++ b/ynr/apps/bulk_adding/views/sopns.py
@@ -51,7 +51,7 @@ class BaseSOPNBulkAddView(LoginRequiredMixin, TemplateView):
             return self.handle_no_permission()
 
         self.ballot = self.get_ballot()
-        if self.ballot.has_lock_suggestion:
+        if self.ballot.has_lock_suggestion or self.ballot.candidates_locked:
             # We don't want someone doing this again, so just set a
             # message and redirect them to the ballot page
             self.ballot_sopn = self.ballot.sopn


### PR DESCRIPTION
Currently YNR allows you to start the bulk adding process for a locked ballot.

Having updated the test, it does look like there's a check for this later in the process
but I think it makes more sense to prevent you starting it in the first place.

If we think we don't want to merge this ahead of this evening, we can park it.