### PR TITLE
Shuffle the open duplicate-suggestion list

### DIFF
--- a/ynr/apps/duplicates/views.py
+++ b/ynr/apps/duplicates/views.py
@@ -17,7 +17,8 @@ class DuplicateSuggestionListView(GroupRequiredMixin, ListView):
 
     def get_queryset(self):
         """
-        Only display suggestions that are open
+        Only display suggestions that are open, in a random order so the
+        gnarly ones don't permanently camp out at the top.
         """
         return (
             DuplicateSuggestion.objects.open()
@@ -34,6 +35,7 @@ class DuplicateSuggestionListView(GroupRequiredMixin, ListView):
                 "person__other_names",
                 "other_person__other_names",
             )
+            .order_by("?")
         )
 
 


### PR DESCRIPTION
Closes #2724.

@russss flagged that the complex suggestions pile up at the top of the open-suggestion list, so reviewers have to page through the difficult ones before they find a quick win. Adds `order_by('?')` to the listview queryset so the order rotates.