### PR TITLE
Don't fail on images that are too large

### DIFF
--- a/ynr/apps/moderation_queue/helpers.py
+++ b/ynr/apps/moderation_queue/helpers.py
@@ -46,6 +46,10 @@ def image_form_valid_response(request, person, image_form):
     )
 
 
+# 15MB — Rekognition's S3 object size limit
+MAX_IMAGE_BYTES = 15 * 1024 * 1024
+
+
 def convert_image_to_png(photo):
     # Some uploaded images are CYMK, which gives you an error when
     # you try to write them as PNG, so convert to RGBA (this is
@@ -60,11 +64,32 @@ def convert_image_to_png(photo):
         photo = PillowImage.open(photo).convert("RGBA")
     else:
         photo = photo.convert("RGBA")
+    converted = photo.copy().convert("RGB")
+    w, h = converted.size
+
+    # Render at full size first; return immediately if already within the limit.
     bytes_obj = BytesIO()
-    converted = photo.copy()
-    converted = converted.convert("RGB")
     converted.save(bytes_obj, "PNG")
-    return bytes_obj
+    if bytes_obj.tell() <= MAX_IMAGE_BYTES:
+        return bytes_obj
+
+    # Binary search over scale factors (0–1) to find the largest image that
+    # still encodes to <= MAX_IMAGE_BYTES.
+    lo, hi = 0.0, 1.0
+    best = bytes_obj  # fallback; always replaced within a couple of iterations
+    for _ in range(20):
+        mid = (lo + hi) / 2
+        resized = converted.resize(
+            (max(1, int(w * mid)), max(1, int(h * mid))), PillowImage.LANCZOS
+        )
+        buf = BytesIO()
+        resized.save(buf, "PNG")
+        if buf.tell() <= MAX_IMAGE_BYTES:
+            lo = mid  # this scale fits — search higher
+            best = buf
+        else:
+            hi = mid  # too large — search lower
+    return best
 
 
 class ImageDownloadException(Exception):

--- a/ynr/apps/moderation_queue/management/commands/moderation_queue_process_queued_images.py
+++ b/ynr/apps/moderation_queue/management/commands/moderation_queue_process_queued_images.py
@@ -1,11 +1,16 @@
 import json
-from io import BytesIO
 
 import boto3
 import sorl
-from django.core.management.base import BaseCommand, CommandError
+from django.core.management.base import BaseCommand
+from moderation_queue.helpers import convert_image_to_png
 from moderation_queue.models import QueuedImage
 from PIL import Image, ImageOps
+
+try:
+    from storages.backends.s3 import S3Storage
+except ImportError:
+    S3Storage = None
 
 # These magic values are because the AWS API crops faces quite tightly by
 # default, meaning we literally just get the face. These values are about
@@ -18,7 +23,6 @@ class Command(BaseCommand):
     def handle(self, **options):
         rekognition = boto3.client("rekognition", region_name="eu-west-1")
         attributes = ["ALL"]
-        any_failed = False
 
         qs = QueuedImage.objects.filter(decision="undecided").exclude(
             face_detection_tried=True
@@ -26,35 +30,39 @@ class Command(BaseCommand):
 
         for qi in qs:
             try:
-                bytes_obj = qi.image.file.read()
-                pil_img = Image.open(BytesIO(bytes_obj))
+                pil_img = Image.open(qi.image.file)
                 pil_img = ImageOps.exif_transpose(pil_img)
             except Exception as e:
                 msg = "Skipping QueuedImage{id}: {error}"
                 self.stdout.write(msg.format(id=qi.id, error=e))
                 continue
 
+            png_buffer = convert_image_to_png(pil_img)
+            qi.image.save(qi.image.name, png_buffer)
+            sorl.thumbnail.delete(qi.image.name, delete_file=False)
+
             try:
+                storage = qi.image.storage
+                if S3Storage and isinstance(storage, S3Storage):
+                    rekognition_image = {
+                        "S3Object": {
+                            "Bucket": storage.bucket_name,
+                            "Name": storage._normalize_name(qi.image.name),
+                        }
+                    }
+                else:
+                    rekognition_image = {"Bytes": png_buffer.getvalue()}
                 detected = rekognition.detect_faces(
-                    Image={"Bytes": bytes_obj}, Attributes=attributes
+                    Image=rekognition_image, Attributes=attributes
                 )
                 self.set_x_y_from_response(qi, detected, options["verbosity"])
             except Exception as e:
                 msg = "Skipping QueuedImage{id}: {error}"
-                self.stdout.write(msg.format(id=qi.id, error=e))
-                any_failed = True
+                self.stderr.write(msg.format(id=qi.id, error=e))
 
             qi.face_detection_tried = True
             qi.rotation_tried = True
-
-            buffer = BytesIO()
-            pil_img.save(buffer, format="PNG")
-            qi.image.save(qi.image.name, buffer)
-            sorl.thumbnail.delete(qi.image.name, delete_file=False)
             qi.save()
-
-        if any_failed:
-            raise CommandError("Broken images found (see above)")
 
     def get_bound(self, bound, im_size, scaling_factor):
         """


### PR DESCRIPTION
Couple of change here:

1. Use existing S3 images if we have them. This means Rekognition can accept larger files.

2. Resize images to no more than 15mb. I used a LLM to generate this binary search

3. Don't raise on Rekognition errors, it's not useful for us to know about these
