### PR TITLE
remove uk-election-timetables library

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,6 @@ dependencies = [
     "djangorestframework-csv==3.0.2",
     "djangorestframework==3.16.1",
     "drf-yasg==1.21.11",
-    "uk-election-timetables==5.0.0",
     "uk-election-ids==0.10.1",
     "gender-detector==0.1.0",
     "gunicorn==23.0.0",

--- a/uv.lock
+++ b/uv.lock
@@ -1903,15 +1903,6 @@ wheels = [
 ]
 
 [[package]]
-name = "uk-election-timetables"
-version = "5.0.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/33/06/34e1ad5f782b6e72f56d3d950d7f364dfe1554362aff7d218f494218ff7f/uk_election_timetables-5.0.0.tar.gz", hash = "sha256:f6d6db174d9e0fcc9a29a8167047530b6d7b93a27af4958c0195fa293e307fba", size = 20743, upload-time = "2026-07-08T08:14:15.173Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/52/8a/1220516bc7c3fe46b5dce6d7a8b67bf601e3c5d1757a9e66a2f804b8ba41/uk_election_timetables-5.0.0-py3-none-any.whl", hash = "sha256:3f85d746b7778bb8b901b1cce0dd92b16592d5fe5a3f7ce2c5c6ebd2ceb71d28", size = 23120, upload-time = "2026-07-08T08:14:14.084Z" },
-]
-
-[[package]]
 name = "uritemplate"
 version = "4.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2121,7 +2112,6 @@ dependencies = [
     { name = "sorl-thumbnail" },
     { name = "sorl-thumbnail-serializer-field" },
     { name = "uk-election-ids" },
-    { name = "uk-election-timetables" },
     { name = "whitenoise" },
     { name = "wreq" },
 ]
@@ -2207,7 +2197,6 @@ requires-dist = [
     { name = "sorl-thumbnail", specifier = "==12.11.0" },
     { name = "sorl-thumbnail-serializer-field", git = "https://github.com/dessibelle/sorl-thumbnail-serializer-field.git?tag=0.2" },
     { name = "uk-election-ids", specifier = "==0.10.1" },
-    { name = "uk-election-timetables", specifier = "==5.0.0" },
     { name = "whitenoise", specifier = "==6.5.0" },
     { name = "wreq", specifier = "==0.10.2" },
 ]

--- a/ynr/apps/candidates/migrations/0096_backfill_ballot_timetable_fields.py
+++ b/ynr/apps/candidates/migrations/0096_backfill_ballot_timetable_fields.py
@@ -1,58 +1,4 @@
 from django.db import migrations
-from uk_election_timetables.calendars import Country
-from uk_election_timetables.election_ids import (
-    InvalidElectionIdError,
-    from_election_id,
-)
-
-country_map = {
-    "WLS": Country.WALES,
-    "ENG": Country.ENGLAND,
-    "NIR": Country.NORTHERN_IRELAND,
-    "SCT": Country.SCOTLAND,
-}
-
-
-def backfill_timetable_fields(apps, schema_editor):
-    Ballot = apps.get_model("candidates", "Ballot")
-
-    qs = (
-        Ballot.objects.using(schema_editor.connection.alias)
-        # We don't have logic for computing timetable for
-        # EU Parliament elections but some do exist in the DB
-        # from back in the day
-        .exclude(ballot_paper_id__startswith="europarl.")
-    )
-    ballots_to_update = []
-
-    for ballot in qs.iterator():
-        try:
-            timetable = from_election_id(
-                ballot.ballot_paper_id,
-                country=country_map[ballot.post.territory_code],
-            )
-        except InvalidElectionIdError:
-            # Some really old elections in YNR don't have a EE ballot ID
-            continue
-
-        ballot.close_of_nominations = timetable.close_of_nominations
-        ballot.sopn_publish_deadline = timetable.sopn_publish_deadline
-        ballots_to_update.append(ballot)
-
-    batch_size = 2000
-    for i in range(0, len(ballots_to_update), batch_size):
-        qs.bulk_update(
-            ballots_to_update[i : i + batch_size],
-            ["close_of_nominations", "sopn_publish_deadline"],
-        )
-
-
-def clear_timetable_fields(apps, schema_editor):
-    Ballot = apps.get_model("candidates", "Ballot")
-    Ballot.objects.using(schema_editor.connection.alias).update(
-        close_of_nominations=None,
-        sopn_publish_deadline=None,
-    )
 
 
 class Migration(migrations.Migration):
@@ -61,5 +7,7 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
-        migrations.RunPython(backfill_timetable_fields, clear_timetable_fields)
+        migrations.RunPython(
+            migrations.RunPython.noop, migrations.RunPython.noop
+        )
     ]


### PR DESCRIPTION
~:warning: This PR targets `timetables20260713` not `master` :warning:~

This follow on from https://github.com/DemocracyClub/yournextrepresentative/pull/2780
After we've applied the data backfill in all the environments we care about, we can then remove the timetables lib from this repo