### PR TITLE
Make watchmedo ignore static

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,6 +37,11 @@ services:
         'auto-restart',
         '--directory=/dc/ynr/code/ynr',
         '--patterns', '*.py;*.html;*.csv;*.json;*.md;*.txt',
+        # Ignore writes into ynr/static/.
+        # Otherwise, you get a 500 without running collectstatic
+        # N.B. watchdog uses pathlib.PurePath.match which doesn't support recursive globbing.
+        # This will be fixed in next release (https://github.com/gorakhargosh/watchdog/pull/1101)
+        '--ignore-patterns', '/dc/ynr/code/ynr/static;/dc/ynr/code/ynr/static/*;/dc/ynr/code/ynr/static/*/*;/dc/ynr/code/ynr/static/*/*/*;/dc/ynr/code/ynr/static/*/*/*/*;/dc/ynr/code/ynr/static/*/*/*/*/*;/dc/ynr/code/ynr/static/*/*/*/*/*/*',
         '--recursive',
         '--',
         # Whilst runnning gunicorn


### PR DESCRIPTION
This shouldn't effect the static pipeline reload that watchmedo provides, because we alter templates etc and the static pipeline writes to ynr/static

I've tested this by running
```
  podman compose down
  rm -rf ynr/static                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        
  podman compose up -d
  podman compose logs --follow frontend
```
And in  a seperate terminal running: `curl http://localhost:8080/`.

On master this gives a 500, but not on this branch. Also editing a template pulls the edits through on page refresh. 

As noted in the comment recursive globbing is coming to watchdog, so that will make the arg a bit nicer.        

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1214418311420173