### PR TITLE
Skip diff_html for photo actions

### DIFF
--- a/ynr/apps/candidates/models/db.py
+++ b/ynr/apps/candidates/models/db.py
@@ -270,11 +270,25 @@ class LoggedAction(models.Model):
             output = f"{prefix} {desc}"
         return mark_safe(output)
 
+    PHOTO_ACTION_TYPES = frozenset(
+        {
+            ActionType.PHOTO_UPLOAD,
+            ActionType.PHOTO_APPROVE,
+            ActionType.PHOTO_REJECT,
+            ActionType.PHOTO_IGNORE,
+        }
+    )
+
     @property
     def diff_html(self):
         from popolo.models import VersionNotFound
 
         if not self.person:
+            return ""
+        if self.action_type in self.PHOTO_ACTION_TYPES:
+            # Photo actions don't write a Person version (the photo lives on a
+            # separate moderation queue) so there's nothing to diff - showing
+            # "Couldn't find version" here is just noise (see #2734).
             return ""
         try:
             return self.person.diff_for_version(

--- a/ynr/apps/candidates/tests/test_logged_action.py
+++ b/ynr/apps/candidates/tests/test_logged_action.py
@@ -56,3 +56,20 @@ class TestLoggedAction(TestUserMixin, UK2015ExamplesMixin, TestCase):
             action.subject_html,
             '<a href="/elections/parl.65913.2015-05-07/">Camberwell and Peckham (65913)</a>',
         )
+
+    def test_diff_html_blank_for_photo_upload(self):
+        # Photo upload doesn't write a Person version (the photo lives on a
+        # separate moderation queue), so diff_html should stay quiet rather
+        # than complaining "Couldn't find version" (see #2734).
+        person = people.tests.factories.PersonFactory.create(
+            id="9876", name="Test Candidate"
+        )
+        action = LoggedAction.objects.create(
+            user=self.user,
+            action_type=ActionType.PHOTO_UPLOAD,
+            ip_address="127.0.0.1",
+            person=person,
+            popit_person_new_version="not-a-real-version",
+            source="Just for tests...",
+        )
+        self.assertEqual(action.diff_html, "")


### PR DESCRIPTION
Closes #2734.

Photo `LoggedAction` rows (upload / approve / reject / ignore) don't write a Person version - the photo flows through the moderation queue instead - so `LoggedAction#diff_html` tries `person.diff_for_version(popit_person_new_version)`, doesn't find anything, and renders `Couldn't find version for person with ID …` in the 'Recent edits' table on `/accounts/me`.

Return empty for those action types. The 'Action Type' / 'Edited' columns already describe what happened ('uploaded a photo of candidate #X'), so the Diff cell just being blank is the cleaner outcome.