### PR TITLE
Fix ballot last updated field

### DIFF
--- a/ynr/apps/candidates/models/popolo_extra.py
+++ b/ynr/apps/candidates/models/popolo_extra.py
@@ -255,23 +255,19 @@ class BallotQueryset(models.QuerySet):
     def with_last_updated(self):
         """
         Annotates the last_updated field to objects, which represents the most
-        recent modified timstamp out of the ballot, related election, post or
-        the most recently updated related candidate
+        recent modified timstamp out of the ballot, related election, post, resultset,
+        or the most recently updated related candidate
         """
-        return (
-            self.annotate(
-                membership_modified_max=Max("membership__modified"),
-                last_updated=Greatest(
-                    "modified",
-                    "election__modified",
-                    "post__modified",
-                    "membership_modified_max",
-                    "resultset__modified",
-                ),
-            )
-            .distinct()
-            .order_by("last_updated")
-        )
+        return self.annotate(
+            membership_modified_max=Max("membership__modified"),
+            last_updated=Greatest(
+                "modified",
+                "election__modified",
+                "post__modified",
+                "membership_modified_max",
+                "resultset__modified",
+            ),
+        ).distinct()
 
     def last_updated(self, datetime):
         """

--- a/ynr/apps/candidates/tests/test_models.py
+++ b/ynr/apps/candidates/tests/test_models.py
@@ -414,9 +414,6 @@ class TestHasResultsOrNoResults(BallotsWithResultsMixin, TestCase):
             ),
         )
         mock_annotate.return_value.distinct.assert_called_once()
-        mock_annotate.return_value.distinct.return_value.order_by.assert_called_once_with(
-            "last_updated"
-        )
 
     def test_ordered_by_latest_ee_modified(self):
         """

--- a/ynr/apps/elections/api/next/api_views.py
+++ b/ynr/apps/elections/api/next/api_views.py
@@ -110,16 +110,17 @@ class BallotViewSet(viewsets.ReadOnlyModelViewSet):
 
     def get_queryset(self):
         """
-        Checks if this is a last_updated request and if so annotates and orders
-        the queryset by the last_updated field so that the ballots with oldest
-        changes appear first.
+        Annotates the queryset with a `last_updated` field which is the latest modified date of
+        the ballot, its election, post, sopn and resultset.
+
+        Also checks if the last_updated query param is used, and if so, orders the queryset by that field.
         This is to help the importer from WCIVF deal with situations where a
         large number of ballots have been updated at the same time e.g. through
         a data migration which saves many or all objects.
         """
-        queryset = super().get_queryset()
+        queryset = super().get_queryset().with_last_updated()
         if self.request.query_params.get("last_updated"):
-            queryset = queryset.with_last_updated()
+            queryset = queryset.order_by("last_updated")
         return queryset
 
     def retrieve(self, request, *args, **kwargs):

--- a/ynr/apps/elections/api/next/api_views.py
+++ b/ynr/apps/elections/api/next/api_views.py
@@ -83,31 +83,6 @@ class BallotViewSet(viewsets.ReadOnlyModelViewSet):
 
         return queryset
 
-    def list(self, request, *args, **kwargs):
-        """
-        If the last_updated filter param is used objects are ordered oldest
-        changes first, and in maximum chunks of 200
-        """
-        return super().list(request, *args, **kwargs)
-        # TEMP return a paginated response to increase speed 2022 elections imported
-        # is_last_updated_query = self.request.query_params.get("last_updated")
-        # if not is_last_updated_query:
-        #     return super().list(request, *args, **kwargs)
-
-        # queryset = self.filter_queryset(self.get_queryset())
-        # queryset = queryset[:200]
-        # serializer = self.get_serializer(queryset, many=True)
-        # return Response(
-        #     OrderedDict(
-        #         [
-        #             ("count", len(serializer.data)),
-        #             ("next", None),
-        #             ("previous", None),
-        #             ("results", serializer.data),
-        #         ]
-        #     )
-        # )
-
     def get_queryset(self):
         """
         Annotates the queryset with a `last_updated` field which is the latest modified date of

--- a/ynr/apps/elections/api/next/serializers.py
+++ b/ynr/apps/elections/api/next/serializers.py
@@ -172,16 +172,9 @@ class BallotSerializer(serializers.HyperlinkedModelSerializer):
         lookup_field="ballot_paper_id",
         lookup_url_kwarg="ballot_paper_id",
     )
-    last_updated = serializers.SerializerMethodField()
+    last_updated = serializers.DateTimeField()
     cancelled = serializers.SerializerMethodField()
     tags = TagsField()
-
-    def get_last_updated(self, instance):
-        """
-        If the last_updated value has been annoated, return that, otherwise use
-        the modified date on the ballot instance
-        """
-        return getattr(instance, "last_updated", instance.modified)
 
     @swagger_serializer_method(serializer_or_field=BallotSOPNSerializer)
     def get_sopn(self, instance):

--- a/ynr/apps/elections/tests/test_viewsets.py
+++ b/ynr/apps/elections/tests/test_viewsets.py
@@ -16,6 +16,9 @@ class TestBallotViewSet:
 
         view.get_queryset()
         view.queryset.with_last_updated.assert_called_once()
+        view.queryset.with_last_updated.return_value.order_by.assert_called_once_with(
+            "last_updated"
+        )
 
     def test_get_queryset_last_updated_not_ordered(self):
         factory = APIRequestFactory()
@@ -26,4 +29,5 @@ class TestBallotViewSet:
         view.queryset = mock.MagicMock()
 
         view.get_queryset()
-        view.queryset.with_last_updated.assert_not_called()
+        view.queryset.with_last_updated.assert_called_once()
+        view.queryset.with_last_updated.return_value.order_by.assert_not_called()


### PR DESCRIPTION
The `last_updated` field's value on `Ballot` objects depends on whether or not the queryset has been annotated with the `last_updated` field:
https://github.com/DemocracyClub/yournextrepresentative/blob/5b4adb5e26fd9f34954335417a756daf0c116bde/ynr/apps/elections/api/next/serializers.py#L179-L184

We only annotate the queryset if the request used the last_updated parameter:
https://github.com/DemocracyClub/yournextrepresentative/blob/5b4adb5e26fd9f34954335417a756daf0c116bde/ynr/apps/elections/api/next/api_views.py#L121-L123

So the values of `last_updated` is inconsistent depending on whether or no you used the `last_updated` parameter in the API.

This PR fixes the above by always annotating the `Ballot` queryset used by the API with `last_updated` so the value will be consistent. 

I also moved the 'order_by' from the `BallotQuerySet.with_last_updated` method to `BallotViewSet.get_queryset` so that the API doesn't reorder the list view unless the `last_updated` paramer is supplied (which is intended behaviour).

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1214417146416280