### PR TITLE
Specify table name when getting versions column

### DIFF
--- a/ynr/apps/people/managers.py
+++ b/ynr/apps/people/managers.py
@@ -116,7 +116,7 @@ ELSE (
         SELECT
             (elem->>'timestamp')::timestamptz AS ts,
             elem->'data'->>'biography' AS bio
-        FROM jsonb_array_elements(versions) AS elem
+        FROM jsonb_array_elements(people_person.versions) AS elem
     ),
     ordered AS (
         SELECT


### PR DESCRIPTION
This was a simple fix. Tested that it also works when used in the QuerySet method