### PR TITLE
populate statement_to_voters_last_updated in API

### DIFF
--- a/ynr/apps/people/api/next/api_views.py
+++ b/ynr/apps/people/api/next/api_views.py
@@ -29,6 +29,7 @@ class PersonViewSet(viewsets.ReadOnlyModelViewSet):
                 "memberships__previous_party_affiliations",
             )
             .select_related("image", "image__uploading_user")
+            .with_biography_last_updated()
             .order_by("id")
         )
 

--- a/ynr/apps/people/api/next/serializers.py
+++ b/ynr/apps/people/api/next/serializers.py
@@ -122,7 +122,7 @@ class PersonSerializer(MinimalPersonSerializer):
         source="biography", allow_blank=True
     )
     statement_to_voters_last_updated = serializers.DateTimeField(
-        source="biography_last_updated", read_only=True
+        source="biography_last_updated"
     )
     favourite_biscuit = serializers.CharField(allow_null=True, allow_blank=True)
     thumbnail = serializers.SerializerMethodField()


### PR DESCRIPTION
Refs https://app.asana.com/1/1204880536137786/project/1204880927741389/task/1214190477127688?focus=true
Refs https://github.com/DemocracyClub/WhoCanIVoteFor/pull/2373

One part of this is: Fix the API.

The second part is: Why did this break silently?

Fundamentally,

```py
does_not_exist = serializers.DateTimeField()
```

throws

```py
alias = serializers.DateTimeField(source="does_not_exist")
```

throws

```py
alias = serializers.DateTimeField(source="does_not_exist", read_only=True)
```

passes silently.

This partly stems from the way serializers are used for both input and output. `read_only=True` implies `required=False` (you can't have a field which is both `required=True` and `read_only=True` - that throws `AssertionError: May not set both read_only and required`). If a field isn't required then it is skipped if missing:
https://github.com/encode/django-rest-framework/blob/385df20e3efd442107fd952fbb1d681bed3905b9/rest_framework/relations.py#L537-L545

So the issue is that we set this field `read_only=True` when we shouldn't have, which essentially made it optional. Any idea why we did that?
I suspect this bug might exist in some other places, but I have opted to leave those worms in the can for now
