### PR TITLE
Show all actions on person page

### DIFF
--- a/ynr/apps/candidates/diffs.py
+++ b/ynr/apps/candidates/diffs.py
@@ -4,6 +4,7 @@
 
 import json
 import re
+from typing import Dict, List
 
 import jsonpatch
 import jsonpointer
@@ -164,7 +165,7 @@ def get_parents_version_data(parents, id_to_version):
     return [(None, {})]
 
 
-def get_version_diffs(versions):
+def get_version_diffs(versions) -> List[Dict]:
     """Add a diff to each of an array of version dicts
 
     The first version is the most recent; the last is the original

--- a/ynr/apps/candidates/models/db.py
+++ b/ynr/apps/candidates/models/db.py
@@ -289,7 +289,7 @@ class LoggedAction(models.Model):
                 self.popit_person_new_version, inline_style=True
             )
         except VersionNotFound as e:
-            return "<p>{}</p>".format(escape(str(e)))
+            return mark_safe("<p>{}</p>".format(escape(str(e))))
 
     def changed_version_fields(self):
         if not self.version_fields:

--- a/ynr/apps/candidates/models/db.py
+++ b/ynr/apps/candidates/models/db.py
@@ -206,6 +206,9 @@ class LoggedAction(models.Model):
             )
         return ""
 
+    def friendly_action_type(self):
+        return ActionType(self.action_type).label
+
     def friendly_description(self):
         url = self.subject_url
         prefix = ""

--- a/ynr/apps/candidates/models/db.py
+++ b/ynr/apps/candidates/models/db.py
@@ -15,6 +15,7 @@ from moderation_queue.review_required_helper import (
     REVIEW_TYPES,
 )
 from moderation_queue.slack import post_action_to_slack
+from popolo.models import VersionNotFound
 
 
 class LoggedActionQuerySet(models.QuerySet):
@@ -271,9 +272,16 @@ class LoggedAction(models.Model):
         return mark_safe(output)
 
     @property
-    def diff_html(self):
-        from popolo.models import VersionNotFound
+    def version_dict(self):
+        if not self.person:
+            return ""
+        try:
+            return self.person.version_dict(self.popit_person_new_version)
+        except VersionNotFound:
+            return None
 
+    @property
+    def diff_html(self):
         if not self.person:
             return ""
         try:

--- a/ynr/apps/candidates/models/db.py
+++ b/ynr/apps/candidates/models/db.py
@@ -325,7 +325,7 @@ class LoggedAction(models.Model):
 
     def save(self, **kwargs):
         has_initial_pk = self.pk
-        if not kwargs.get("review_not_required", False):
+        if not kwargs.pop("review_not_required", False):
             self.set_review_required()
 
         if self.person:

--- a/ynr/apps/candidates/models/db.py
+++ b/ynr/apps/candidates/models/db.py
@@ -277,7 +277,7 @@ class LoggedAction(models.Model):
     @property
     def version_dict(self):
         if not self.person:
-            return ""
+            return None
         try:
             return self.person.version_dict(self.popit_person_new_version)
         except VersionNotFound:

--- a/ynr/apps/candidates/templates/candidates/person-create.html
+++ b/ynr/apps/candidates/templates/candidates/person-create.html
@@ -26,8 +26,4 @@
   </div>
 </div>
 
-<div class="person__versions">
-{% include 'candidates/person-versions.html' %}
-</div>
-
 {% endblock %}

--- a/ynr/apps/candidates/templates/candidates/person-edit.html
+++ b/ynr/apps/candidates/templates/candidates/person-edit.html
@@ -28,7 +28,6 @@
 {% endblock %}
 
 {% block content %}
-
 {% if user_can_edit and person_edits_allowed %}
 
   <div class="person__details">

--- a/ynr/apps/candidates/templates/candidates/person-versions.html
+++ b/ynr/apps/candidates/templates/candidates/person-versions.html
@@ -14,7 +14,7 @@
             >
                 <dl>
                     <dt>Edit type</dt>
-                    <dd>{{ action.action_type }}</dd>
+                    <dd>{{ action.friendly_action_type }}</dd>
                     <dt>Username</dt>
                     <dd>{{ action.user.username }}</dd>
                     {% if action.popit_person_new_version and action.version_dict %}

--- a/ynr/apps/candidates/templates/candidates/person-versions.html
+++ b/ynr/apps/candidates/templates/candidates/person-versions.html
@@ -32,7 +32,9 @@
                     <dd>{{ action.created }}</dd>
                     <dt>Source</dt>
                     <dd>{{ action.source }}</dd>
-                    {% if person_edits_allowed and action.popit_person_new_version and not forloop.first %}
+                    {% if action.popit_person_new_version %}
+                        {{ action.diff_html }}
+                    	{% if person_edits_allowed and not forloop.first %}
                         <dt>Revert to this</dt>
                         <dd>
                             <form id="revert-form-{{ action.popit_person_new_version }}"
@@ -45,7 +47,9 @@
                                 <input type="submit" class="button tiny alert" value="Revert"/>
                             </form>
                         </dd>
+                        {% endif %}
                     {% endif %}
+
                 </dl>
             </div>
         {% endfor %}

--- a/ynr/apps/candidates/templates/candidates/person-versions.html
+++ b/ynr/apps/candidates/templates/candidates/person-versions.html
@@ -1,36 +1,53 @@
 {% load prettyjson %}
 
 {% if request.user.is_authenticated %}
-<div class="person__versions">
-    <h2>All versions</h2>
-    {% for version in person.version_diffs %}
-      <div class="version" id="version-{{ version.version_id }}" data-parent-version-ids="{{ version.parent_version_ids|join:' ' }}">
-        <dl>
-          <dt>Version</dt>
-          <dd>
-            {{ version.version_id }} <a class="button tiny js-toggle-full-version-json">Hide full version</a>
-            <pre class="full-version-json">{{ version.data|prettyjson }}</pre>
-          </dd>
-          <dt>Username</dt>
-          <dd>{{ version.username }}</dd>
-          <dt>Timestamp</dt>
-          <dd>{{ version.timestamp }}</dd>
-          <dt>Source</dt>
-          <dd>{{ version.information_source }}</dd>
-          {% include 'candidates/_diffs_against_parents.html' with diffs_against_all_parents=version.diffs inline_style=False %}
-          {% if user.is_authenticated and person_edits_allowed and not forloop.first %}
-          <dt>Revert to this</dt>
-          <dd>
-            <form id="revert-form-{{ version.version_id }}" action="{% url 'person-revert' person_id=person.id %}" method="post" class="version-revert">
-              {% csrf_token %}
-              <input type="hidden" name="version_id" value="{{ version.version_id }}"/>
-              <input type="text" name="source" id="id_source" maxlength="512" required="required" value="Reverting to version {{ version.version_id }} because…"/>
-              <input type="submit" class="button tiny alert" value="Revert" />
-            </form>
-          </dd>
-          {% endif %}
-        </dl>
-      </div>
-    {% endfor %}
-</div>
+    <div class="person__versions">
+        <h2>All versions</h2>
+
+        {% for action in actions %}
+            <div
+                    class="version"
+                    id="version-{{ action.popit_person_new_version }}"
+                    {% if action.version_dict %}
+                    data-parent-version-ids="{{ action.version_dict.parent_version_ids|join:' ' }}"
+                    {% endif %}
+            >
+                <dl>
+                    <dt>Edit type</dt>
+                    <dd>{{ action.action_type }}</dd>
+                    <dt>Username</dt>
+                    <dd>{{ action.user.username }}</dd>
+                    {% if action.popit_person_new_version and action.version_dict %}
+                        {# Not all edit types have a version ID (e.g if marking as elected), uploading a photo #}
+                        <dt>Version</dt>
+                        <dd>
+                            {{ action.popit_person_new_version }} <a class="button tiny js-toggle-full-version-json">Hide
+                            full version</a>
+                            <pre class="full-version-json">{{ action.version_dict.data|prettyjson }}</pre>
+                        </dd>
+                    {% endif %}
+
+
+                    <dt>Timestamp</dt>
+                    <dd>{{ action.created }}</dd>
+                    <dt>Source</dt>
+                    <dd>{{ action.source }}</dd>
+                    {% if person_edits_allowed and action.popit_person_new_version and not forloop.first %}
+                        <dt>Revert to this</dt>
+                        <dd>
+                            <form id="revert-form-{{ action.popit_person_new_version }}"
+                                  action="{% url 'person-revert' person_id=person.id %}" method="post"
+                                  class="version-revert">
+                                {% csrf_token %}
+                                <input type="hidden" name="version_id" value="{{ action.popit_person_new_version }}"/>
+                                <input type="text" name="source" id="id_source" maxlength="512" required="required"
+                                       value="Reverting to version {{ action.popit_person_new_version }} because…"/>
+                                <input type="submit" class="button tiny alert" value="Revert"/>
+                            </form>
+                        </dd>
+                    {% endif %}
+                </dl>
+            </div>
+        {% endfor %}
+    </div>
 {% endif %}

--- a/ynr/apps/candidates/templates/candidates/recent-changes.html
+++ b/ynr/apps/candidates/templates/candidates/recent-changes.html
@@ -105,7 +105,7 @@
         <td></td>
         <td colspan="6">
           <div class="diff-html">
-            <p>{{ action.diff_html|safe }}</p>
+            <p>{{ action.diff_html }}</p>
           </div>
         </td>
       </tr>

--- a/ynr/apps/candidates/views/people.py
+++ b/ynr/apps/candidates/views/people.py
@@ -34,7 +34,6 @@ from popolo.models import NotStandingValidationError
 
 from ynr.apps.people.merging import InvalidMergeError, PersonMerger
 
-from ..diffs import get_version_diffs
 from ..models import (
     TRUSTED_TO_MERGE_GROUP_NAME,
     Ballot,
@@ -100,6 +99,11 @@ class PersonView(TemplateView):
         context["redirect_after_login"] = quote(path)
         context["canonical_url"] = self.person.wcivf_url()
         context["person"] = self.person
+        context["actions"] = (
+            self.person.loggedaction_set.all()
+            .select_related("user")
+            .order_by("-created")
+        )
         context["other_names"] = self.person.other_names
         if not self.request.user.is_authenticated:
             context["other_names"] = context["other_names"].filter(
@@ -439,6 +443,11 @@ class UpdatePersonView(LoginRequiredMixin, ProcessInlineFormsMixin, UpdateView):
 
         person = self.object
         context["person"] = person
+        context["actions"] = (
+            person.loggedaction_set.all()
+            .select_related("user")
+            .order_by("-created")
+        )
 
         context["person_edits_allowed"] = person.user_can_edit(
             self.request.user
@@ -446,7 +455,6 @@ class UpdatePersonView(LoginRequiredMixin, ProcessInlineFormsMixin, UpdateView):
         context["current_locked_ballots"] = person.memberships.filter(
             ballot__election__current=True, ballot__candidates_locked=True
         )
-        context["versions"] = get_version_diffs(person.versions)
 
         return context
 

--- a/ynr/apps/people/models.py
+++ b/ynr/apps/people/models.py
@@ -24,7 +24,7 @@ from django.urls import reverse
 from django.utils import timezone
 from django.utils.functional import cached_property
 from django.utils.html import format_html
-from django.utils.safestring import SafeString
+from django.utils.safestring import SafeString, mark_safe
 from django_extensions.db.models import TimeStampedModel
 from people.helpers import person_names_equal
 from people.managers import (
@@ -661,7 +661,7 @@ class Person(TimeStampedModel, models.Model):
         )
         from people.helpers import squash_whitespace
 
-        return squash_whitespace("<dl>{}</dl>".format(rendered))
+        return mark_safe(squash_whitespace("<dl>{}</dl>".format(rendered)))
 
     def update_complex_field(self, location, new_value):
         existing_info_types = [location.info_type]

--- a/ynr/apps/people/models.py
+++ b/ynr/apps/people/models.py
@@ -640,17 +640,18 @@ class Person(TimeStampedModel, models.Model):
             versions = []
         return get_version_diffs(versions)
 
-    def diff_for_version(self, version_id, inline_style=False):
+    def version_dict(self, version_id):
         versions = self.versions or []
-        all_version_diffs = get_version_diffs(versions)
-        right_version_diff = None
-        for version_diff in all_version_diffs:
+        if not hasattr(self, "_version_diff_cache"):
+            self._version_diff_cache = get_version_diffs(versions)
+        for version_diff in self._version_diff_cache:
             if version_diff["version_id"] == version_id:
-                right_version_diff = version_diff
-                break
-        if not right_version_diff:
-            msg = "Couldn't find version {0} for person with ID {1}"
-            raise VersionNotFound(msg.format(version_id, self.id))
+                return version_diff
+        msg = "Couldn't find version {0} for person with ID {1}"
+        raise VersionNotFound(msg.format(version_id, self.id))
+
+    def diff_for_version(self, version_id, inline_style=False):
+        right_version_diff = self.version_dict(version_id)
         template = loader.get_template("candidates/_diffs_against_parents.html")
         rendered = template.render(
             {

--- a/ynr/apps/people/tests/test_revert.py
+++ b/ynr/apps/people/tests/test_revert.py
@@ -1,5 +1,7 @@
 from datetime import datetime
 
+from candidates.models import LoggedAction
+from candidates.models.db import ActionType, EditType
 from candidates.tests.auth import TestUserMixin
 from candidates.tests.factories import MembershipFactory
 from candidates.tests.uk_examples import UK2015ExamplesMixin
@@ -85,6 +87,24 @@ class TestRevertPersonView(TestUserMixin, UK2015ExamplesMixin, WebTest):
             },
         ]
 
+    def create_logged_actions_from_versions(self, person: Person):
+        """
+        A helper function to create logged actions from a pre-defined
+         version dict
+
+        :return:
+        """
+        for version in reversed(person.versions):
+            action = LoggedAction(
+                edit_type=EditType.USER,
+                action_type=ActionType.PERSON_UPDATE,
+                person=person,
+                popit_person_new_version=version["version_id"],
+                user=self.user,
+                created=version["timestamp"],
+            )
+            action.save(review_not_required=True)
+
     def setUp(self):
         super().setUp()
         person = PersonFactory.create(
@@ -92,6 +112,7 @@ class TestRevertPersonView(TestUserMixin, UK2015ExamplesMixin, WebTest):
             name="Tessa Jowell",
             versions=self.version_template(party_slug=self.labour_party.ec_id),
         )
+        self.create_logged_actions_from_versions(person)
         PersonIdentifier.objects.create(
             person=person, value="jowell@example.com", value_type="email"
         )

--- a/ynr/apps/wombles/templates/wombles/my_profile.html
+++ b/ynr/apps/wombles/templates/wombles/my_profile.html
@@ -32,7 +32,7 @@
 
                     </td>
                     <td>{{ recent_edit.created }}</td>
-                    <td>{{ recent_edit.diff_html|safe }}</td>
+                    <td>{{ recent_edit.diff_html }}</td>
                 </tr>
             {% endfor %}
             </tbody>


### PR DESCRIPTION
This change moves from showing a list of `Person.vesions` to showing `LoggedAction` for a person on the person update and view pages. 

I've done this because `Person.versions` is only written to when a person field is updated (e.g a name, email, or related `PersonIdentifier` and a few other things). If a womble uploads a new photo for a person, this isn't a 'version' so never used to show on the person's history. 



---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1215815059118506