### PR TITLE
allow the same duplicate/merge to be suggested multiple times

### DIFF
--- a/ynr/apps/candidates/tests/test_duplicate_suggestion_view.py
+++ b/ynr/apps/candidates/tests/test_duplicate_suggestion_view.py
@@ -151,7 +151,10 @@ class TestDuplicatePersonViewIntegrationTests(TestUserMixin, WebTest, TestCase):
         url = f"{url}?other_person={self.other_person.pk}"
         response = self.app.get(url, user=self.user)
 
-        self.assertContains(
-            response,
-            "A suggestion between these two people has already been checked and rejected as not duplicate",
-        )
+        # submit the suggestion form and expect object to be created
+        suggestion_form = response.forms[SUGGESTION_FORM_ID]
+        response = suggestion_form.submit()
+
+        # we're allowed to suggest the same person again
+        # if the first one was rejected
+        assert DuplicateSuggestion.objects.count() == 2

--- a/ynr/apps/candidates/views/people.py
+++ b/ynr/apps/candidates/views/people.py
@@ -21,6 +21,7 @@ from django.views.decorators.cache import cache_control
 from django.views.generic import FormView, TemplateView, UpdateView, View
 from django.views.generic.detail import DetailView
 from duplicates.forms import DuplicateSuggestionForm
+from duplicates.helpers import get_previous_rejections
 from elections.mixins import ElectionMixin
 from elections.models import Election
 from elections.uk.forms import SelectBallotForm
@@ -287,6 +288,19 @@ class DuplicatePersonView(LoginRequiredMixin, FormView, DetailView):
         context["user_can_merge"] = user_in_group(
             self.request.user, TRUSTED_TO_MERGE_GROUP_NAME
         )
+        raw_other_id = self.request.GET.get(
+            "other_person"
+        ) or self.request.POST.get("other_person")
+        try:
+            other_person_id = int(raw_other_id)
+        except (TypeError, ValueError):
+            context["previous_rejections"] = []
+            return context
+
+        p1_id, p2_id = sorted([self.object.pk, other_person_id])
+        rejections_map = get_previous_rejections([(p1_id, p2_id)])
+        context["previous_rejections"] = rejections_map.get((p1_id, p2_id), [])
+
         return context
 
 

--- a/ynr/apps/duplicates/forms.py
+++ b/ynr/apps/duplicates/forms.py
@@ -33,25 +33,19 @@ class DuplicateSuggestionForm(forms.ModelForm):
             msg = f"You can't suggest a duplicate person ({self.instance.person.pk}) with themself ({other_person.pk})"
             self.add_error(field="other_person", error=msg)
 
-        existing_suggestion = DuplicateSuggestion.objects.for_both_people(
-            person=self.instance.person, other_person=other_person
-        ).first()
+        existing_suggestion = (
+            DuplicateSuggestion.objects.for_both_people(
+                person=self.instance.person, other_person=other_person
+            )
+            .open()
+            .first()
+        )
         if not existing_suggestion:
             return cleaned_data
 
-        if existing_suggestion.open:
-            raise ValidationError(
-                "A suggestion between these people is already open"
-            )
-
-        if existing_suggestion.rejected:
-            msg = (
-                "A suggestion between these two people has already been "
-                "checked and rejected as not duplicate because: "
-                f"{existing_suggestion.rejection_reasoning}"
-            )
-            raise ValidationError(msg)
-        return None
+        raise ValidationError(
+            "A suggestion between these people is already open"
+        )
 
 
 class RejectionForm(forms.ModelForm):

--- a/ynr/apps/duplicates/helpers.py
+++ b/ynr/apps/duplicates/helpers.py
@@ -1,0 +1,33 @@
+from django.db.models import Q
+from duplicates.models import DuplicateSuggestion
+
+
+def get_previous_rejections(pairs):
+    """
+    Given a list of (person_id, other_person_id) tuples
+    (where person_id is always the lower of the two IDs)
+    returns a dict mapping each tuple to a
+    list of rejected DuplicateSuggestion instances,
+    ordered by modification date.
+    """
+    if not pairs:
+        return {}
+
+    pairs_q = Q()
+    for person_id, other_person_id in pairs:
+        pairs_q |= Q(person_id=person_id, other_person_id=other_person_id)
+
+    rejections = (
+        DuplicateSuggestion.objects.rejected()
+        .filter(pairs_q)
+        .select_related("user")
+        .order_by("modified")
+    )
+
+    result = {pair: [] for pair in pairs}
+    for rejection in rejections:
+        key = (rejection.person_id, rejection.other_person_id)
+        if key in result:
+            result[key].append(rejection)
+
+    return result

--- a/ynr/apps/duplicates/migrations/0005_remove_duplicatesuggestion_unique_together.py
+++ b/ynr/apps/duplicates/migrations/0005_remove_duplicatesuggestion_unique_together.py
@@ -1,0 +1,14 @@
+from django.db import migrations
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("duplicates", "0004_alter_duplicatesuggestion_status"),
+    ]
+
+    operations = [
+        migrations.AlterUniqueTogether(
+            name="duplicatesuggestion",
+            unique_together=set(),
+        ),
+    ]

--- a/ynr/apps/duplicates/models.py
+++ b/ynr/apps/duplicates/models.py
@@ -81,9 +81,6 @@ class DuplicateSuggestion(StatusModel, TimeStampedModel):
 
     objects = DuplicateSuggestionQuerySet.as_manager()
 
-    class Meta:
-        unique_together = ("person", "other_person")
-
     def save(self, **kwargs):
         """
         Force the order of the IDs, making self.person always

--- a/ynr/apps/duplicates/templates/duplicates/duplicate_suggestion.html
+++ b/ynr/apps/duplicates/templates/duplicates/duplicate_suggestion.html
@@ -27,7 +27,7 @@
         is a duplicate of
         <strong><a href="{{ other_person.get_absolute_url }}">{{ other_person.name }}</a></strong>.
       </p>
-      {% include "duplicates/includes/_compare_people_table.html" with person=person other_person=other_person %}
+      {% include "duplicates/includes/_compare_people_table.html" with person=person other_person=other_person previous_rejections=previous_rejections %}
     {% endwith %}
 
     <p>Would you like to proceed?</p>

--- a/ynr/apps/duplicates/templates/duplicates/duplicatesuggestion_list.html
+++ b/ynr/apps/duplicates/templates/duplicates/duplicatesuggestion_list.html
@@ -10,7 +10,7 @@
       <a href="{{ object.person.get_absolute_url }}">{{ object.person }}</a> is a duplicate of
       <a href="{{ object.other_person.get_absolute_url }}">{{ object.other_person }}</a>.
     </p>
-    {% include "duplicates/includes/_compare_people_table.html" with person=object.person other_person=object.other_person  show_review_actions=True %}
+    {% include "duplicates/includes/_compare_people_table.html" with person=object.person other_person=object.other_person show_review_actions=True previous_rejections=object.previous_rejections %}
   {% empty %}
     <p>There are no duplicate suggestions to review at this time.</p>
   {% endfor %}

--- a/ynr/apps/duplicates/templates/duplicates/includes/_compare_people_table.html
+++ b/ynr/apps/duplicates/templates/duplicates/includes/_compare_people_table.html
@@ -1,3 +1,13 @@
+{% if previous_rejections %}
+  <div>
+    <p><strong>This pair has been rejected {{ previous_rejections|length }} time{{ previous_rejections|length|pluralize }} previously.</strong></p>
+    <ul>
+      {% for rejection in previous_rejections %}
+        <li>Rejected on {{ rejection.modified|date:"j F Y" }} by {{ rejection.user }}{% if rejection.rejection_reasoning %}: {{ rejection.rejection_reasoning }}{% endif %}</li>
+      {% endfor %}
+    </ul>
+  </div>
+{% endif %}
 <table class="table">
   <thead>
     <tr>

--- a/ynr/apps/duplicates/tests/test_duplicate_helpers.py
+++ b/ynr/apps/duplicates/tests/test_duplicate_helpers.py
@@ -1,0 +1,74 @@
+from candidates.tests.auth import TestUserMixin
+from django.test import TestCase
+from duplicates.helpers import get_previous_rejections
+from duplicates.models import DuplicateSuggestion
+from people.tests.factories import PersonFactory
+
+
+class TestGetPreviousRejections(TestUserMixin, TestCase):
+    def setUp(self):
+        # Sort by pk so p1.pk < p2.pk < p3.pk is guaranteed throughout.
+        self.p1, self.p2, self.p3 = sorted(
+            PersonFactory.create_batch(3), key=lambda p: p.pk
+        )
+
+    def _make_rejection(self, person, other_person, reasoning=""):
+        return DuplicateSuggestion.objects.create(
+            person=person,
+            other_person=other_person,
+            user=self.user,
+            status=DuplicateSuggestion.STATUS.not_duplicate,
+            rejection_reasoning=reasoning,
+        )
+
+    def test_empty_pairs_returns_empty_dict(self):
+        result = get_previous_rejections([])
+        self.assertEqual(result, {})
+
+    def test_pair_with_no_rejections_returns_empty_list(self):
+        result = get_previous_rejections([(self.p1.pk, self.p2.pk)])
+        self.assertEqual(result[(self.p1.pk, self.p2.pk)], [])
+
+    def test_single_rejection_is_returned(self):
+        rejection = self._make_rejection(self.p1, self.p2)
+        result = get_previous_rejections([(self.p1.pk, self.p2.pk)])
+        self.assertEqual(result[(self.p1.pk, self.p2.pk)], [rejection])
+
+    def test_open_suggestions_are_excluded(self):
+        DuplicateSuggestion.objects.create(
+            person=self.p1, other_person=self.p2, user=self.user
+        )
+        result = get_previous_rejections([(self.p1.pk, self.p2.pk)])
+        self.assertEqual(result[(self.p1.pk, self.p2.pk)], [])
+
+    def test_multiple_rejections_all_returned(self):
+        r1 = self._make_rejection(self.p1, self.p2, "first reason")
+        r2 = self._make_rejection(self.p1, self.p2, "second reason")
+        result = get_previous_rejections([(self.p1.pk, self.p2.pk)])
+        self.assertCountEqual(result[(self.p1.pk, self.p2.pk)], [r1, r2])
+
+    def test_pairs_work_with_low_id_first(self):
+        rejection = self._make_rejection(self.p1, self.p2)
+        result = get_previous_rejections([(self.p1.pk, self.p2.pk)])
+        self.assertEqual(result[(self.p1.pk, self.p2.pk)], [rejection])
+
+    def test_multiple_pairs_rejections_correctly_separated(self):
+        r12 = self._make_rejection(self.p1, self.p2)
+        r13 = self._make_rejection(self.p1, self.p3)
+        result = get_previous_rejections(
+            [(self.p1.pk, self.p2.pk), (self.p1.pk, self.p3.pk)]
+        )
+        self.assertEqual(result[(self.p1.pk, self.p2.pk)], [r12])
+        self.assertEqual(result[(self.p1.pk, self.p3.pk)], [r13])
+
+    def test_rejections_for_other_pairs_not_included(self):
+        self._make_rejection(self.p1, self.p3)
+        result = get_previous_rejections([(self.p1.pk, self.p2.pk)])
+        self.assertEqual(result[(self.p1.pk, self.p2.pk)], [])
+
+    def test_pairs_with_high_id_first(self):
+        # p2.pk > p1.pk - the pair is passed reversed relative to DB storage
+        # It is expected that this will not match anything
+        self._make_rejection(self.p1, self.p2)
+        result = get_previous_rejections([(self.p2.pk, self.p1.pk)])
+        self.assertEqual(result[(self.p2.pk, self.p1.pk)], [])

--- a/ynr/apps/duplicates/tests/test_models.py
+++ b/ynr/apps/duplicates/tests/test_models.py
@@ -1,5 +1,4 @@
 from candidates.tests.auth import TestUserMixin
-from django.db import IntegrityError
 from django.test import TestCase
 from duplicates.models import DuplicateSuggestion
 from people.tests.factories import PersonFactory
@@ -44,24 +43,6 @@ class TestDuplicateSuggestion(TestUserMixin, TestCase):
                 self.person_2, self.person_1
             )
         )
-
-    def test_not_duplicate_duplicates_create_method(self):
-        """
-        Make sure we can't make a duplicate duplicate suggestion using create()
-        """
-        DuplicateSuggestion.objects.create(
-            person=self.person_1,
-            other_person=self.person_2,
-            user=self.user,
-            status=DuplicateSuggestion.STATUS.not_duplicate,
-        )
-        with self.assertRaises(IntegrityError):
-            DuplicateSuggestion.objects.create(
-                person=self.person_2,
-                other_person=self.person_1,
-                user=self.user,
-                status=DuplicateSuggestion.STATUS.not_duplicate,
-            )
 
     def test_not_duplicate_duplicates_upsert(self):
         DuplicateSuggestion.objects.create(

--- a/ynr/apps/duplicates/views.py
+++ b/ynr/apps/duplicates/views.py
@@ -7,6 +7,7 @@ from django.views.generic import ListView, UpdateView
 from popolo.models import Membership
 
 from .forms import RejectionForm
+from .helpers import get_previous_rejections
 from .models import DuplicateSuggestion
 
 
@@ -35,6 +36,20 @@ class DuplicateSuggestionListView(GroupRequiredMixin, ListView):
                 "other_person__other_names",
             )
         )
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        object_list = context["object_list"]
+
+        pairs = [(obj.person_id, obj.other_person_id) for obj in object_list]
+        rejection_map = get_previous_rejections(pairs)
+
+        for obj in object_list:
+            obj.previous_rejections = rejection_map.get(
+                (obj.person_id, obj.other_person_id), []
+            )
+
+        return context
 
 
 class RejectSuggestion(GroupRequiredMixin, UpdateView):


### PR DESCRIPTION
Refs https://app.asana.com/1/1204880536137786/project/1204880927741389/task/1214041815638938?focus=true

This PR:

- Allows more than one `DuplicateSuggestion` for the same pair of people. You still can't have a duplicate if one is open
- Surfaces any previous rejections in the DuplicatePersonView (suggest a duplicate) and DuplicateSuggestionListView (review duplicates)
- Update + add tests

Example output:

<img width="1002" height="682" alt="Screenshot at 2026-07-16 10-32-10" src="https://github.com/user-attachments/assets/c163382e-1c91-40b7-be2f-b6a38c72c7e7" />

This PR is mostly Claude with a bit of my own guidance/judgement/review.