### PR TITLE
Stop using deprecated datetime.utcnow()

### DIFF
--- a/ynr/apps/candidates/views/version_data.py
+++ b/ynr/apps/candidates/views/version_data.py
@@ -1,5 +1,5 @@
 import sys
-from datetime import datetime
+from datetime import datetime, timezone
 from random import randint
 
 
@@ -18,7 +18,7 @@ def create_version_id():
 
 
 def get_current_timestamp():
-    return datetime.utcnow().isoformat()
+    return datetime.now(timezone.utc).replace(tzinfo=None).isoformat()
 
 
 def get_change_metadata(request, information_source, user=None):

--- a/ynr/apps/people/tests/test_revert.py
+++ b/ynr/apps/people/tests/test_revert.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timezone
 
 from candidates.tests.auth import TestUserMixin
 from candidates.tests.factories import MembershipFactory
@@ -283,7 +283,7 @@ class TestRevertPersonView(TestUserMixin, UK2015ExamplesMixin, WebTest):
             change_metadata={
                 "information_source": "initial version",
                 "version_id": "1",
-                "timestamp": datetime.utcnow().isoformat(),
+                "timestamp": datetime.now(timezone.utc).replace(tzinfo=None).isoformat(),
                 "username": self.user.username,
             }
         )
@@ -296,7 +296,7 @@ class TestRevertPersonView(TestUserMixin, UK2015ExamplesMixin, WebTest):
             change_metadata={
                 "information_source": "cleared the previous_party_affiliations",
                 "version_id": "2",
-                "timestamp": datetime.utcnow().isoformat(),
+                "timestamp": datetime.now(timezone.utc).replace(tzinfo=None).isoformat(),
                 "username": self.user.username,
             }
         )


### PR DESCRIPTION
Python 3.12 deprecated `datetime.utcnow()`. Two call sites left in the repo: `candidates/views/version_data.get_current_timestamp` (used for new Person version metadata) and a fixture in `people/tests/test_revert.py`. Both write a naive UTC isoformat into JSON, so swapped for `datetime.now(timezone.utc).replace(tzinfo=None)` to keep the same shape.