### PR TITLE
prefer person over ballot when constructing subject_url

### DIFF
--- a/ynr/apps/candidates/models/db.py
+++ b/ynr/apps/candidates/models/db.py
@@ -182,11 +182,11 @@ class LoggedAction(models.Model):
 
     @property
     def subject_url(self):
+        if self.person:
+            return reverse("person-view", kwargs={"person_id": self.person.id})
         ballot = self.ballot
         if ballot:
             return ballot.get_absolute_url()
-        if self.person:
-            return reverse("person-view", kwargs={"person_id": self.person.id})
         return "/"
 
     @property


### PR DESCRIPTION
Closes https://github.com/DemocracyClub/yournextrepresentative/issues/2783
Closes https://github.com/DemocracyClub/yournextrepresentative/issues/2786

I can't quite put my finger on where this happened, but I think one of the changes we made recently-ish means that we now create `LoggedAction`s that have both a `ballot` and a `person` on them, where the equivalent actions used to have a `person` but not a `ballot` attached to them.