### PR TITLE
Allow 18-year-olds to enter their birth year

### DIFF
--- a/ynr/apps/people/helpers.py
+++ b/ynr/apps/people/helpers.py
@@ -206,7 +206,7 @@ def clean_biography(bio):
 def clean_birth_date(year):
     if year:
         current_year = date.today().year
-        min_year = str(current_year - 19)
+        min_year = str(current_year - 18)
         if not "1900" < year <= min_year:
             raise ValidationError("Please enter a valid year of birth")
     return year


### PR DESCRIPTION
Fixes #2726.

`clean_birth_date` was using `current_year - 19` as the cutoff, so right now (2026) it rejects 2008, even though someone born in 2008 turns 18 this year and is eligible to stand. Bumped the offset to 18.