### PR TITLE
Fix 'seperate' / 'moemnt' typos in comments and docs

### DIFF
--- a/ynr/apps/official_documents/models.py
+++ b/ynr/apps/official_documents/models.py
@@ -273,7 +273,7 @@ class BaseBallotSOPN(TimeStampedModel):
         in which case this may be the string 'all'
 
         Related to an ElectionSOPN
-        in which case this must be a comma seperated list of sequential pages
+        in which case this must be a comma separated list of sequential pages
         3,4,5 is valid
         but 3,4,6 or 3,5,4 is not valid
         We can't deal with that

--- a/ynr/apps/parties/tests/test_importer.py
+++ b/ynr/apps/parties/tests/test_importer.py
@@ -299,7 +299,7 @@ class TestECPartyImporter(DefaultPartyFixtures, TmpMediaRootMixin, TestCase):
     @patch("parties.importer.ECEmblem.download_emblem")
     def test_bilingual_description_marked_inactive(self, FakeEmblemPath):
         """
-        We used to import these as a single pipe seperated description e.g:
+        We used to import these as a single pipe separated description e.g:
         "Make Good Use of Bad Rubbish | Gwneud Defnydd Da o Sbwriel Gwael"
         We now import
         - "Make Good Use of Bad Rubbish" and

--- a/ynr/apps/people/merging.py
+++ b/ynr/apps/people/merging.py
@@ -187,7 +187,7 @@ class PersonMerger:
             "patronymic_name",
             "summary",
         ]
-        # name is handled seperately because it does not
+        # name is handled separately because it does not
         attrs_to_merge.remove("name")
         return attrs_to_merge
 

--- a/ynr/apps/people/models.py
+++ b/ynr/apps/people/models.py
@@ -127,7 +127,7 @@ class PersonIdentifier(TimeStampedModel):
         unique_together = (
             ("person", "internal_identifier", "value_type"),
             # TODO: Remove this.
-            # At the moemnt the version history can't deal with more than one
+            # At the moment the version history can't deal with more than one
             # value per value_type. This prevents creating duplicates, and
             # therefore means we'll be able to merge and revert people.
             # This constraint should be removed when the version history can

--- a/ynr/apps/people/tests/test_merging.py
+++ b/ynr/apps/people/tests/test_merging.py
@@ -677,7 +677,7 @@ class TestMerging(TestUserMixin, UK2015ExamplesMixin, WebTest):
     def test_person_attrs_to_merge(self):
         """
         Regression test to ensure that 'name' is not included in standard attrs
-        to be merged, as it is handled seperately
+        to be merged, as it is handled separately
         """
         merger = PersonMerger(self.dest_person, self.source_person)
         assert "name" not in merger.person_attrs_to_merge

--- a/ynr/apps/popolo/models.py
+++ b/ynr/apps/popolo/models.py
@@ -415,7 +415,7 @@ class Membership(Dateframeable, TimeStampedModel, models.Model):
     @property
     def previous_party_affiliations_string(self):
         """
-        Return a comma seperated list of EC-ID's for previous party affiliations
+        Return a comma separated list of EC-ID's for previous party affiliations
         relations
         """
         return "; ".join(

--- a/ynr/apps/sopn_parsing/README.md
+++ b/ynr/apps/sopn_parsing/README.md
@@ -61,7 +61,7 @@ will import data such as ballots from the live site that the other commands are
 reliant on
 - Then run `make download-sopns` which will download the SOPN pdf's and use them
 to create `OfficialDocument` objects that can then be used to test against. This
-command is seperated from `test-sopns` so that we can test the SOPN parsing
+command is separated from `test-sopns` so that we can test the SOPN parsing
 without making repeated unnecessary calls to the YNR api.
 - When this is completed you can now use the `make test-sopns` command.
 
@@ -76,13 +76,13 @@ returned if the number we have been able to parse has gone down.
 
 To download SOPN's for a specific election, open the Makefile and in the
 `download-sopns` command add the election slugs to the `--election-slugs=`
-argument as a comma seperated list e.g.
+argument as a comma separated list e.g.
 `--election-slugs=local.sheffield.2021-05-06,local.derbyshire.2021-05-06`.
 Remember not to commit these changes in the Makefile.
 
 To run the `make test-sopns` command for a specific Election, open the Makefile
 and in the `test-sopns` command add the election slugs to the `--election-slugs=`
-argument as a comma seperated list e.g.
+argument as a comma separated list e.g.
 `--election-slugs=local.sheffield.2021-05-06,local.derbyshire.2021-05-06`.
 Remember not to commit these changes in the Makefile.
 


### PR DESCRIPTION
Caught these while reading through the merge/import code. All comment, docstring, and README spelling fixes, nothing behavioural.