### PR TITLE
moderation_queue: drop the cgi import

### DIFF
--- a/ynr/apps/moderation_queue/forms.py
+++ b/ynr/apps/moderation_queue/forms.py
@@ -1,4 +1,3 @@
-import cgi
 from io import BytesIO
 
 import requests
@@ -90,7 +89,7 @@ class UploadPersonPhotoURLForm(forms.Form):
             msg = "That URL produced an HTTP error status code: {0}"
             raise ValidationError(msg.format(response.status_code))
         content_type = response.headers["content-type"]
-        main, sub = cgi.parse_header(content_type)
+        main = content_type.split(";", 1)[0].strip()
         if not main.startswith("image/"):
             msg = "This URL isn't for an image - it had Content-Type: {0}"
             raise ValidationError(msg.format(main))


### PR DESCRIPTION
`cgi` was removed in Python 3.13. `is_valid_image_url` only used `cgi.parse_header` to pull the main media type off the `content-type` header, so just split on `;`.