### PR TITLE
Page results for results Atom

### DIFF
--- a/ynr/apps/results/feeds.py
+++ b/ynr/apps/results/feeds.py
@@ -2,21 +2,34 @@ from urllib.parse import urlunsplit
 
 from django.conf import settings
 from django.contrib.sites.models import Site
-from django.contrib.syndication.views import Feed
+from django.contrib.syndication.views import Feed, add_domain
+from django.core.paginator import Paginator
 from django.utils.feedgenerator import Atom1Feed
 
 from .models import ResultEvent
 
+PAGE_SIZE = 300
 
-class BasicResultEventsFeed(Feed):
-    feed_type = Atom1Feed
-    title = "Election results from {site_name}".format(
-        site_name=settings.SITE_NAME
-    )
-    link = "/"
-    description = "A basic feed of election results"
 
-    def items(self):
+class RFC5005PagingMixin:
+    """
+    Mixin adding RFC 5005 (Feed Paging and Archiving) support.
+
+    Adds first/last/next/previous link elements to the feed root and
+    slices the queryset to PAGE_SIZE items per page, selected via ?page=N.
+    """
+
+    page_size = PAGE_SIZE
+
+    def get_object(self, request, *args, **kwargs):
+        try:
+            page_number = max(1, int(request.GET.get("page", 1)))
+        except (ValueError, TypeError):
+            page_number = 1
+        paginator = Paginator(self._base_queryset(), self.page_size)
+        return paginator.get_page(page_number)
+
+    def _base_queryset(self):
         return (
             ResultEvent.objects.filter(election__current=True)
             .select_related("user")
@@ -26,6 +39,52 @@ class BasicResultEventsFeed(Feed):
             .select_related("winner_party")
             .select_related("winner__image")
         )
+
+    def items(self, page_obj):
+        return page_obj
+
+    def get_feed(self, obj, request):
+        feed = super().get_feed(obj, request)
+        page_obj = obj
+        base_url = add_domain(
+            Site.objects.get_current().domain, request.path, request.is_secure()
+        )
+
+        feed.feed["feed_url"] = f"{base_url}?page={page_obj.number}"
+
+        paging_links = [
+            ("first", f"{base_url}?page=1"),
+            ("last", f"{base_url}?page={page_obj.paginator.num_pages}"),
+        ]
+        if page_obj.has_previous():
+            paging_links.append(
+                (
+                    "previous",
+                    f"{base_url}?page={page_obj.previous_page_number()}",
+                )
+            )
+        if page_obj.has_next():
+            paging_links.append(
+                ("next", f"{base_url}?page={page_obj.next_page_number()}")
+            )
+        feed.feed["paging_links"] = paging_links
+        return feed
+
+
+class PagingAtom1Feed(Atom1Feed):
+    def add_root_elements(self, handler):
+        super().add_root_elements(handler)
+        for rel, href in self.feed.get("paging_links", []):
+            handler.addQuickElement("link", "", {"rel": rel, "href": href})
+
+
+class BasicResultEventsFeed(RFC5005PagingMixin, Feed):
+    feed_type = PagingAtom1Feed
+    title = "Election results from {site_name}".format(
+        site_name=settings.SITE_NAME
+    )
+    link = "/"
+    description = "A basic feed of election results"
 
     def item_title(self, item):
         if item.retraction:
@@ -63,8 +122,6 @@ class BasicResultEventsFeed(Feed):
         )
 
     def item_link(self, item):
-        # Assuming we're only going to show these events on the front
-        # page for the moment:
         return "/#{}".format(item.id)
 
     def item_updateddate(self, item):
@@ -79,7 +136,7 @@ class BasicResultEventsFeed(Feed):
         return "unknown"
 
 
-class ResultEventsAtomFeedGenerator(Atom1Feed):
+class ResultEventsAtomFeedGenerator(PagingAtom1Feed):
     def add_item_elements(self, handler, item):
         super().add_item_elements(handler, item)
         keys = [

--- a/ynr/apps/results/feeds.py
+++ b/ynr/apps/results/feeds.py
@@ -38,6 +38,7 @@ class RFC5005PagingMixin:
             .select_related("winner")
             .select_related("winner_party")
             .select_related("winner__image")
+            .order_by("-created")
         )
 
     def items(self, page_obj):

--- a/ynr/apps/results/tests/test_results.py
+++ b/ynr/apps/results/tests/test_results.py
@@ -1,4 +1,5 @@
 from io import BytesIO
+from unittest.mock import patch
 
 import people.tests.factories
 from candidates.tests.auth import TestUserMixin
@@ -8,6 +9,7 @@ from django_webtest import WebTest
 from lxml import etree
 from moderation_queue.tests.paths import EXAMPLE_IMAGE_FILENAME
 from people.models import PersonImage
+from results.feeds import RFC5005PagingMixin
 from results.models import ResultEvent
 
 
@@ -75,9 +77,11 @@ class TestResultsFeed(
         expected = """<feed xmlns="http://www.w3.org/2005/Atom" xml:lang="en-gb">
   <title>Election results from example.com (with extra data)</title>
   <link href="http://example.com/" rel="alternate"/>
-  <link href="http://example.com/results/all.atom" rel="self"/>
+  <link href="http://example.com/results/all.atom?page=1" rel="self"/>
   <id>http://example.com/</id>
   <updated>{updated}</updated>
+  <link href="http://example.com/results/all.atom?page=1" rel="first"/>
+  <link href="http://example.com/results/all.atom?page=1" rel="last"/>
   <entry>
     <title>Tessa Jowell (Labour Party) won in Dulwich and West Norwood</title>
     <link href="http://example.com/#{item_id}" rel="alternate"/>
@@ -123,9 +127,11 @@ class TestResultsFeed(
         expected = """<feed xmlns="http://www.w3.org/2005/Atom" xml:lang="en-gb">
   <title>Election results from example.com</title>
   <link href="http://example.com/" rel="alternate"/>
-  <link href="http://example.com/results/all-basic.atom" rel="self"/>
+  <link href="http://example.com/results/all-basic.atom?page=1" rel="self"/>
   <id>http://example.com/</id>
   <updated>{updated}</updated>
+  <link href="http://example.com/results/all-basic.atom?page=1" rel="first"/>
+  <link href="http://example.com/results/all-basic.atom?page=1" rel="last"/>
   <entry>
     <title>Tessa Jowell (Labour Party) won in Dulwich and West Norwood</title>
     <link href="http://example.com/#{item_id}" rel="alternate"/>
@@ -195,9 +201,11 @@ class TestResultsFeedWithRetraction(
         expected = """<feed xmlns="http://www.w3.org/2005/Atom" xml:lang="en-gb">
   <title>Election results from example.com (with extra data)</title>
   <link href="http://example.com/" rel="alternate"/>
-  <link href="http://example.com/results/all.atom" rel="self"/>
+  <link href="http://example.com/results/all.atom?page=1" rel="self"/>
   <id>http://example.com/</id>
   <updated>{updated[2]}</updated>
+  <link href="http://example.com/results/all.atom?page=1" rel="first"/>
+  <link href="http://example.com/results/all.atom?page=1" rel="last"/>
   <entry>
     <title>Tessa Jowell (Labour Party) won in Dulwich and West Norwood</title>
     <link href="http://example.com/#{item_id[0]}" rel="alternate"/>
@@ -293,9 +301,11 @@ class TestResultsFeedWithRetraction(
         expected = """<feed xmlns="http://www.w3.org/2005/Atom" xml:lang="en-gb">
   <title>Election results from example.com</title>
   <link href="http://example.com/" rel="alternate"/>
-  <link href="http://example.com/results/all-basic.atom" rel="self"/>
+  <link href="http://example.com/results/all-basic.atom?page=1" rel="self"/>
   <id>http://example.com/</id>
   <updated>{updated[2]}</updated>
+  <link href="http://example.com/results/all-basic.atom?page=1" rel="first"/>
+  <link href="http://example.com/results/all-basic.atom?page=1" rel="last"/>
   <entry>
     <title>Tessa Jowell (Labour Party) won in Dulwich and West Norwood</title>
     <link href="http://example.com/#{item_id[0]}" rel="alternate"/>
@@ -342,3 +352,121 @@ class TestResultsFeedWithRetraction(
             item_id=[result_event.id for result_event in self.events],
         )
         self.compare_xml(expected, xml_pretty)
+
+
+class TestResultsFeedPaging(TestUserMixin, UK2015ExamplesMixin, WebTest):
+    """
+    Tests for RFC 5005 paging behaviour. Uses page_size=2 so we can exercise
+    multi-page logic without creating hundreds of fixtures.
+    """
+
+    def setUp(self):
+        super().setUp()
+        people_list = [
+            people.tests.factories.PersonFactory.create(
+                id=5000 + i, name=f"Person {i}"
+            )
+            for i in range(3)
+        ]
+        for person in people_list:
+            ResultEvent.objects.create(
+                election=self.election,
+                winner=person,
+                post=self.dulwich_post,
+                winner_party=self.labour_party,
+                source="Source",
+                user=self.user,
+            )
+        self.events = list(ResultEvent.objects.order_by("created"))
+
+    def _get_links(self, url):
+        response = self.app.get(url)
+        root = etree.XML(response.content)
+        ns = {"atom": "http://www.w3.org/2005/Atom"}
+        return {
+            el.get("rel"): el.get("href")
+            for el in root.findall("atom:link", ns)
+        }
+
+    def _get_entries(self, url):
+        response = self.app.get(url)
+        root = etree.XML(response.content)
+        ns = {"atom": "http://www.w3.org/2005/Atom"}
+        return root.findall("atom:entry", ns)
+
+    @patch.object(RFC5005PagingMixin, "page_size", new=2)
+    def test_first_page_has_first_last_next_no_previous(self):
+        links = self._get_links("/results/all-basic.atom?page=1")
+        self.assertIn("first", links)
+        self.assertIn("last", links)
+        self.assertIn("next", links)
+        self.assertNotIn("previous", links)
+
+    @patch.object(RFC5005PagingMixin, "page_size", new=2)
+    def test_last_page_has_first_last_previous_no_next(self):
+        links = self._get_links("/results/all-basic.atom?page=2")
+        self.assertIn("first", links)
+        self.assertIn("last", links)
+        self.assertIn("previous", links)
+        self.assertNotIn("next", links)
+
+    @patch.object(RFC5005PagingMixin, "page_size", new=2)
+    def test_paging_link_urls_are_correct(self):
+        links = self._get_links("/results/all-basic.atom?page=1")
+        self.assertEqual(
+            links["first"], "http://example.com/results/all-basic.atom?page=1"
+        )
+        self.assertEqual(
+            links["last"], "http://example.com/results/all-basic.atom?page=2"
+        )
+        self.assertEqual(
+            links["next"], "http://example.com/results/all-basic.atom?page=2"
+        )
+
+        links2 = self._get_links("/results/all-basic.atom?page=2")
+        self.assertEqual(
+            links2["previous"],
+            "http://example.com/results/all-basic.atom?page=1",
+        )
+
+    @patch.object(RFC5005PagingMixin, "page_size", new=2)
+    def test_self_link_includes_page_number(self):
+        links = self._get_links("/results/all-basic.atom?page=2")
+        self.assertEqual(
+            links["self"], "http://example.com/results/all-basic.atom?page=2"
+        )
+
+    @patch.object(RFC5005PagingMixin, "page_size", new=2)
+    def test_correct_items_on_each_page(self):
+        page1_entries = self._get_entries("/results/all-basic.atom?page=1")
+        page2_entries = self._get_entries("/results/all-basic.atom?page=2")
+        self.assertEqual(len(page1_entries), 2)
+        self.assertEqual(len(page2_entries), 1)
+
+    @patch.object(RFC5005PagingMixin, "page_size", new=2)
+    def test_single_page_feed_has_no_next_or_previous(self):
+        # Only 1 item — fits on one page even with page_size=2 patched
+        ResultEvent.objects.all().delete()
+        person = people.tests.factories.PersonFactory.create(
+            id=9999, name="Solo Person"
+        )
+        ResultEvent.objects.create(
+            election=self.election,
+            winner=person,
+            post=self.dulwich_post,
+            winner_party=self.labour_party,
+            source="Source",
+            user=self.user,
+        )
+        links = self._get_links("/results/all-basic.atom?page=1")
+        self.assertNotIn("next", links)
+        self.assertNotIn("previous", links)
+        self.assertIn("first", links)
+        self.assertIn("last", links)
+
+    @patch.object(RFC5005PagingMixin, "page_size", new=2)
+    def test_paging_works_for_full_feed_too(self):
+        links = self._get_links("/results/all.atom?page=1")
+        self.assertIn("first", links)
+        self.assertIn("next", links)
+        self.assertNotIn("previous", links)

--- a/ynr/apps/results/tests/test_results.py
+++ b/ynr/apps/results/tests/test_results.py
@@ -73,7 +73,7 @@ class TestResultsFeed(
         root = etree.XML(response.content)
         xml_pretty = etree.tounicode(root, pretty_print=True)
 
-        result_event = ResultEvent.objects.first()
+        result_event = ResultEvent.objects.order_by("-created").first()
         expected = """<feed xmlns="http://www.w3.org/2005/Atom" xml:lang="en-gb">
   <title>Election results from example.com (with extra data)</title>
   <link href="http://example.com/" rel="alternate"/>
@@ -206,29 +206,30 @@ class TestResultsFeedWithRetraction(
   <updated>{updated[2]}</updated>
   <link href="http://example.com/results/all.atom?page=1" rel="first"/>
   <link href="http://example.com/results/all.atom?page=1" rel="last"/>
+  
+  
   <entry>
-    <title>Tessa Jowell (Labour Party) won in Dulwich and West Norwood</title>
-    <link href="http://example.com/#{item_id[0]}" rel="alternate"/>
-    <published>{updated[0]}</published>
-    <updated>{updated[0]}</updated>
+    <title>James Barber (Liberal Democrats) won in Dulwich and West Norwood</title>
+    <link href="http://example.com/#{item_id[2]}" rel="alternate"/>
+    <published>{updated[2]}</published>
+    <updated>{updated[2]}</updated>
     <author>
       <name>john</name>
     </author>
-    <id>http://example.com/#{item_id[0]}</id>
-    <summary type="html">A example.com volunteer recorded at {space_separated[0]} that Tessa Jowell (Labour Party) won the ballot in Dulwich and West Norwood, quoting the source 'Seen on the BBC news'.</summary>
+    <id>http://example.com/#{item_id[2]}</id>
+    <summary type="html">A example.com volunteer recorded at {space_separated[2]} that James Barber (Liberal Democrats) won the ballot in Dulwich and West Norwood, quoting the source 'Seen on Sky News'.</summary>
     <retraction>0</retraction>
     <election_slug>parl.2015-05-07</election_slug>
     <election_name>2015 General Election</election_name>
     <election_date>{election_date}</election_date>
     <post_id>65808</post_id>
-    <winner_person_id>4322</winner_person_id>
-    <winner_person_name>Tessa Jowell</winner_person_name>
-    <winner_party_id>party:53</winner_party_id>
-    <winner_party_name>Labour Party</winner_party_name>
+    <winner_person_id>4493</winner_person_id>
+    <winner_person_name>James Barber</winner_person_name>
+    <winner_party_id>party:90</winner_party_id>
+    <winner_party_name>Liberal Democrats</winner_party_name>
     <user_id>{user_id}</user_id>
     <post_name>Dulwich and West Norwood</post_name>
-    <information_source>Seen on the BBC news</information_source>
-    <parlparse_id>uk.org.publicwhip/person/123456</parlparse_id>
+    <information_source>Seen on Sky News</information_source>
   </entry>
   <entry>
     <title>Correction: retracting the statement that Tessa Jowell (Labour Party) won in Dulwich and West Norwood</title>
@@ -255,27 +256,28 @@ class TestResultsFeedWithRetraction(
     <parlparse_id>uk.org.publicwhip/person/123456</parlparse_id>
   </entry>
   <entry>
-    <title>James Barber (Liberal Democrats) won in Dulwich and West Norwood</title>
-    <link href="http://example.com/#{item_id[2]}" rel="alternate"/>
-    <published>{updated[2]}</published>
-    <updated>{updated[2]}</updated>
+    <title>Tessa Jowell (Labour Party) won in Dulwich and West Norwood</title>
+    <link href="http://example.com/#{item_id[0]}" rel="alternate"/>
+    <published>{updated[0]}</published>
+    <updated>{updated[0]}</updated>
     <author>
       <name>john</name>
     </author>
-    <id>http://example.com/#{item_id[2]}</id>
-    <summary type="html">A example.com volunteer recorded at {space_separated[2]} that James Barber (Liberal Democrats) won the ballot in Dulwich and West Norwood, quoting the source 'Seen on Sky News'.</summary>
+    <id>http://example.com/#{item_id[0]}</id>
+    <summary type="html">A example.com volunteer recorded at {space_separated[0]} that Tessa Jowell (Labour Party) won the ballot in Dulwich and West Norwood, quoting the source 'Seen on the BBC news'.</summary>
     <retraction>0</retraction>
     <election_slug>parl.2015-05-07</election_slug>
     <election_name>2015 General Election</election_name>
     <election_date>{election_date}</election_date>
     <post_id>65808</post_id>
-    <winner_person_id>4493</winner_person_id>
-    <winner_person_name>James Barber</winner_person_name>
-    <winner_party_id>party:90</winner_party_id>
-    <winner_party_name>Liberal Democrats</winner_party_name>
+    <winner_person_id>4322</winner_person_id>
+    <winner_person_name>Tessa Jowell</winner_person_name>
+    <winner_party_id>party:53</winner_party_id>
+    <winner_party_name>Labour Party</winner_party_name>
     <user_id>{user_id}</user_id>
     <post_name>Dulwich and West Norwood</post_name>
-    <information_source>Seen on Sky News</information_source>
+    <information_source>Seen on the BBC news</information_source>
+    <parlparse_id>uk.org.publicwhip/person/123456</parlparse_id>
   </entry>
 </feed>
 """.format(
@@ -307,15 +309,15 @@ class TestResultsFeedWithRetraction(
   <link href="http://example.com/results/all-basic.atom?page=1" rel="first"/>
   <link href="http://example.com/results/all-basic.atom?page=1" rel="last"/>
   <entry>
-    <title>Tessa Jowell (Labour Party) won in Dulwich and West Norwood</title>
-    <link href="http://example.com/#{item_id[0]}" rel="alternate"/>
-    <published>{updated[0]}</published>
-    <updated>{updated[0]}</updated>
+    <title>James Barber (Liberal Democrats) won in Dulwich and West Norwood</title>
+    <link href="http://example.com/#{item_id[2]}" rel="alternate"/>
+    <published>{updated[2]}</published>
+    <updated>{updated[2]}</updated>
     <author>
       <name>john</name>
     </author>
-    <id>http://example.com/#{item_id[0]}</id>
-    <summary type="html">A example.com volunteer recorded at {space_separated[0]} that Tessa Jowell (Labour Party) won the ballot in Dulwich and West Norwood, quoting the source 'Seen on the BBC news'.</summary>
+    <id>http://example.com/#{item_id[2]}</id>
+    <summary type="html">A example.com volunteer recorded at {space_separated[2]} that James Barber (Liberal Democrats) won the ballot in Dulwich and West Norwood, quoting the source 'Seen on Sky News'.</summary>
   </entry>
   <entry>
     <title>Correction: retracting the statement that Tessa Jowell (Labour Party) won in Dulwich and West Norwood</title>
@@ -329,16 +331,16 @@ class TestResultsFeedWithRetraction(
     <summary type="html">At {space_separated[1]}, a example.com volunteer retracted the previous assertion that Tessa Jowell (Labour Party) won the ballot in Dulwich and West Norwood, quoting the source 'Result recorded in error, retracting'.</summary>
   </entry>
   <entry>
-    <title>James Barber (Liberal Democrats) won in Dulwich and West Norwood</title>
-    <link href="http://example.com/#{item_id[2]}" rel="alternate"/>
-    <published>{updated[2]}</published>
-    <updated>{updated[2]}</updated>
+    <title>Tessa Jowell (Labour Party) won in Dulwich and West Norwood</title>
+    <link href="http://example.com/#{item_id[0]}" rel="alternate"/>
+    <published>{updated[0]}</published>
+    <updated>{updated[0]}</updated>
     <author>
       <name>john</name>
     </author>
-    <id>http://example.com/#{item_id[2]}</id>
-    <summary type="html">A example.com volunteer recorded at {space_separated[2]} that James Barber (Liberal Democrats) won the ballot in Dulwich and West Norwood, quoting the source 'Seen on Sky News'.</summary>
-  </entry>
+    <id>http://example.com/#{item_id[0]}</id>
+    <summary type="html">A example.com volunteer recorded at {space_separated[0]} that Tessa Jowell (Labour Party) won the ballot in Dulwich and West Norwood, quoting the source 'Seen on the BBC news'.</summary>
+  </entry>  
 </feed>
 """.format(
             updated=[


### PR DESCRIPTION
Currently the site exposes a URL that attempts to build a massive Atom feed of all results (in current elections). 

This change implements paging for that endpoint. 

I used an LLM to help with some of this code, especially the new test. 