### PR TITLE
Strip mailto: prefix from email identifiers

### DIFF
--- a/ynr/apps/bulk_adding/fields.py
+++ b/ynr/apps/bulk_adding/fields.py
@@ -29,6 +29,8 @@ HTTP_IDENTIFIERS = [
 
 
 def clean_email(email):
+    if email.lower().startswith("mailto:"):
+        email = email[len("mailto:") :]
     validate_email(email)
     if email.lower().endswith("parliament.uk"):
         raise ValueError(

--- a/ynr/apps/people/forms/forms.py
+++ b/ynr/apps/people/forms/forms.py
@@ -181,6 +181,8 @@ class PersonIdentifierForm(forms.ModelForm):
             raise ValidationError(e)
 
     def clean_email(self, email):
+        if email.lower().startswith("mailto:"):
+            email = email[len("mailto:") :]
         validate_email(email)
         if email.lower().endswith("parliament.uk"):
             raise ValidationError(


### PR DESCRIPTION
Fixes #2735.

If you copy an email address out of a candidate's 'Contact' link on their council profile, you usually get something like `mailto:sarah_freestone@labour.org.uk`. Right now `validate_email` rejects that because of the scheme. Stripping it before validating means the address gets stored cleanly, the same way other identifier inputs already strip `https://`, `@`, etc.