### PR TITLE
fixes for display of cancelled elections

### DIFF
--- a/ynr/apps/candidates/models/popolo_extra.py
+++ b/ynr/apps/candidates/models/popolo_extra.py
@@ -425,7 +425,7 @@ class Ballot(EEModifiedMixin, models.Model):
     @property
     def cancelled_status_text(self):
         if self.cancelled:
-            return "(❌ cancelled)"
+            return "❌ cancelled"
         return None
 
     @property
@@ -441,7 +441,7 @@ class Ballot(EEModifiedMixin, models.Model):
     @property
     def locked_status_text(self):
         if self.candidates_locked:
-            return mark_safe("🔐 Locked")
+            return "🔐 Locked"
         return None
 
     @property

--- a/ynr/apps/elections/templates/elections/ballot_view.html
+++ b/ynr/apps/elections/templates/elections/ballot_view.html
@@ -45,6 +45,14 @@
 <div class="row">
   <div class="columns large-9">
     <div class="ballot_status">
+        {% if ballot.cancelled %}
+          <p>
+            ❌ The poll for this election was cancelled
+            {% if ballot.replaced_by %}
+            and <a href="{{ ballot.replaced_by.get_absolute_url }}">replaced by {{ ballot.replaced_by.ballot_paper_id }}</a>
+          </p>
+          {% endif %}
+        {% endif %}
         {% if candidates.exists %}
             {% if ballot.candidates_locked %}
                 <p>

--- a/ynr/apps/elections/templates/elections/election_list.html
+++ b/ynr/apps/elections/templates/elections/election_list.html
@@ -124,7 +124,7 @@
                 {% endif %}
             {% else %}
                 {% if ballot.cancelled %}
-                  {{ ballot.cancelled }}
+                  {{ ballot.cancelled_status_html }}
                 {% elif ballot.candidates_locked %}
                   {{ ballot.locked_status_html }}
                 {% else %}

--- a/ynr/apps/elections/views.py
+++ b/ynr/apps/elections/views.py
@@ -548,7 +548,9 @@ class BallotsForSelectAjaxView(View):
 
             ballot_label = ballot.post.label
             if ballot.cancelled:
-                ballot_label = f"{ballot_label} {ballot.cancelled_status_text}"
+                ballot_label = (
+                    f"{ballot_label} ({ballot.cancelled_status_text})"
+                )
             if ballot.candidates_locked:
                 ballot_label = f"{ballot_label} ({ballot.locked_status_text})"
                 option_attrs["disabled"] = True


### PR DESCRIPTION
1. Don't output "true" on the election list page when a ballot is cancelled
2. Give some indication a ballot is cancelled on the ballot detail page if a ballot is cancelled (this was deleted in https://github.com/DemocracyClub/yournextrepresentative/pull/2666 )