### PR TITLE
upgrade pypdf

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,9 +57,7 @@ dependencies = [
     "sorl-thumbnail-serializer-field",
     "slacker2",
     "pypandoc_binary==1.14",
-    "PyPDF2==2.12.1",
-    "amazon-textract-response-parser==1.0.3",
-    "amazon-textract-helper==0.0.35",
+    "pypdf==6.12.2",
     "pandas>=3.0.0",
     "wreq==0.10.2",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -24,56 +24,6 @@ wheels = [
 ]
 
 [[package]]
-name = "amazon-textract-helper"
-version = "0.0.35"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "amazon-textract-caller" },
-    { name = "amazon-textract-overlayer" },
-    { name = "amazon-textract-prettyprinter" },
-    { name = "amazon-textract-response-parser" },
-    { name = "boto3" },
-    { name = "botocore" },
-    { name = "pillow" },
-    { name = "pypdf" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/8c/2b/e6b0aca31d5504bac5d4f9b47b8ba6cbb816c0bc787f3839456aa61138a8/amazon-textract-helper-0.0.35.tar.gz", hash = "sha256:e5dc1afc4ade3cb5aa247ca556ee26a2e8e2b5e3aa7e176f3449df445262a53d", size = 1419526, upload-time = "2023-11-14T16:47:31.73Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/6e/a6/a16de3e84d357a68357dcda378bc80cd2def24e0065dfc0e692128f8d056/amazon_textract_helper-0.0.35-py2.py3-none-any.whl", hash = "sha256:4f727e480da17d5cf8060a5b1f1c045f61331f782c90cbd0084b20fd92808ab9", size = 298117, upload-time = "2023-11-14T16:47:29.034Z" },
-]
-
-[[package]]
-name = "amazon-textract-overlayer"
-version = "0.0.12"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "amazon-textract-caller" },
-    { name = "boto3" },
-    { name = "botocore" },
-    { name = "pillow" },
-    { name = "pypdf" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/be/41/cdfc5dcab9eaf3c2b3aedc7d49bfa18cecae06d0f87e2732bf39ce2f5aa7/amazon-textract-overlayer-0.0.12.tar.gz", hash = "sha256:f6b7f87381d62a84aa8f159c218600f7e6742771a58e6126515b1849a105e288", size = 9100, upload-time = "2023-11-14T16:44:58.594Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/7b/d6/65dd95f8807c7bba6f6ace217ae00c505504b09ca39d2c7559a2f4edff18/amazon_textract_overlayer-0.0.12-py2.py3-none-any.whl", hash = "sha256:68ac82fbee1fa8080a79cb2cba304d94e07862b856fbbaebe50fc2f23195926c", size = 9400, upload-time = "2023-11-14T16:44:57.077Z" },
-]
-
-[[package]]
-name = "amazon-textract-prettyprinter"
-version = "0.1.4"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "amazon-textract-response-parser" },
-    { name = "boto3" },
-    { name = "botocore" },
-    { name = "tabulate" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/ae/08/3657fa43e40205729774eccebfc1b1b81c9d0a80d70c2926cca211c7fc46/amazon-textract-prettyprinter-0.1.4.tar.gz", hash = "sha256:3da1f01a05f450674ef592a9a1d77293db84818c39b704203ad50f80da46534a", size = 12039, upload-time = "2023-09-19T15:38:02.499Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/1f/f9/d4229a13515f157a8d04e6178300672d0c846846a532ecf8d9b383c6c2f7/amazon_textract_prettyprinter-0.1.4-py2.py3-none-any.whl", hash = "sha256:bcfe3677e056f38acddb462d3fcd8b2621c8c3dc325f5dd96ba1e38ebb17d496", size = 13417, upload-time = "2023-09-19T15:38:00.417Z" },
-]
-
-[[package]]
 name = "amazon-textract-response-parser"
 version = "1.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -1532,20 +1482,11 @@ wheels = [
 
 [[package]]
 name = "pypdf"
-version = "3.17.4"
+version = "6.12.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/6a/28/81460a77a64bb1e5254e37d4fa855e0a0549634a717bd4e407cba5fc92c6/pypdf-3.17.4.tar.gz", hash = "sha256:ec96e2e4fc9648ac609d19c00d41e9d606e0ae2ce5a0bbe7691426f5f157166a", size = 276323, upload-time = "2023-12-24T10:41:09.674Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/0a/6d/20879428577c1e57ecd41b69dc86beabf43db9287ad2e702207f8b48c751/pypdf-6.12.2.tar.gz", hash = "sha256:111669eb6680c04495ae0c113a1476e3bf93a95761d23c7406b591c80a6490b1", size = 6468184, upload-time = "2026-05-26T13:31:26.911Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/29/10/055b649e914ad8c5d07113c22805014988825abbeff007b0e89255b481fa/pypdf-3.17.4-py3-none-any.whl", hash = "sha256:6aa0f61b33779b64486de3f42835d3668badd48dac4a536aeb87da187a5eacd2", size = 278159, upload-time = "2023-12-24T10:41:06.79Z" },
-]
-
-[[package]]
-name = "pypdf2"
-version = "2.12.1"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/77/d6/afcbdb452c335bccf22ec8ac5ac27b03222f9be8b96043bcce87ba1ce32a/PyPDF2-2.12.1.tar.gz", hash = "sha256:e03ef18abcc75da741a0acc1a7749253496887be38cd9887bcce1cee393da45e", size = 218096, upload-time = "2022-12-10T18:28:53.225Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/2e/40/4f997b7cf72d89bb5aafd57b01dfa0be4e9560c8e5b993fde3986b3904f9/pypdf2-2.12.1-py3-none-any.whl", hash = "sha256:41ff16ee122bad9790d57a4235281a838002d7f1cc8d631d91b6f65d709bd825", size = 222844, upload-time = "2022-12-10T18:28:49.6Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/44/fee070a16639d9869bb6a7e0f3a1b3946da1d66f32b9260b4d19cb90d7b2/pypdf-6.12.2-py3-none-any.whl", hash = "sha256:67b2699357a1f3f4c945940ea80826349ee507c9e2577724a14b4941982c104d", size = 343865, upload-time = "2026-05-26T13:31:25.068Z" },
 ]
 
 [[package]]
@@ -2120,8 +2061,6 @@ name = "yournextrepresentative"
 version = "0.0.0"
 source = { virtual = "." }
 dependencies = [
-    { name = "amazon-textract-helper" },
-    { name = "amazon-textract-response-parser" },
     { name = "amazon-textract-textractor", extra = ["pdf"] },
     { name = "beautifulsoup4" },
     { name = "blessed" },
@@ -2161,7 +2100,7 @@ dependencies = [
     { name = "pillow" },
     { name = "psycopg" },
     { name = "pypandoc-binary" },
-    { name = "pypdf2" },
+    { name = "pypdf" },
     { name = "python-dateutil" },
     { name = "python-dotenv" },
     { name = "python-magic" },
@@ -2207,8 +2146,6 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "amazon-textract-helper", specifier = "==0.0.35" },
-    { name = "amazon-textract-response-parser", specifier = "==1.0.3" },
     { name = "amazon-textract-textractor", extras = ["pdf"], specifier = "==1.9.2" },
     { name = "beautifulsoup4", specifier = "==4.12.0" },
     { name = "blessed", specifier = "==1.20.0" },
@@ -2248,7 +2185,7 @@ requires-dist = [
     { name = "pillow", specifier = "==12.2.0" },
     { name = "psycopg", specifier = "==3.1.12" },
     { name = "pypandoc-binary", specifier = "==1.14" },
-    { name = "pypdf2", specifier = "==2.12.1" },
+    { name = "pypdf", specifier = "==6.12.2" },
     { name = "python-dateutil", specifier = "==2.8.2" },
     { name = "python-dotenv", specifier = "==1.2.2" },
     { name = "python-magic", specifier = "==0.4.27" },

--- a/ynr/apps/official_documents/extract_pages.py
+++ b/ynr/apps/official_documents/extract_pages.py
@@ -10,8 +10,8 @@ from official_documents.models import (
     PageMatchingMethods,
     add_ballot_sopn,
 )
-from PyPDF2 import PdfReader, PdfWriter
-from PyPDF2.errors import DependencyError, PdfReadError
+from pypdf import PdfReader, PdfWriter
+from pypdf.errors import DependencyError, PdfReadError
 
 
 class PDFProcessingError(ValueError):

--- a/ynr/apps/official_documents/tests/test_page_splitter.py
+++ b/ynr/apps/official_documents/tests/test_page_splitter.py
@@ -14,8 +14,8 @@ from official_documents.extract_pages import (
     PDFProcessingError,
 )
 from official_documents.models import BallotSOPN, ElectionSOPN
-from PyPDF2 import PdfReader, PdfWriter
-from PyPDF2.errors import DependencyError, PdfReadError
+from pypdf import PdfReader, PdfWriter
+from pypdf.errors import DependencyError, PdfReadError
 
 
 class ElectionSOPNPageSplitterTestCase(UK2015ExamplesMixin, TestCase):

--- a/ynr/apps/official_documents/tests/test_page_splitter.py
+++ b/ynr/apps/official_documents/tests/test_page_splitter.py
@@ -1,0 +1,94 @@
+from io import BytesIO
+from unittest.mock import patch
+
+from candidates.tests.factories import (
+    BallotPaperFactory,
+    ElectionFactory,
+    PostFactory,
+)
+from candidates.tests.uk_examples import UK2015ExamplesMixin
+from django.core.files.base import ContentFile
+from django.test import TestCase
+from official_documents.extract_pages import (
+    ElectionSOPNPageSplitter,
+    PDFProcessingError,
+)
+from official_documents.models import BallotSOPN, ElectionSOPN
+from PyPDF2 import PdfReader, PdfWriter
+from PyPDF2.errors import DependencyError, PdfReadError
+
+
+class ElectionSOPNPageSplitterTestCase(UK2015ExamplesMixin, TestCase):
+    def setUp(self):
+        election = ElectionFactory.create(
+            slug="arse",
+            name="2015 General Election",
+            current=True,
+        )
+        BallotPaperFactory(
+            election=election,
+            post=PostFactory(label="Constituency 1", organization=self.commons),
+            ballot_paper_id="ballot1",
+        )
+        BallotPaperFactory(
+            election=election,
+            post=PostFactory(label="Constituency 2", organization=self.commons),
+            ballot_paper_id="ballot2",
+        )
+        self.election_sopn = ElectionSOPN.objects.create(
+            election=election,
+            uploaded_file=ContentFile(
+                self.create_sample_pdf(), name="test_sopn.pdf"
+            ),
+        )
+
+    def create_sample_pdf(self):
+        writer = PdfWriter()
+
+        for _ in range(3):
+            writer.add_blank_page(width=612, height=792)
+
+        buffer = BytesIO()
+        writer.write(buffer)
+        buffer.seek(0)
+
+        return buffer.read()
+
+    def test_raises_pdf_read_error_for_non_pdf(self):
+        non_pdf_sopn = ElectionSOPN.objects.create(
+            election=self.election_sopn.election,
+            uploaded_file=ContentFile(b"not a pdf", name="test_sopn.txt"),
+        )
+        with self.assertRaises(PdfReadError):
+            ElectionSOPNPageSplitter(non_pdf_sopn, {"ballot1": [0]})
+
+    def test_dependency_error_raises_pdf_processing_error(self):
+        ballot_to_pages = {"ballot1": [0]}
+        splitter = ElectionSOPNPageSplitter(self.election_sopn, ballot_to_pages)
+        with patch.object(
+            PdfWriter,
+            "add_page",
+            side_effect=DependencyError("missing dependency"),
+        ), self.assertRaises(PDFProcessingError):
+            splitter.split()
+
+    def test_split_pages(self):
+        ballot_to_pages = {
+            "ballot1": [0],
+            "ballot2": [1, 2],
+        }
+        splitter = ElectionSOPNPageSplitter(self.election_sopn, ballot_to_pages)
+        splitter.split()
+
+        ballot_sopns = BallotSOPN.objects.filter(
+            election_sopn=self.election_sopn
+        )
+        self.assertEqual(ballot_sopns.count(), 2)
+
+        bs1 = ballot_sopns.get(ballot__ballot_paper_id="ballot1")
+        reader = PdfReader(bs1.uploaded_file.open())
+        self.assertEqual(len(reader.pages), 1)
+
+        bs2 = ballot_sopns.get(ballot__ballot_paper_id="ballot2")
+        reader = PdfReader(bs2.uploaded_file.open())
+        self.assertEqual(len(reader.pages), 2)


### PR DESCRIPTION
There's quite a lot of background to explain here.

First off: We've removed a lot of the custom PDF parsing code from YNR in https://github.com/DemocracyClub/yournextrepresentative/commit/f3d95c4c2a5af6f2ec56a0d83ec452058bf6ce8b
This leaves us with a relatively small amount of custom PDF parsing code. Just the stuff for splitting PDFs into pages
For this, we are using a library called PyPDF2 which is long-deprecated https://pypi.org/project/PyPDF2/ and replaced by pypdf https://pypi.org/project/pypdf/
Also, there's a bunch of reported security issues in pypdf which are fixed in the current version but we've been ignoring it because it requires jumping multiple major versions.

One of the reasons why upgrading this code is hard is: We have no tests for the PDF page splitting code. So the first thing I did was get that code under test. Given my objective here was to be able to upgrade the library with confidence, I've focussed here on tests that exercise all the library imports.
Then I wanted to migrate PyPDF2 to pypdf.
The next issue I hit was: `amazon-textract-response-parser==1.0.3` and `amazon-textract-helper==0.0.35` were pinning us to `pypdf>=3.1,<4.0`. Both those top-level libraries were already on the latest available versions, so I decided to dig into what they did and I came to the conclusion.. nothing.

- amazon-textract-helper provides a command line tool called `amazon-textract`, which we don't seem to invoke anywhere
- amazon-textract-response-parser provides a module called `trp` and I don't see any python files in our codebase importing from `trp`

Looking back at the original PR where these libraries were added https://github.com/DemocracyClub/yournextrepresentative/pull/2177 I don't think we were ever using them for anything.

So I think we can just delete these with no consequences. Having removed those libraries, we're now free to install the latest version of pypdf.
Then I migrated our first-party code from PyPDF2 to pypdf. Turns out there are no breaking API changes affecting us other than changing the import from PyPDF2 to pypdf, but the tests made it easy to verify that.

..and then the upshot of all that is: It patches a bunch of known security issues, and if more pop up in future we have the tests in place to upgrade pypdf with a high level of confidence we're not breaking anything.