### PR TITLE
show re-scheduled elections on the front-page

### DIFF
--- a/ynr/apps/elections/uk/templatetags/home_page_tags.py
+++ b/ynr/apps/elections/uk/templatetags/home_page_tags.py
@@ -231,7 +231,8 @@ def by_election_ctas(context):
 
         all_ballots = (
             Ballot.objects.filter(
-                election__current=True, ballot_paper_id__contains=".by."
+                Q(ballot_paper_id__contains=".by.") | Q(replaces__isnull=False),
+                election__current=True,
             )
             .exclude(election__election_date__in=dates_to_ignore)
             .order_by("election__election_date", "election")


### PR DESCRIPTION
This modifies the query to include rescheduled elections on the front page.

There are two problems with this:

1. The title for this block is still "Upcoming by-elections" which is now not strictly accurate. Is there a better title for this?
2. The reason we show by-elections on the front page and not all elections is really about volume. Limiting to by-elections means when we create scheduled elections we don't show thousands of ballots on the home page and make it really slow. One possible way that this could go wrong is if there are mass cancellations and we mark all the rescheduled elections as replacements. So for example, if large swathes of elections were cancelled due to [COVID pandemic|local government re-org|foot & mouth outbreak|etc] and then we create the new ones and mark them all as replacements for the cancelled ones then this query will return more data then we really want it to.