### PR TITLE
Fix error when raw people longer than initial forms

### DIFF
--- a/ynr/apps/bulk_adding/forms.py
+++ b/ynr/apps/bulk_adding/forms.py
@@ -392,8 +392,22 @@ class QuickAddSinglePersonForm(PopulatePartiesMixin, NameOnlyPersonForm):
             "previous_party_affiliations"
         ].choices = previous_party_affiliations_choices
 
+    def full_clean(self):
+        """
+        Consider a form as empty if there's no name.
+
+        Remove any other errors from other fields.
+        """
+        name_key = self.add_prefix("name")
+        if self.is_bound and not (self.data.get(name_key, "")).strip():
+            self._errors = forms.utils.ErrorDict()
+            self.cleaned_data = {}
+            return
+        super().full_clean()
+
     def has_changed(self, *args, **kwargs):
-        if "name" not in self.changed_data:
+        name_key = self.add_prefix("name")
+        if not (self.data.get(name_key) or "").strip():
             return False
         return super().has_changed(*args, **kwargs)
 

--- a/ynr/apps/bulk_adding/tests/test_bulk_add.py
+++ b/ynr/apps/bulk_adding/tests/test_bulk_add.py
@@ -1673,6 +1673,32 @@ class TestBulkAdding(TestUserMixin, UK2015ExamplesMixin, WebTest):
         self.assertEqual(raw_people.claimed_by, self.user)
         self.assertIsNotNone(raw_people.claimed_at)
 
+    def test_longer_rawpeople_than_initial_forms(self):
+        """
+        Regression test: previously if the number of items
+        in a raw_people object was more than the initial forms
+        an AttributeError error would be raised.
+
+        """
+        raw_people = self._create_sopn_and_rawpeople()
+
+        raw_people.textract_data = [
+            {
+                "name": "Husam Alharahsheh",
+                "party_id": "PP63",
+                "sopn_last_name": "ALHARAHSHEH",
+                "sopn_first_names": "Husam",
+            }
+            for i in range(20)
+        ]
+        raw_people.save()
+        response = self.app.get(
+            "/bulk_adding/sopn/parl.65808.2015-05-07/",
+            user=self.user_who_can_merge,
+        )
+        response = response.forms["bulk_add_form"].submit()
+        self.assertEqual(response.status_code, 302)
+
 
 class TestOddCandidateCountWarnings(
     TestUserMixin, UK2015ExamplesMixin, WebTest

--- a/ynr/apps/bulk_adding/tests/test_bulk_add.py
+++ b/ynr/apps/bulk_adding/tests/test_bulk_add.py
@@ -851,7 +851,9 @@ class TestBulkAdding(TestUserMixin, UK2015ExamplesMixin, WebTest):
         self.assertEqual(resp.status_code, 302)
         resp = resp.follow()
         self.assertContains(resp, "Reconcile candidates")
-        resp = form.submit()
+        reconcile_form = resp.forms["bulk_add_reconcile_formset"]
+        reconcile_form["form-0-select_person"].select("_new")
+        resp = reconcile_form.submit().follow()
         self.assertContains(resp, "Bart Simpson")
 
     def test_existing_ballot_member_is_top_suggestion_on_reconcile_form(self):


### PR DESCRIPTION
This fixes the is_welsh_run error, but also allows for removing a person from the initial form