### PR TITLE
add resultset__modified to last_updated

### DIFF
--- a/ynr/apps/candidates/models/popolo_extra.py
+++ b/ynr/apps/candidates/models/popolo_extra.py
@@ -266,6 +266,7 @@ class BallotQueryset(models.QuerySet):
                     "election__modified",
                     "post__modified",
                     "membership_modified_max",
+                    "resultset__modified",
                 ),
             )
             .distinct()

--- a/ynr/apps/candidates/tests/test_models.py
+++ b/ynr/apps/candidates/tests/test_models.py
@@ -410,6 +410,7 @@ class TestHasResultsOrNoResults(BallotsWithResultsMixin, TestCase):
                 "election__modified",
                 "post__modified",
                 "membership_modified_max",
+                "resultset__modified",
             ),
         )
         mock_annotate.return_value.distinct.assert_called_once()


### PR DESCRIPTION
Adding results to non-FPTP ballots isn't syncing to WCIVF, because the non-FPTP `ResultSet` objects don't update anything `Ballot.last_updated` checks when being calculated. This commit should fix that.

Tested this locally by adding results to an old ballot and checking the API reponse had the correct timestamp.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1214385772444618