### PR TITLE
Reject adding a person to two ballots from the same election

### DIFF
--- a/ynr/apps/people/forms/formsets.py
+++ b/ynr/apps/people/forms/formsets.py
@@ -37,6 +37,32 @@ class MembershipFormSet(BaseInlineFormSet):
         kwargs["person"] = self.instance
         return kwargs
 
+    def clean(self):
+        # Reject adding the same person to two ballots from the same
+        # election (e.g. two wards in the same council on the same date) -
+        # that combination otherwise blew up downstream with a 500 (#2685).
+        super().clean()
+        seen_elections = {}
+        for form in self.forms:
+            if not form.cleaned_data:
+                continue
+            if form.cleaned_data.get(DELETION_FIELD_NAME):
+                continue
+            ballot = form.cleaned_data.get("ballot_paper_id")
+            if not ballot:
+                continue
+            election_id = ballot.election_id
+            other = seen_elections.get(election_id)
+            if other is not None:
+                form.add_error(
+                    "ballot_paper_id",
+                    "This person is already standing in another ballot "
+                    "in the same election ({}); please remove one before "
+                    "saving.".format(other.ballot_paper_id),
+                )
+            else:
+                seen_elections[election_id] = ballot
+
 
 PersonMembershipFormsetFactory = forms.inlineformset_factory(
     Person,

--- a/ynr/apps/people/tests/test_forms.py
+++ b/ynr/apps/people/tests/test_forms.py
@@ -7,6 +7,7 @@ from django.test import TestCase
 from parties.models import Party
 from parties.tests.fixtures import DefaultPartyFixtures
 from people.forms.forms import PersonMembershipForm
+from people.forms.formsets import PersonMembershipFormsetFactory
 from people.tests.factories import PersonFactory
 
 
@@ -98,4 +99,29 @@ class TestPersonMembershipForm(
         self.assertIn(
             '<option value="PP53" selected register="GB">Labour Party</option>',
             select_html,
+        )
+
+    def test_formset_rejects_two_ballots_from_same_election(self):
+        person = PersonFactory()
+        data = {
+            "memberships-TOTAL_FORMS": "2",
+            "memberships-INITIAL_FORMS": "0",
+            "memberships-MIN_NUM_FORMS": "0",
+            "memberships-MAX_NUM_FORMS": "1000",
+            "memberships-0-ballot_paper_id": (
+                self.dulwich_post_ballot.ballot_paper_id
+            ),
+            "memberships-0-party_identifier_0": "",
+            "memberships-0-party_identifier_1": self.labour_party.ec_id,
+            "memberships-1-ballot_paper_id": (
+                self.camberwell_post_ballot.ballot_paper_id
+            ),
+            "memberships-1-party_identifier_0": "",
+            "memberships-1-party_identifier_1": self.labour_party.ec_id,
+        }
+        formset = PersonMembershipFormsetFactory(data=data, instance=person)
+        self.assertFalse(formset.is_valid())
+        self.assertIn(
+            "already standing in another ballot in the same election",
+            str(formset.errors),
         )


### PR DESCRIPTION
Closes #2685.

@pmk01 reported that the person edit form let you add the same person to two ballots in the same organisation, which then 500'd and had to be unstuck through the admin. @chris48s asked for validation up-front.

Added a `clean` on `MembershipFormSet` that walks the non-deleted forms, collects their ballots, and rejects any pair that share an `election_id` (so two wards on the same council on the same date, the canonical case). Error is attached to the second `ballot_paper_id` field and names the conflicting ballot so it's clear what to remove.

Test goes through the formset directly with two sibling ballots (`dulwich_post_ballot` and `camberwell_post_ballot`, both attached to the existing UK examples' election fixture).