### PR TITLE
Results button

### DIFF
--- a/ynr/apps/data_exports/csv_fields.py
+++ b/ynr/apps/data_exports/csv_fields.py
@@ -290,7 +290,7 @@ csv_fields["turnout_reported"] = CSVField(
     type="expr",
     value=F("ballot_paper__resultset__num_turnout_reported"),
     value_group="results",
-    label="Reported turnout",
+    label="Ballot papers issued",
 )
 csv_fields["spoilt_ballots"] = CSVField(
     type="expr",

--- a/ynr/apps/elections/templates/elections/ballot_view.html
+++ b/ynr/apps/elections/templates/elections/ballot_view.html
@@ -251,7 +251,7 @@
 
           {% include "elections/includes/_ballot_suggest_locking.html" %}
 
-          {% if user_can_record_results and has_any_winners %}
+          {% if not ballot.resultset.candidate_results.exists and user_can_record_results and has_any_winners %}
             <form action="{% url 'retract-winner' ballot_paper_id=ballot.ballot_paper_id %}" method="post">
               {% csrf_token %}
               <input type="submit" class="button alert small" value="Unset the current winners, if incorrect">

--- a/ynr/apps/elections/templates/elections/ballot_view.html
+++ b/ynr/apps/elections/templates/elections/ballot_view.html
@@ -275,26 +275,25 @@
    {# Only include these if the user can alter memberships #}
       {% include "elections/includes/_ballot_candidates_might_stand.html" %}
       {% include "elections/includes/_ballot_candidates_not_standing.html" %}
-
-
-      {% if user.is_authenticated and logged_actions %}
-        <h2 id="history">History for this ballot</h2>
-        {% for action in logged_actions %}
-          <div class="version">
-            <dl>
-              <dt>Description</dt>
-              <dd>{{ action.friendly_description }}</dd>
-              <dt>Timestamp</dt>
-              <dd>{{ action.created }}</dd>
-            </dl>
-          </div>
-        {% endfor %}
-      {% endif %}
-
     </div>
     <div class="columns large-3">
       {% include "uk/data_timeline.html" %}
     </div>
   </div>
+  {% if user.is_authenticated and logged_actions %}
+    <div class="row">
+      <h2 id="history">History for this ballot</h2>
+      {% for action in logged_actions %}
+        <div class="version">
+          <dl>
+            <dt>Description</dt>
+            <dd>{{ action.friendly_description }}</dd>
+            <dt>Timestamp</dt>
+            <dd>{{ action.created }}</dd>
+          </dl>
+        </div>
+      {% endfor %}
+    </div>
+  {% endif %}
 
 {% endblock %}

--- a/ynr/apps/elections/templates/elections/ballot_view.html
+++ b/ynr/apps/elections/templates/elections/ballot_view.html
@@ -258,6 +258,12 @@
             </form>
           {% endif %}
 
+          {% if ballot.has_results and ballot.resultset %}
+            <a class="button small" href="{% url "ballot_paper_results_form" ballot.ballot_paper_id %}">Edit results</a>
+          {% else %}
+            <a class="button small" href="{% url "ballot_paper_results_form" ballot.ballot_paper_id %}">Add results</a>
+          {% endif %}
+
           {% if has_missing_list_positions %}
             <p>Some candidates on this party list ballot are missing list positions. Can you add them?</p>
           {% endif %}

--- a/ynr/apps/elections/templates/elections/ballot_view.html
+++ b/ynr/apps/elections/templates/elections/ballot_view.html
@@ -275,9 +275,14 @@
    {# Only include these if the user can alter memberships #}
       {% include "elections/includes/_ballot_candidates_might_stand.html" %}
       {% include "elections/includes/_ballot_candidates_not_standing.html" %}
-
-
-      {% if user.is_authenticated and logged_actions %}
+    </div>
+    <div class="columns large-3">
+      {% include "uk/data_timeline.html" %}
+    </div>
+  </div>
+  {% if user.is_authenticated and logged_actions %}
+    <div class="row">
+      <div class="column">
         <h2 id="history">History for this ballot</h2>
         {% for action in logged_actions %}
           <div class="version">
@@ -289,12 +294,8 @@
             </dl>
           </div>
         {% endfor %}
-      {% endif %}
-
+      </div>
     </div>
-    <div class="columns large-3">
-      {% include "uk/data_timeline.html" %}
-    </div>
-  </div>
+  {% endif %}
 
 {% endblock %}

--- a/ynr/apps/elections/templates/elections/ballot_view.html
+++ b/ynr/apps/elections/templates/elections/ballot_view.html
@@ -270,6 +270,9 @@
 
       {% if ballot.has_results and ballot.resultset %}
         {% include "elections/includes/_ballot_results_table.html" with results=ballot.resultset %}
+        <a class="button small" href="{% url "ballot_paper_results_form" ballot.ballot_paper_id %}">Edit results</a>
+      {% else %}
+        <a class="button small" href="{% url "ballot_paper_results_form" ballot.ballot_paper_id %}">Add results</a>
       {% endif %}
 
    {# Only include these if the user can alter memberships #}

--- a/ynr/apps/elections/templates/elections/includes/_ballot_results_table.html
+++ b/ynr/apps/elections/templates/elections/includes/_ballot_results_table.html
@@ -7,7 +7,7 @@
         </thead>
         <tbody>
             <tr>
-                <td>Reported Turnout</td>
+                <td>Ballot papers issued</td>
                 <td>{{ results.num_turnout_reported|default_if_none:"Unknown" }}</td>
             </tr>
             <tr>


### PR DESCRIPTION
This PR makes a few changes/fixes that Peter requested:
- It removes the unset winners button when we have votes cast for a ballot
- It adds an add/edit results button to area at the bottom of the ballot
- It changes "reported turnout" in the frontend to "ballot papers issued" to match WCIVF
- It reorders the layout of the ballot detail view for small screens so that the data timeline appears after the ballot and results summary rather than the ballot history.

Here is a comparison between the web view and the dev tools small screen view:
<img width="1072" height="664" alt="ynrpr" src="https://github.com/user-attachments/assets/ee2b3214-1409-44af-b8b7-b4e12f0aaa7b" />


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1216205220037504