### PR TITLE
fix previous party affiliations in CSV output

### DIFF
--- a/ynr/apps/data_exports/csv_fields.py
+++ b/ynr/apps/data_exports/csv_fields.py
@@ -18,6 +18,7 @@ from collections import OrderedDict
 from dataclasses import dataclass
 from typing import Callable, Dict, Literal, Optional, Union
 
+from django.contrib.postgres.aggregates import StringAgg
 from django.core.files.storage import default_storage
 from django.db.models import BooleanField, CharField, Expression
 from django.db.models.expressions import (
@@ -235,7 +236,9 @@ csv_fields["organisation_name"] = CSVField(
 )
 csv_fields["previous_party_affiliations"] = CSVField(
     type="expr",
-    value=F("membership__previous_party_affiliations"),
+    value=StringAgg(
+        "membership__previous_party_affiliations__name", delimiter=";"
+    ),
     value_group="candidacy",
     label="Previous party affiliations (Welsh candidacies only)",
 )


### PR DESCRIPTION
This PR fixes multiple bugs with the previous party affiliations field in CSV outputs:

1. Previously we were outputting our internal ID field. I've updated it to output the party name. We could potentially modify this so we've got 2 fields. One with the (EC register) IDs and one with the party names, but I just did party names for now. Partly because it means changing the column names (breaking) and partly because I think the second issue means I might end up circling back..

2. One membership can have multiple previous party affiliations. The way this code was previously written: If a person specified multiple previous party affiliations on a given nomination, this would give us duplicated output rows for that person in the CSV file. I've modified this to use a `StringAgg`. So now that gets presented as a list of party names separated by a `;` character. Do we have a pattern elsewhere for how we deal with this kind of situation (where a single candidacy can be associated with many of another object)? Seems like something that should have come up before.