### PR TITLE
Bump ruff to 0.15.22 and repair the lint gate

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 repos:
 - repo: https://github.com/charliermarsh/ruff-pre-commit
   # Ruff version.
-  rev: 'v0.2.2'
+  rev: 'v0.15.22'
   hooks:
     - id: ruff
       args: [--fix, --exit-non-zero-on-fix, --extend-exclude, TCH]

--- a/cdk/app.py
+++ b/cdk/app.py
@@ -22,9 +22,9 @@ app = cdk.App(context=app_wide_context)
 # Set the DC Environment early on. This is important to be able to conditionally
 # change the stack configurations
 dc_environment = app.node.try_get_context("dc-environment") or None
-assert (
-    dc_environment in valid_environments
-), f"context `dc-environment` must be one of {valid_environments}"
+assert dc_environment in valid_environments, (
+    f"context `dc-environment` must be one of {valid_environments}"
+)
 
 
 YnrStack(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,7 +86,7 @@ dev = [
     "pytest-django==4.5.2",
     "pytest-freezegun==0.4.2",
     "pytest-ruff==0.2.1",
-    "ruff==0.2.2",
+    "ruff==0.15.22",
     "watchdog==4.0.2",
     "WebTest==3.0.0",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -85,7 +85,7 @@ dev = [
     "pytest-cov==4.0.0",
     "pytest-django==4.5.2",
     "pytest-freezegun==0.4.2",
-    "pytest-ruff==0.2.1",
+    "pytest-ruff==0.5",
     "ruff==0.15.22",
     "watchdog==4.0.2",
     "WebTest==3.0.0",

--- a/uv.lock
+++ b/uv.lock
@@ -947,7 +947,7 @@ name = "jinxed"
 version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "ansicon", marker = "sys_platform == 'win32'" },
+    { name = "ansicon" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/20/d0/59b2b80e7a52d255f9e0ad040d2e826342d05580c4b1d7d7747cfb8db731/jinxed-1.3.0.tar.gz", hash = "sha256:1593124b18a41b7a3da3b078471442e51dbad3d77b4d4f2b0c26ab6f7d660dbf", size = 80981, upload-time = "2024-07-31T22:39:18.854Z" }
 wheels = [
@@ -1286,7 +1286,7 @@ name = "pexpect"
 version = "4.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "ptyprocess", marker = "sys_platform != 'win32'" },
+    { name = "ptyprocess" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/42/92/cc564bf6381ff43ce1f4d06852fc19a2f11d180f23dc32d9588bee2f149d/pexpect-4.9.0.tar.gz", hash = "sha256:ee7d41123f3c9911050ea2c2dac107568dc43b2d3b0c7557a33212c398ead30f", size = 166450, upload-time = "2023-11-25T09:07:26.339Z" }
 wheels = [
@@ -1677,26 +1677,27 @@ wheels = [
 
 [[package]]
 name = "ruff"
-version = "0.2.2"
+version = "0.15.22"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/70/06/b2e9ee5f17dab59476fcb6cc6fdd268e8340d95b7dfc760ed93f4243f16f/ruff-0.2.2.tar.gz", hash = "sha256:e62ed7f36b3068a30ba39193a14274cd706bc486fad521276458022f7bccb31d", size = 2040633, upload-time = "2024-02-17T22:36:38.19Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3a/06/ae069393fc66e8ff33036d4b368003833bf6e88ccf182e17e7a2f1c754fd/ruff-0.15.22.tar.gz", hash = "sha256:3f15175b1fb580126f58285a5dae6b2ea89000136d980c64499211f116b54809", size = 4785063, upload-time = "2026-07-16T15:14:13.244Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/13/21/e56126ca3b56e6d05a0f6744558305f6589327945ee01b85ffe85a0f37bf/ruff-0.2.2-py3-none-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:0a9efb032855ffb3c21f6405751d5e147b0c6b631e3ca3f6b20f917572b97eb6", size = 14894866, upload-time = "2024-02-17T22:35:45.715Z" },
-    { url = "https://files.pythonhosted.org/packages/b6/1e/fd238f116e2fab69a2fbb4c3ab8903225836cb6d900ff8139c03c2f6f7b7/ruff-0.2.2-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:d450b7fbff85913f866a5384d8912710936e2b96da74541c82c1b458472ddb39", size = 7634941, upload-time = "2024-02-17T22:35:51.518Z" },
-    { url = "https://files.pythonhosted.org/packages/4c/53/30651b54241f4f26796cbc5b7cdcafebf5ecd7a30997e7a08673e8050b30/ruff-0.2.2-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ecd46e3106850a5c26aee114e562c329f9a1fbe9e4821b008c4404f64ff9ce73", size = 7332185, upload-time = "2024-02-17T22:35:55.053Z" },
-    { url = "https://files.pythonhosted.org/packages/1c/8a/8c14e40da4cb8d651fc78f769e938552069e7bc34e9e65f7335f3469f9d2/ruff-0.2.2-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:5e22676a5b875bd72acd3d11d5fa9075d3a5f53b877fe7b4793e4673499318ba", size = 6739587, upload-time = "2024-02-17T22:35:57.465Z" },
-    { url = "https://files.pythonhosted.org/packages/db/71/5be31e5505307e852020d624049ae6610e1ebb68431bb03251904aa082c6/ruff-0.2.2-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1695700d1e25a99d28f7a1636d85bafcc5030bba9d0578c0781ba1790dbcf51c", size = 7813597, upload-time = "2024-02-17T22:36:00.015Z" },
-    { url = "https://files.pythonhosted.org/packages/45/20/89df4f35f0644b529b9e8bb4c9a0a4633ad2fcba888941caaba744ae5768/ruff-0.2.2-py3-none-manylinux_2_17_ppc64.manylinux2014_ppc64.whl", hash = "sha256:b0c232af3d0bd8f521806223723456ffebf8e323bd1e4e82b0befb20ba18388e", size = 8465022, upload-time = "2024-02-17T22:36:03.46Z" },
-    { url = "https://files.pythonhosted.org/packages/ec/c2/d2f2b750971593580b29d965bd7bc36a7f5e971b3de24e342235ae7578a9/ruff-0.2.2-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f63d96494eeec2fc70d909393bcd76c69f35334cdbd9e20d089fb3f0640216ca", size = 8196736, upload-time = "2024-02-17T22:36:07.188Z" },
-    { url = "https://files.pythonhosted.org/packages/bc/83/0dfcc589d8d4d27c551dfb5d50ef57b58fc6432298bc115010f7a0642f48/ruff-0.2.2-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:6a61ea0ff048e06de273b2e45bd72629f470f5da8f71daf09fe481278b175001", size = 8896228, upload-time = "2024-02-17T22:36:10.642Z" },
-    { url = "https://files.pythonhosted.org/packages/27/f1/3bf230a048561fd03bc779f2a3e5b05d8ea8cb1c91456a4246c5673b8ef5/ruff-0.2.2-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5e1439c8f407e4f356470e54cdecdca1bd5439a0673792dbe34a2b0a551a2fe3", size = 7817875, upload-time = "2024-02-17T22:36:15.006Z" },
-    { url = "https://files.pythonhosted.org/packages/63/ad/57e10d775d94a22eabdbe272d6ebb687d10ff0312ad8cd81dbc3bdf74081/ruff-0.2.2-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:940de32dc8853eba0f67f7198b3e79bc6ba95c2edbfdfac2144c8235114d6726", size = 7248228, upload-time = "2024-02-17T22:36:17.976Z" },
-    { url = "https://files.pythonhosted.org/packages/1d/65/250a8dd655563a31d7f38af35e5a2860a54bc66c121084f36c63d46dd687/ruff-0.2.2-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:0c126da55c38dd917621552ab430213bdb3273bb10ddb67bc4b761989210eb6e", size = 6735053, upload-time = "2024-02-17T22:36:20.94Z" },
-    { url = "https://files.pythonhosted.org/packages/ac/e5/6684718861b205985164afb9a1a8ab83deb4fa2326c903570e9d1af9347a/ruff-0.2.2-py3-none-musllinux_1_2_i686.whl", hash = "sha256:3b65494f7e4bed2e74110dac1f0d17dc8e1f42faaa784e7c58a98e335ec83d7e", size = 7471896, upload-time = "2024-02-17T22:36:23.793Z" },
-    { url = "https://files.pythonhosted.org/packages/4c/40/25de7bd89d5af3cd033d42935c7ea2bc79f52fa2f2cf4cbd8f1dbc2cae2b/ruff-0.2.2-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:1ec49be4fe6ddac0503833f3ed8930528e26d1e60ad35c2446da372d16651ce9", size = 7883633, upload-time = "2024-02-17T22:36:26.637Z" },
-    { url = "https://files.pythonhosted.org/packages/49/98/9c678bd07561bcdf2129df8284b5708e0393e7c52256db9b30b1b1043cfd/ruff-0.2.2-py3-none-win32.whl", hash = "sha256:d920499b576f6c68295bc04e7b17b6544d9d05f196bb3aac4358792ef6f34325", size = 6909240, upload-time = "2024-02-17T22:36:29.721Z" },
-    { url = "https://files.pythonhosted.org/packages/47/d2/23fe9d73dadec045cbffc0c2046a34f7b829f217abd76fb2d6ef7114d792/ruff-0.2.2-py3-none-win_amd64.whl", hash = "sha256:cc9a91ae137d687f43a44c900e5d95e9617cb37d4c989e462980ba27039d239d", size = 7593466, upload-time = "2024-02-17T22:36:32.51Z" },
-    { url = "https://files.pythonhosted.org/packages/1a/83/0d002e72ba3c15a74e5ac63d31f57d222d8f297e637d065db28f1253f109/ruff-0.2.2-py3-none-win_arm64.whl", hash = "sha256:c9d15fc41e6054bfc7200478720570078f0b41c9ae4f010bcc16bd6f4d1aacdd", size = 7222811, upload-time = "2024-02-17T22:36:35.499Z" },
+    { url = "https://files.pythonhosted.org/packages/23/18/ee54b7ae1e121be7a28ea6da4b67564ebb0530e183a54415ab7e3bcd2c4e/ruff-0.15.22-py3-none-linux_armv6l.whl", hash = "sha256:44423e73493737f5e7c5b41d475483898ff37afcdae38bc3da5085e29af1c2d8", size = 10781258, upload-time = "2026-07-16T15:13:19.452Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/d2/2520cb14761ddbeaf57642a76942fc36adcbdbe53b4532241995f6fc485c/ruff-0.15.22-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:b82c6482946e9eda7ff2e091d25b8bad3f718684e1916d41bd56873cee05b697", size = 10999477, upload-time = "2026-07-16T15:13:23.318Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/10/74e53572aa758dfaa678c2a2646b5c5515d884b7ca56be4d2ce03ca4b560/ruff-0.15.22-py3-none-macosx_11_0_arm64.whl", hash = "sha256:11c1c715af53a09f714e011106bffc419751ec8232fcb5da42173284ea3fec6f", size = 10466716, upload-time = "2026-07-16T15:13:26.162Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/cc/44eaaf0844e028182f2d0a8f2190d0f359159aed0a9e5ab861d892f1ae2a/ruff-0.15.22-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:742a29cf29bddb7c8327895d6a10e0e6c5b38a96dd407af9b5d0857f809c0576", size = 10892644, upload-time = "2026-07-16T15:13:29.229Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/21/8edf559014d2b0f82beea19cfb713993ad802ccda16868769979c6090a84/ruff-0.15.22-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:72af58b951b0ae395935ae79763dc349bc0eb706319d28f7a33ad2cfb3cfc178", size = 10576719, upload-time = "2026-07-16T15:13:32.35Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/1e/3a13abd392a3b50b62e5938a831f9ab6e588358cacad5c18545b716d2182/ruff-0.15.22-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:62d425005c1835eb24e2ee4161cb90e8db263415f4a71c8c72c33abaa6c0c224", size = 11376494, upload-time = "2026-07-16T15:13:35.958Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/3e/422d3d95bcf04dd78e1aeac22184d4f9a8fb2c01865d39d44618484a0317/ruff-0.15.22-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e8b9b3f8779a4f08c969defc3c8c35abffaa757e601ed5ae66d6d1db6519969a", size = 12208370, upload-time = "2026-07-16T15:13:39.185Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/91/5d065a0e0a02bf4813f5119ad278462eed081d2b832eb7c021ade0ec9e65/ruff-0.15.22-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:1e0dd1b2e4d3d585f897a0d137cbf4eaf6223bef4e8ce34d6bb12556c5f9249e", size = 11581098, upload-time = "2026-07-16T15:13:42.132Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/f9/a0d4871d12fae702eb1f41b686caf05f1f8b124dc6db6f784f53d74918fa/ruff-0.15.22-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:365523eb91d9224e1bcb03b022fbf0facb8f9e23792a2c53d9d4b3924bdbdebb", size = 11399422, upload-time = "2026-07-16T15:13:45.2Z" },
+    { url = "https://files.pythonhosted.org/packages/18/80/c843a5176cddbceb0b7e8dd41cf9993490796c1c469348d384f5a5c13c56/ruff-0.15.22-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:fabfd168afdf29fee5be98b831efa9683c94d7c5a3b58b9ce5a2e38444589a74", size = 11381683, upload-time = "2026-07-16T15:13:48.46Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/00/8485de0ae92239438a36cfc51350db9b9e85c9ebdfaea91b18e422706662/ruff-0.15.22-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:225dbf095a87f1d9f90f5fd7924d2613ee452a75a4308c63a8f50f761787aa7c", size = 10850295, upload-time = "2026-07-16T15:13:51.655Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/91/24977ec2ec72eaf15e4394ace2959fdff2dd1e14f03e005e838023407169/ruff-0.15.22-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:1877d63b9d24ed278744f1523fd11b85540566d54641f97c566d7d9dc5ca5296", size = 10579640, upload-time = "2026-07-16T15:13:54.79Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/47/9b51216951974df1f263ac19da550d34252e0ed7218c25f10c5ef9ed7517/ruff-0.15.22-py3-none-musllinux_1_2_i686.whl", hash = "sha256:a1606c510bd7215680d32efab38965f7cdec3ef69f5170a3f4791404ffdd5262", size = 11105077, upload-time = "2026-07-16T15:13:57.915Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/47/20e9d4a3b8016778acea5fc32bb50d35d207500a17ddb529ffa6996feef8/ruff-0.15.22-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:630479b18625f5ffc373f77603a22a9f8ac0acd7ff0501178b5db28ec71e9c64", size = 11490980, upload-time = "2026-07-16T15:14:01.032Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/76/3f72d8fc38c1cb77b38c56a70da9d0c17700cc1cc50f9649c9d3c8f5ba71/ruff-0.15.22-py3-none-win32.whl", hash = "sha256:e5ba0e4a13fd14abbed2a77b517a3911290c6c6c59ef67784328d1668fab76cf", size = 10789165, upload-time = "2026-07-16T15:14:04.16Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/46/4965251734c2b6fcdca1b1b187d20bcac3af0ee5b083b89c910bb961ce3a/ruff-0.15.22-py3-none-win_amd64.whl", hash = "sha256:9be63ba1eb936acd2d1342fb8337c356353706fce233b2a15a09a97037e6acde", size = 11938297, upload-time = "2026-07-16T15:14:07.316Z" },
+    { url = "https://files.pythonhosted.org/packages/57/c9/e69b1ff4c8b69093ef08b8919ab767af0569666865b39c30a8795d88d3c6/ruff-0.15.22-py3-none-win_arm64.whl", hash = "sha256:e1168075b72158510839f250027659cdd78476f40507dd517892304c41318661", size = 11298172, upload-time = "2026-07-16T15:14:10.51Z" },
 ]
 
 [[package]]
@@ -2224,7 +2225,7 @@ dev = [
     { name = "pytest-dotenv", specifier = "==0.5.2" },
     { name = "pytest-freezegun", specifier = "==0.4.2" },
     { name = "pytest-ruff", specifier = "==0.2.1" },
-    { name = "ruff", specifier = "==0.2.2" },
+    { name = "ruff", specifier = "==0.15.22" },
     { name = "watchdog", specifier = "==4.0.2" },
     { name = "webtest", specifier = "==3.0.0" },
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -1567,14 +1567,15 @@ wheels = [
 
 [[package]]
 name = "pytest-ruff"
-version = "0.2.1"
+version = "0.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
+    { name = "pytest" },
     { name = "ruff" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/fe/d7/6a26602ccf764f4e055cb91002f9c682fca5756dd2df580f48b11d32c0f1/pytest_ruff-0.2.1.tar.gz", hash = "sha256:078ad696bfa347b466991ed4f9cc5ec807f5a171d7f06091660d8f16ba03a5dc", size = 3216, upload-time = "2023-10-31T18:52:11.29Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/32/5a/bee55130757fb4a14e0ac5d2c6558323275b5dccfa2f5353f3893299ff7d/pytest_ruff-0.5.tar.gz", hash = "sha256:f611c780fc2b9b8d7041fa0e7589f0a9f352b288d0cfc330881101b35d382063", size = 3854, upload-time = "2025-06-19T07:26:24.607Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d4/18/982b32eb5b453444f302a9f443baea0cfe11756c67c9c5025d45d658903e/pytest_ruff-0.2.1-py3-none-any.whl", hash = "sha256:f586bbd7978cb5782b673c8e55fa069d83430139931b918bd72232ba3f71eb67", size = 3750, upload-time = "2023-10-31T18:52:09.763Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/ca/abfce6de0bb0f017ed05ef9f2330596235cc5a3341b4d8d40895682b3814/pytest_ruff-0.5-py3-none-any.whl", hash = "sha256:d9db170d86fb167008e6702b4d79e2cccd8287f069c3a57f9261831cebdc4a31", size = 4680, upload-time = "2025-06-19T07:26:23.897Z" },
 ]
 
 [[package]]
@@ -2224,7 +2225,7 @@ dev = [
     { name = "pytest-django", specifier = "==4.5.2" },
     { name = "pytest-dotenv", specifier = "==0.5.2" },
     { name = "pytest-freezegun", specifier = "==0.4.2" },
-    { name = "pytest-ruff", specifier = "==0.2.1" },
+    { name = "pytest-ruff", specifier = "==0.5" },
     { name = "ruff", specifier = "==0.15.22" },
     { name = "watchdog", specifier = "==4.0.2" },
     { name = "webtest", specifier = "==3.0.0" },

--- a/ynr/apps/api/tests/test_api_next.py
+++ b/ynr/apps/api/tests/test_api_next.py
@@ -210,7 +210,7 @@ class TestAPI(
                             },
                             {
                                 "id": "PP53__1",
-                                "text": "Labour Party " "Candidate",
+                                "text": "Labour Party Candidate",
                                 "register": "GB",
                             },
                         ],

--- a/ynr/apps/auth_helpers/views.py
+++ b/ynr/apps/auth_helpers/views.py
@@ -12,7 +12,6 @@ def user_in_group(user, group_name):
 
 
 class GroupRequiredMixin(object):
-
     """A mixin that requires the user is a member of a particular group
 
     You should set 'required_group_name' on the class that uses this

--- a/ynr/apps/bulk_adding/forms.py
+++ b/ynr/apps/bulk_adding/forms.py
@@ -121,9 +121,9 @@ class BulkAddFormSet(BaseBulkAddFormSet):
     def get_form_kwargs(self, index):
         kwargs = super().get_form_kwargs(index)
         kwargs["party_choices"] = self.parties
-        kwargs[
-            "previous_party_affiliations_choices"
-        ] = self.previous_party_affiliations_choices
+        kwargs["previous_party_affiliations_choices"] = (
+            self.previous_party_affiliations_choices
+        )
         return kwargs
 
     @property

--- a/ynr/apps/bulk_adding/tests/test_bulk_add_by_party.py
+++ b/ynr/apps/bulk_adding/tests/test_bulk_add_by_party.py
@@ -199,9 +199,9 @@ class TestBulkAddingByParty(TestUserMixin, UK2015ExamplesMixin, WebTest):
         form[f"{ballot.pk}-0-person_identifiers_0_1"] = "homepage_url"
         form[f"{ballot.pk}-0-person_identifiers_1_0"] = "pp@gmail.com"
         form[f"{ballot.pk}-0-person_identifiers_1_1"] = "email"
-        form[
-            f"{ballot.pk}-0-person_identifiers_2_0"
-        ] = "https://linkedin.com/in/pamphero"
+        form[f"{ballot.pk}-0-person_identifiers_2_0"] = (
+            "https://linkedin.com/in/pamphero"
+        )
         form[f"{ballot.pk}-0-person_identifiers_2_1"] = "linkedin_url"
 
         response = form.submit().follow()
@@ -305,22 +305,22 @@ class TestBulkAddingByParty(TestUserMixin, UK2015ExamplesMixin, WebTest):
         form["source"] = "https://example.com/candidates/"
         for ballot in ballots:
             form[f"{ballot.pk}-0-name"] = f"Candidate {ballot.pk}"
-            form[
-                f"{ballot.pk}-0-biography"
-            ] = f"Biography for Candidate {ballot.pk}"
+            form[f"{ballot.pk}-0-biography"] = (
+                f"Biography for Candidate {ballot.pk}"
+            )
             form[f"{ballot.pk}-0-gender"] = "female"
             form[f"{ballot.pk}-0-birth_date"] = "1990"
-            form[
-                f"{ballot.pk}-0-person_identifiers_0_0"
-            ] = f"https://example.com/{ballot.pk}"
+            form[f"{ballot.pk}-0-person_identifiers_0_0"] = (
+                f"https://example.com/{ballot.pk}"
+            )
             form[f"{ballot.pk}-0-person_identifiers_0_1"] = "homepage_url"
-            form[
-                f"{ballot.pk}-0-person_identifiers_1_0"
-            ] = f"candidate{ballot.pk}@example.com"
+            form[f"{ballot.pk}-0-person_identifiers_1_0"] = (
+                f"candidate{ballot.pk}@example.com"
+            )
             form[f"{ballot.pk}-0-person_identifiers_1_1"] = "email"
-            form[
-                f"{ballot.pk}-0-person_identifiers_2_0"
-            ] = f"https://linkedin.com/in/candidate{ballot.pk}"
+            form[f"{ballot.pk}-0-person_identifiers_2_0"] = (
+                f"https://linkedin.com/in/candidate{ballot.pk}"
+            )
             form[f"{ballot.pk}-0-person_identifiers_2_1"] = "linkedin_url"
 
         # Submit the form

--- a/ynr/apps/bulk_adding/views/sopns.py
+++ b/ynr/apps/bulk_adding/views/sopns.py
@@ -286,9 +286,9 @@ class BulkAddSOPNReconcileView(BaseSOPNBulkAddView):
                 )
                 if party_description:
                     form["description_id"] = party_description
-                    form[
-                        "party_description_text"
-                    ] = party_description.description
+                    form["party_description_text"] = (
+                        party_description.description
+                    )
 
             form["name"] = candidacy["name"]
             form["party_id"] = party_obj.ec_id

--- a/ynr/apps/cached_counts/filters.py
+++ b/ynr/apps/cached_counts/filters.py
@@ -12,14 +12,14 @@ from ynr_refactoring.settings import PersonIdentifierFields
 class CompletenessFilter(django_filters.FilterSet):
     def __init__(self, data=None, queryset=None, *, request=None, prefix=None):
         for identifier in PersonIdentifierFields:
-            self.base_filters[
-                f"has_{identifier.name}"
-            ] = django_filters.ChoiceFilter(
-                field_name=identifier.name,
-                method="filter_null_or_empty_str",
-                label=f"Has {identifier.value}",
-                choices=[("yes", "Yes"), ("no", "No")],
-                widget=forms.HiddenInput,
+            self.base_filters[f"has_{identifier.name}"] = (
+                django_filters.ChoiceFilter(
+                    field_name=identifier.name,
+                    method="filter_null_or_empty_str",
+                    label=f"Has {identifier.value}",
+                    choices=[("yes", "Yes"), ("no", "No")],
+                    widget=forms.HiddenInput,
+                )
             )
 
         super().__init__(data, queryset, request=request, prefix=prefix)

--- a/ynr/apps/cached_counts/report_helpers.py
+++ b/ynr/apps/cached_counts/report_helpers.py
@@ -808,8 +808,8 @@ class GenderSplitBySeatsContested(BaseReport):
             ] = gender["gender_count"]
         for seats_contested, data in grouped_rows.items():
             ratio = (
-                f'{round(data["M"] / data["F"], 2)}'
-                f':{round(data["F"] / data["F"], 2)}'
+                f"{round(data['M'] / data['F'], 2)}"
+                f":{round(data['F'] / data['F'], 2)}"
             )
             report_list.append([seats_contested, data["F"], data["M"], ratio])
 

--- a/ynr/apps/candidates/csv_helpers.py
+++ b/ynr/apps/candidates/csv_helpers.py
@@ -10,7 +10,7 @@ def list_to_csv(membership_list):
     csv_fields = settings.CSV_ROW_FIELDS
     writer = BufferDictWriter(fieldnames=csv_fields)
     writer.writeheader()
-    for row in sorted(membership_list, key=lambda d: (d["election_date"])):
+    for row in sorted(membership_list, key=lambda d: d["election_date"]):
         writer.writerow(row)
     return writer.output
 

--- a/ynr/apps/candidates/management/commands/candidates_rename_ballot.py
+++ b/ynr/apps/candidates/management/commands/candidates_rename_ballot.py
@@ -2,6 +2,7 @@
 Foo Bar
 
 """
+
 import json
 import sys
 from argparse import ArgumentParser

--- a/ynr/apps/candidates/models/popolo_extra.py
+++ b/ynr/apps/candidates/models/popolo_extra.py
@@ -210,9 +210,9 @@ class BallotQueryset(models.QuerySet):
         """
         nuts_codes = []
         for nation_code in nation_codes:
-            assert (
-                nation_code in settings.NUTS_TO_NATION
-            ), f"Unknown nation {nation_code}"
+            assert nation_code in settings.NUTS_TO_NATION, (
+                f"Unknown nation {nation_code}"
+            )
             nuts_codes += settings.NUTS_TO_NATION[nation_code]
 
         return self.filter(tags__NUTS1__key__in=nuts_codes)

--- a/ynr/apps/candidates/models/versions.py
+++ b/ynr/apps/candidates/models/versions.py
@@ -81,9 +81,9 @@ def get_person_as_version_data(person, new_person=False):
             if membership.elected is not None:
                 candidacy["elected"] = membership.elected
             if membership.party_list_position is not None:
-                candidacy[
-                    "party_list_position"
-                ] = membership.party_list_position
+                candidacy["party_list_position"] = (
+                    membership.party_list_position
+                )
             if ballot.is_welsh_run:
                 ec_ids = membership.previous_party_affiliations.values_list(
                     "ec_id", flat=True

--- a/ynr/apps/candidates/tests/test_models.py
+++ b/ynr/apps/candidates/tests/test_models.py
@@ -220,7 +220,7 @@ class TestBallotMethods(TestCase, SingleBallotStatesMixin):
             "gla.",
             "ref.",
             # TODO confirm if these could be welsh run?
-            "pcc." "mayor.",
+            "pcc.mayor.",
             # TODO check this one
             "naw.",
         ]

--- a/ynr/apps/candidates/tests/test_update_view.py
+++ b/ynr/apps/candidates/tests/test_update_view.py
@@ -59,9 +59,9 @@ class TestUpdatePersonView(TestUserMixin, UK2015ExamplesMixin, WebTest):
             "/person/2009/update", user=self.user_who_can_lock
         )
         form = response.forms["person-details"]
-        form[
-            "tmp_person_identifiers-0-value"
-        ] = "http://en.wikipedia.org/wiki/Tessa_Jowell"
+        form["tmp_person_identifiers-0-value"] = (
+            "http://en.wikipedia.org/wiki/Tessa_Jowell"
+        )
         form["tmp_person_identifiers-0-value_type"] = "wikipedia_url"
 
         form["memberships-0-party_identifier_1"] = self.labour_party.ec_id
@@ -146,9 +146,9 @@ class TestUpdatePersonView(TestUserMixin, UK2015ExamplesMixin, WebTest):
         # happen with the Javascript addition of a new candidacy.
         form = response.forms["person-details"]
         form["memberships-1-party_identifier_1"] = self.labour_party.ec_id
-        form[
-            "memberships-1-ballot_paper_id"
-        ] = self.local_ballot.ballot_paper_id
+        form["memberships-1-ballot_paper_id"] = (
+            self.local_ballot.ballot_paper_id
+        )
         form["source"] = "testing adding new candidacy"
 
         response = form.submit()

--- a/ynr/apps/candidates/views/help.py
+++ b/ynr/apps/candidates/views/help.py
@@ -30,8 +30,8 @@ class HelpResultsView(TemplateView):
                 for role_data in elections:
                     for election_dict in role_data["elections"]:
                         election = election_dict["election"]
-                        election_dict[
-                            "results_file_exists"
-                        ] = self.results_file_exists(election.slug)
+                        election_dict["results_file_exists"] = (
+                            self.results_file_exists(election.slug)
+                        )
 
         return context

--- a/ynr/apps/candidates/views/users.py
+++ b/ynr/apps/candidates/views/users.py
@@ -41,9 +41,9 @@ class LeaderboardView(ContributorsMixin, TemplateView):
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         context["leaderboards"] = self.get_leaderboards()
-        context[
-            "num_new_users_since_date"
-        ] = self.get_num_new_users_since_date()
+        context["num_new_users_since_date"] = (
+            self.get_num_new_users_since_date()
+        )
         return context
 
 
@@ -52,9 +52,9 @@ class UserContributions(View):
 
     def get(self, request, *args, **kwargs):
         response = HttpResponse(content_type="text/csv")
-        response[
-            "Content-Disposition"
-        ] = 'attachment; filename="contributions.csv"'
+        response["Content-Disposition"] = (
+            'attachment; filename="contributions.csv"'
+        )
         headers = ["rank", "username", "contributions"]
         writer = csv.DictWriter(response, fieldnames=headers)
         writer.writerow({k: k for k in headers})

--- a/ynr/apps/data_exports/filters.py
+++ b/ynr/apps/data_exports/filters.py
@@ -179,8 +179,7 @@ def create_materialized_membership_filter(
     :return:
     """
 
-    class DynamicMaterializedMembershipFilter(MaterializedMembershipFilter):
-        ...
+    class DynamicMaterializedMembershipFilter(MaterializedMembershipFilter): ...
 
     for field_name, field in fields:
         if not field.dynamic_filter:

--- a/ynr/apps/data_exports/views.py
+++ b/ynr/apps/data_exports/views.py
@@ -140,9 +140,9 @@ class DataShortcutView(TemplateView):
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         # Get loads of recent elections for this page
-        context[
-            "charismatic_elections"
-        ] = ElectionReport.objects.all().order_by("-election_date")
+        context["charismatic_elections"] = (
+            ElectionReport.objects.all().order_by("-election_date")
+        )
         context["special_reports"] = [
             {
                 "only_by_elections": True,

--- a/ynr/apps/elections/tests/test_ballot_lock.py
+++ b/ynr/apps/elections/tests/test_ballot_lock.py
@@ -256,9 +256,9 @@ class TestBallotLockWorks(TestUserMixin, UK2015ExamplesMixin, WebTest):
         form = response.forms["new-candidate-form"]
         form["name"] = "Imaginary Candidate"
         form["party_identifier_1"] = self.green_party.ec_id
-        form[
-            "source"
-        ] = "Testing adding a new candidate to a locked constituency"
+        form["source"] = (
+            "Testing adding a new candidate to a locked constituency"
+        )
         submission_response = form.submit()
         self.assertEqual(submission_response.status_code, 302)
         # Find the person this should have redirected to:
@@ -279,9 +279,9 @@ class TestBallotLockWorks(TestUserMixin, UK2015ExamplesMixin, WebTest):
             form["memberships-0-ballot_paper_id"].value,
             self.dulwich_post_ballot.ballot_paper_id,
         )
-        form[
-            "memberships-0-ballot_paper_id"
-        ] = self.camberwell_post_ballot.ballot_paper_id
+        form["memberships-0-ballot_paper_id"] = (
+            self.camberwell_post_ballot.ballot_paper_id
+        )
         submission_response = form.submit()
         self.assertEqual(
             submission_response.context["memberships_formset"].errors,

--- a/ynr/apps/elections/uk/management/commands/uk_create_elections_from_every_election.py
+++ b/ynr/apps/elections/uk/management/commands/uk_create_elections_from_every_election.py
@@ -135,9 +135,9 @@ class Command(BaseCommand):
         local_current_ballots = Ballot.objects.filter(
             election__current=True
         ).count()
-        assert (
-            ee_current_ballots == local_current_ballots
-        ), f"Local and EE current ballots don't match EE: {ee_current_ballots} Local: {local_current_ballots}"
+        assert ee_current_ballots == local_current_ballots, (
+            f"Local and EE current ballots don't match EE: {ee_current_ballots} Local: {local_current_ballots}"
+        )
 
     def delete_deleted_elections(self, recently_updated_timestamp):
         # Get all deleted elections from EE

--- a/ynr/apps/elections/uk/templatetags/home_page_tags.py
+++ b/ynr/apps/elections/uk/templatetags/home_page_tags.py
@@ -204,12 +204,12 @@ def results_progress(context):
             output_field=TextField(),
         )
 
-        context[
-            "results_progress_by_election_type"
-        ] = results_progress_by_value(
-            ballot_qs.annotate(election_type=election_type),
-            lookup_value="election_type",
-            label_field="election__for_post_role",
+        context["results_progress_by_election_type"] = (
+            results_progress_by_value(
+                ballot_qs.annotate(election_type=election_type),
+                lookup_value="election_type",
+                label_field="election__for_post_role",
+            )
         )
 
     shortcuts = filter_shortcuts(context["request"])["list"]

--- a/ynr/apps/elections/views.py
+++ b/ynr/apps/elections/views.py
@@ -242,11 +242,11 @@ class BallotPaperView(TemplateView):
 
         # Lock Suggestions
         if ballot.has_lock_suggestion:
-            context[
-                "current_user_suggested_lock"
-            ] = ballot.suggestedpostlock_set.filter(
-                user=self.request.user
-            ).exists()
+            context["current_user_suggested_lock"] = (
+                ballot.suggestedpostlock_set.filter(
+                    user=self.request.user
+                ).exists()
+            )
         else:
             context["suggest_lock_form"] = SuggestedPostLockForm(ballot=ballot)
 
@@ -264,20 +264,20 @@ class BallotPaperView(TemplateView):
             context["identifiers_formset"] = PersonIdentifierFormsetFactory()
 
             # Previous candidate suggestions
-            context["previous_ballot"] = (
-                previous_ballot
-            ) = Ballot.objects.get_previous_ballot_for_post(ballot)
+            context["previous_ballot"] = previous_ballot = (
+                Ballot.objects.get_previous_ballot_for_post(ballot)
+            )
             if previous_ballot and not ballot.polls_closed:
-                context[
-                    "people_not_standing"
-                ] = ballot.people_not_standing_again(previous_ballot)
+                context["people_not_standing"] = (
+                    ballot.people_not_standing_again(previous_ballot)
+                )
 
-                context[
-                    "candidates_might_stand_again"
-                ] = Membership.objects.memberships_for_ballot(
-                    previous_ballot,
-                    exclude_memberships_qs=context["candidates"],
-                    exclude_people_qs=context["people_not_standing"],
+                context["candidates_might_stand_again"] = (
+                    Membership.objects.memberships_for_ballot(
+                        previous_ballot,
+                        exclude_memberships_qs=context["candidates"],
+                        exclude_people_qs=context["people_not_standing"],
+                    )
                 )
 
         context["logged_actions"] = (
@@ -558,7 +558,7 @@ class BallotsForSelectAjaxView(View):
             attrs_str = " ".join(
                 [f"{k}='{v}'" for k, v in option_attrs.items()]
             )
-            data.append(f"<option {attrs_str}>" f"{ballot_label}" f"</option>")
+            data.append(f"<option {attrs_str}>{ballot_label}</option>")
         data.append("</optgroup>")
         # empty option needs to be included for select2 to display a placeholder
         # see https://select2.org/placeholders#single-select-placeholders

--- a/ynr/apps/moderation_queue/tests/test_queue.py
+++ b/ynr/apps/moderation_queue/tests/test_queue.py
@@ -275,9 +275,9 @@ class PhotoReviewTests(UK2015ExamplesMixin, WebTest):
             )
             form = review_page_response.forms["photo-review-form"]
             form["decision"] = "rejected"
-            form[
-                "rejection_reason"
-            ] = "There's no clear source or copyright statement"
+            form["rejection_reason"] = (
+                "There's no clear source or copyright statement"
+            )
             response = form.submit(user=self.test_reviewer)
             self.assertEqual(response.status_code, 302)
             split_location = urlsplit(response.location)

--- a/ynr/apps/moderation_queue/views.py
+++ b/ynr/apps/moderation_queue/views.py
@@ -257,10 +257,10 @@ class PhotoReview(GroupRequiredMixin, TemplateView):
         context["google_image_search_url"] = self.get_google_image_search_url(
             person
         )
-        context[
-            "google_reverse_image_search_url"
-        ] = self.get_google_reverse_image_search_url(
-            self.queued_image.image.url
+        context["google_reverse_image_search_url"] = (
+            self.get_google_reverse_image_search_url(
+                self.queued_image.image.url
+            )
         )
         context["person"] = person
         return context

--- a/ynr/apps/official_documents/tests/test_page_splitter.py
+++ b/ynr/apps/official_documents/tests/test_page_splitter.py
@@ -65,11 +65,14 @@ class ElectionSOPNPageSplitterTestCase(UK2015ExamplesMixin, TestCase):
     def test_dependency_error_raises_pdf_processing_error(self):
         ballot_to_pages = {"ballot1": [0]}
         splitter = ElectionSOPNPageSplitter(self.election_sopn, ballot_to_pages)
-        with patch.object(
-            PdfWriter,
-            "add_page",
-            side_effect=DependencyError("missing dependency"),
-        ), self.assertRaises(PDFProcessingError):
+        with (
+            patch.object(
+                PdfWriter,
+                "add_page",
+                side_effect=DependencyError("missing dependency"),
+            ),
+            self.assertRaises(PDFProcessingError),
+        ):
             splitter.split()
 
     def test_split_pages(self):

--- a/ynr/apps/parties/forms.py
+++ b/ynr/apps/parties/forms.py
@@ -39,9 +39,7 @@ def party_and_description_dict_from_string(value):
             )
         return ret
     except Party.DoesNotExist:
-        raise ValidationError(
-            f"'{value}' is not a current party " f"identifier"
-        )
+        raise ValidationError(f"'{value}' is not a current party identifier")
 
 
 class PartyIdentifierInput(forms.CharField):

--- a/ynr/apps/parties/models.py
+++ b/ynr/apps/parties/models.py
@@ -133,10 +133,10 @@ class Party(TimeStampedModel):
             "fallback": "{} {}".format(self.name, url),
         }
         if self.default_emblem:
-            attachment[
-                "image_url"
-            ] = "http://search.electoralcommission.org.uk/Api/Registrations/Emblems/{}".format(
-                self.default_emblem.ec_emblem_id
+            attachment["image_url"] = (
+                "http://search.electoralcommission.org.uk/Api/Registrations/Emblems/{}".format(
+                    self.default_emblem.ec_emblem_id
+                )
             )
         if self.descriptions.exists():
             attachment["fields"] = [

--- a/ynr/apps/parties/tests/test_importer.py
+++ b/ynr/apps/parties/tests/test_importer.py
@@ -308,7 +308,7 @@ class TestECPartyImporter(DefaultPartyFixtures, TmpMediaRootMixin, TestCase):
         However, there are existing candidacies with FKs out to the old
         bilingual ones. They should be kept around and marked inactive.
         """
-        bilingual_description = f'{FAKE_PARTY_DICT["PartyDescriptions"][0]["Description"]} | {FAKE_PARTY_DICT["PartyDescriptions"][0]["Translation"]}'
+        bilingual_description = f"{FAKE_PARTY_DICT['PartyDescriptions'][0]['Description']} | {FAKE_PARTY_DICT['PartyDescriptions'][0]['Translation']}"
 
         FakeEmblemPath.return_value = make_tmp_file_from_source(
             EXAMPLE_IMAGE_FILENAME

--- a/ynr/apps/parties/tests/test_managers.py
+++ b/ynr/apps/parties/tests/test_managers.py
@@ -2,6 +2,7 @@
 Test some of the basic model use cases
 
 """
+
 from collections import namedtuple
 
 from django.test import TestCase

--- a/ynr/apps/parties/tests/test_models.py
+++ b/ynr/apps/parties/tests/test_models.py
@@ -2,6 +2,7 @@
 Test some of the basic model use cases
 
 """
+
 from candidates.tests.helpers import TmpMediaRootMixin
 from django.conf import settings
 from django.core.files.storage import DefaultStorage

--- a/ynr/apps/people/forms/forms.py
+++ b/ynr/apps/people/forms/forms.py
@@ -206,7 +206,7 @@ class PersonIdentifierForm(forms.ModelForm):
 class PersonMembershipForm(PopulatePartiesMixin, forms.ModelForm):
     def __init__(self, *args, **kwargs):
         self.user = kwargs.pop("user", None)
-        instance: Membership = kwargs.get("instance", None)
+        instance: Membership = kwargs.get("instance")
         person: Person = kwargs.pop("person", None)
         if instance:
             if instance.party_description:
@@ -504,7 +504,7 @@ class SopnNameForm(forms.ModelForm):
 
     def __init__(self, *args, **kwargs):
         self.user = kwargs.pop("user", None)
-        instance: Membership = kwargs.get("instance", None)
+        instance: Membership = kwargs.get("instance")
         if instance:
             initial = {}
             if hasattr(instance.ballot, "sopn"):

--- a/ynr/apps/people/forms/forms.py
+++ b/ynr/apps/people/forms/forms.py
@@ -110,9 +110,9 @@ class PersonIdentifierForm(forms.ModelForm):
         if self.cleaned_data.get("value_type") in self.HTTP_IDENTIFIERS:
             # Add https schema if missing
             if not self.cleaned_data.get("value").startswith("http"):
-                self.cleaned_data[
-                    "value"
-                ] = f"https://{self.cleaned_data['value']}"
+                self.cleaned_data["value"] = (
+                    f"https://{self.cleaned_data['value']}"
+                )
             URLValidator()(value=self.cleaned_data["value"])
         if (
             "value_type" in self.cleaned_data
@@ -233,9 +233,9 @@ class PersonMembershipForm(PopulatePartiesMixin, forms.ModelForm):
         )
 
         if self.show_previous_party_affiliations:
-            self.fields[
-                "previous_party_affiliations"
-            ] = PreviousPartyAffiliationsField(membership=self.instance)
+            self.fields["previous_party_affiliations"] = (
+                PreviousPartyAffiliationsField(membership=self.instance)
+            )
 
     @property
     def show_previous_party_affiliations(self):

--- a/ynr/apps/people/migrations/0013_populate_favourite_biscuit.py
+++ b/ynr/apps/people/migrations/0013_populate_favourite_biscuit.py
@@ -26,8 +26,7 @@ def populate_favourite_biscuit_from_extrafieldvalue(apps, schema_editor):
 
     if too_long.exists():
         msg = [
-            "Value is too long for the following people. "
-            "Please manually fix:"
+            "Value is too long for the following people. Please manually fix:"
         ]
         for value_field in too_long:
             msg.append(str(value_field.person.pk))

--- a/ynr/apps/people/tests/test_merge_view.py
+++ b/ynr/apps/people/tests/test_merge_view.py
@@ -626,9 +626,9 @@ class TestMergeViewFullyFrontEnd(TestUserMixin, UK2015ExamplesMixin, WebTest):
         form["name"] = "Elizabeth Bennet"
         form["tmp_person_identifiers-0-value"] = "lizzie@example.com"
         form["tmp_person_identifiers-0-value_type"] = "email"
-        form[
-            "tmp_person_identifiers-1-value"
-        ] = "http://en.wikipedia.org/wiki/Lizzie_Bennet"
+        form["tmp_person_identifiers-1-value"] = (
+            "http://en.wikipedia.org/wiki/Lizzie_Bennet"
+        )
         form["tmp_person_identifiers-1-value_type"] = "wikipedia_url"
 
         form["party_identifier_1"] = self.labour_party.ec_id
@@ -739,9 +739,9 @@ class TestMergeViewFullyFrontEnd(TestUserMixin, UK2015ExamplesMixin, WebTest):
         form = response.forms["new-candidate-form"]
         form["name"] = "Foo Bar"
         form["party_identifier_1"] = self.labour_party.ec_id
-        form[
-            "ballot_paper_id"
-        ] = self.dulwich_post_ballot_earlier.ballot_paper_id
+        form["ballot_paper_id"] = (
+            self.dulwich_post_ballot_earlier.ballot_paper_id
+        )
         form["source"] = "foo bar"
 
         response = form.submit()

--- a/ynr/apps/people/tests/test_merging.py
+++ b/ynr/apps/people/tests/test_merging.py
@@ -551,9 +551,9 @@ class TestMerging(TestUserMixin, UK2015ExamplesMixin, WebTest):
         form = response.forms["new-candidate-form"]
         form["name"] = "Imaginary Candidate"
         form["party_identifier_1"] = self.green_party.ec_id
-        form[
-            "source"
-        ] = "Testing adding a new candidate to a locked constituency"
+        form["source"] = (
+            "Testing adding a new candidate to a locked constituency"
+        )
         response = form.submit().follow()
         person_1 = response.context["person"]
 
@@ -562,9 +562,9 @@ class TestMerging(TestUserMixin, UK2015ExamplesMixin, WebTest):
         form = response.forms["new-candidate-form"]
         form["name"] = "Imaginary Candidate"
         form["party_identifier_1"] = self.green_party.ec_id
-        form[
-            "source"
-        ] = "Testing adding a new candidate to a locked constituency"
+        form["source"] = (
+            "Testing adding a new candidate to a locked constituency"
+        )
         response = form.submit().follow()
         person_2 = response.context["person"]
 

--- a/ynr/apps/people/tests/test_new_person_view.py
+++ b/ynr/apps/people/tests/test_new_person_view.py
@@ -33,9 +33,9 @@ class TestNewPersonView(TestUserMixin, UK2015ExamplesMixin, WebTest):
         form["name"] = "Elizabeth Bennet"
         form["tmp_person_identifiers-0-value"] = "lizzie@example.com"
         form["tmp_person_identifiers-0-value_type"] = "email"
-        form[
-            "tmp_person_identifiers-1-value"
-        ] = "http://en.wikipedia.org/wiki/Lizzie_Bennet"
+        form["tmp_person_identifiers-1-value"] = (
+            "http://en.wikipedia.org/wiki/Lizzie_Bennet"
+        )
         form["tmp_person_identifiers-1-value_type"] = "wikipedia_url"
 
         form["party_identifier_1"] = self.labour_party.ec_id

--- a/ynr/apps/people/tests/test_person_form_identifier_crud.py
+++ b/ynr/apps/people/tests/test_person_form_identifier_crud.py
@@ -372,9 +372,9 @@ class PersonFormsIdentifierCRUDTestCase(TestUserMixin, WebTest):
         form["tmp_person_identifiers-0-value_type"] = "email"
         form["tmp_person_identifiers-0-value"] = "person@example.com"
 
-        form[
-            "tmp_person_identifiers-1-value"
-        ] = "https://www.facebook.com/example"
+        form["tmp_person_identifiers-1-value"] = (
+            "https://www.facebook.com/example"
+        )
         form["tmp_person_identifiers-1-value_type"] = "facebook_page_url"
 
         form["tmp_person_identifiers-2-id"] = pi.pk

--- a/ynr/apps/people/tests/test_person_models.py
+++ b/ynr/apps/people/tests/test_person_models.py
@@ -123,9 +123,9 @@ class TestPersonModels(
         form = response.forms["person-details"]
         form["memberships-0-ballot_paper_id"].value = ballot.ballot_paper_id
         form["memberships-0-party_identifier_0"].value = self.labour_party.ec_id
-        form[
-            "source"
-        ] = "Test adding a person to a ballot removes them from the not standing list"
+        form["source"] = (
+            "Test adding a person to a ballot removes them from the not standing list"
+        )
         form.submit()
 
         # check that the person is no longer marked as not standing in the election

--- a/ynr/apps/people/tests/test_revert.py
+++ b/ynr/apps/people/tests/test_revert.py
@@ -144,9 +144,9 @@ class TestRevertPersonView(TestUserMixin, UK2015ExamplesMixin, WebTest):
 
         response = self.app.get("/person/2009/update", user=self.user)
         revert_form = response.forms["revert-form-5469de7db0cbd155"]
-        revert_form[
-            "source"
-        ] = "Reverting to version 5469de7db0cbd155 for testing purposes"
+        revert_form["source"] = (
+            "Reverting to version 5469de7db0cbd155 for testing purposes"
+        )
         response = revert_form.submit()
         self.assertEqual(response.status_code, 302)
         self.assertEqual(response.location, "/person/2009")
@@ -255,9 +255,9 @@ class TestRevertPersonView(TestUserMixin, UK2015ExamplesMixin, WebTest):
 
         response = self.app.get("/person/2009/update", user=self.user)
         revert_form = response.forms["revert-form-5469de7db0cbd155"]
-        revert_form[
-            "source"
-        ] = "Reverting to version 5469de7db0cbd155 for testing purposes"
+        revert_form["source"] = (
+            "Reverting to version 5469de7db0cbd155 for testing purposes"
+        )
         response = revert_form.submit()
         self.assertEqual(response.status_code, 302)
         self.assertEqual(response.location, "/person/2009")
@@ -288,9 +288,9 @@ class TestRevertPersonView(TestUserMixin, UK2015ExamplesMixin, WebTest):
 
         response = self.app.get(person.get_edit_url(), user=self.user)
         revert_form = response.forms["revert-form-5469de7db0cbd155"]
-        revert_form[
-            "source"
-        ] = "Reverting to version 5469de7db0cbd155 for testing purposes"
+        revert_form["source"] = (
+            "Reverting to version 5469de7db0cbd155 for testing purposes"
+        )
         response = revert_form.submit()
 
     def test_revert_with_memberships_previous_party_affiliations(self):

--- a/ynr/apps/popolo/tests/test_models.py
+++ b/ynr/apps/popolo/tests/test_models.py
@@ -82,9 +82,12 @@ class TestMembership(TestCase):
         Membership.is_welsh_run_ballot returns the same
         """
         for case in [True, False]:
-            with self.subTest(msg=case), patch.object(
-                Ballot, "is_welsh_run", new_callable=PropertyMock
-            ) as mock:
+            with (
+                self.subTest(msg=case),
+                patch.object(
+                    Ballot, "is_welsh_run", new_callable=PropertyMock
+                ) as mock,
+            ):
                 mock.return_value = case
                 membership = Membership(ballot=Ballot())
                 assert membership.is_welsh_run_ballot is case

--- a/ynr/apps/resultsbot/helpers.py
+++ b/ynr/apps/resultsbot/helpers.py
@@ -54,9 +54,9 @@ class ResultsBot(object):
                     edit_type=EditType.BOT.name,
                 )
             else:
-                change_metadata[
-                    "information_source"
-                ] = 'Setting as "not elected" by implication'
+                change_metadata["information_source"] = (
+                    'Setting as "not elected" by implication'
+                )
                 membership.person.record_version(change_metadata)
                 membership.person.save()
 
@@ -74,9 +74,9 @@ class ResultsBot(object):
             }
             # Only include num_turnout_reported if it was reported in Modgov
             if division.numballotpapersissued > 0:
-                defaults[
-                    "num_turnout_reported"
-                ] = division.numballotpapersissued
+                defaults["num_turnout_reported"] = (
+                    division.numballotpapersissued
+                )
             # Same for total electorate
             if division.electorate > 0:
                 defaults["total_electorate"] = division.electorate

--- a/ynr/apps/search/tests/test_search.py
+++ b/ynr/apps/search/tests/test_search.py
@@ -140,7 +140,7 @@ class TestSearchView(TestUserMixin, UK2015ExamplesMixin, WebTest):
         PersonFactory(name="Henry Jekyll")
         self.assertTrue(
             search_person_by_name(
-                "` ' £$$^*   ($ £%  Henry   " "Jekyll \t"
+                "` ' £$$^*   ($ £%  Henry   Jekyll \t"
             ).exists()
         )
 

--- a/ynr/apps/sopn_parsing/helpers/convert_pdf.py
+++ b/ynr/apps/sopn_parsing/helpers/convert_pdf.py
@@ -14,9 +14,10 @@ def convert_docx_to_pdf(uploaded_file: ContentFile):
     Takes a File-like docx object, attempts to convert it to a PDF, and returns the
     new file.
     """
-    with tempfile.NamedTemporaryFile(
-        suffix=".docx"
-    ) as in_file, tempfile.NamedTemporaryFile(suffix=".pdf") as out_file:
+    with (
+        tempfile.NamedTemporaryFile(suffix=".docx") as in_file,
+        tempfile.NamedTemporaryFile(suffix=".pdf") as out_file,
+    ):
         # convert the docx and save to a temp file
         with open(in_file.name, "wb") as f:
             uploaded_file.seek(0)

--- a/ynr/apps/sopn_parsing/helpers/parse_tables.py
+++ b/ynr/apps/sopn_parsing/helpers/parse_tables.py
@@ -486,9 +486,11 @@ def parse_dataframe(ballot: Ballot, df: DataFrame):
     df.reset_index(drop=True, inplace=True)
     polling_station_index = df[
         df.apply(
-            lambda row: row.astype(str)
-            .str.contains("polling station", case=False)
-            .any(),
+            lambda row: (
+                row.astype(str)
+                .str.contains("polling station", case=False)
+                .any()
+            ),
             axis=1,
         )
     ].index

--- a/ynr/apps/sopn_parsing/management/commands/sopn_parsing_parse_tables.py
+++ b/ynr/apps/sopn_parsing/management/commands/sopn_parsing_parse_tables.py
@@ -31,9 +31,9 @@ class Command(BaseSOPNParsingCommand):
             return filter_kwargs
 
         if options.get("reparse"):
-            filter_kwargs[
-                "rawpeople__source_type"
-            ] = RawPeople.SOURCE_PARSED_PDF
+            filter_kwargs["rawpeople__source_type"] = (
+                RawPeople.SOURCE_PARSED_PDF
+            )
             return filter_kwargs
 
         return filter_kwargs

--- a/ynr/apps/sopn_parsing/tests/test_parse_textract_results.py
+++ b/ynr/apps/sopn_parsing/tests/test_parse_textract_results.py
@@ -1,6 +1,7 @@
 """
 Tests for the code that converts a raw Textract result into a pandas data frame for parsing.
 """
+
 from pathlib import Path
 
 from candidates.tests.uk_examples import UK2015ExamplesMixin

--- a/ynr/apps/twitterbot/tests/test_twitter_queue_images_command.py
+++ b/ynr/apps/twitterbot/tests/test_twitter_queue_images_command.py
@@ -167,8 +167,7 @@ class TestTwitterImageQueueCommand(TestUserMixin, TestCase):
                 "  That person already had an image in the queue, so skipping.",
                 "Considering adding a photo for Person With An Existing "
                 "Image But None In The Queue with Twitter user ID: 1006",
-                "  Adding that person's Twitter avatar to the moderation "
-                "queue",
+                "  Adding that person's Twitter avatar to the moderation queue",
                 "Considering adding a photo for Person With Only Rejected "
                 "Images In The Queue with Twitter user ID: 1003",
                 "  That person already had an image in the queue, so skipping.",

--- a/ynr/apps/uk_results/views/base_views.py
+++ b/ynr/apps/uk_results/views/base_views.py
@@ -17,9 +17,9 @@ class ResultsHomeView(TemplateView):
         context = super().get_context_data(**kwargs)
 
         elections_list = reverse("election_list_view")
-        context[
-            "elections_without_results_url"
-        ] = f"{elections_list}?has_results=0&is_cancelled=0"
+        context["elections_without_results_url"] = (
+            f"{elections_list}?has_results=0&is_cancelled=0"
+        )
         return context
 
     def test_func(self, user):

--- a/ynr/apps/wombles/management/commands/wombles_make_email_list_for_candidates.py
+++ b/ynr/apps/wombles/management/commands/wombles_make_email_list_for_candidates.py
@@ -9,8 +9,7 @@ from popolo.models import Membership
 from sesame.utils import get_token
 
 
-class NoEmailError(ValueError):
-    ...
+class NoEmailError(ValueError): ...
 
 
 def make_fake_username(email):

--- a/ynr/apps/wombles/views.py
+++ b/ynr/apps/wombles/views.py
@@ -54,9 +54,9 @@ class SingleWombleView(LoginRequiredMixin, DetailView):
             .order_by("day")
         )
 
-        context[
-            "edits_over_time"
-        ] = self.object.womble_profile.edits_over_time()
+        context["edits_over_time"] = (
+            self.object.womble_profile.edits_over_time()
+        )
         return context
 
 
@@ -82,9 +82,9 @@ class LoginView(FormView):
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
-        context[
-            "new_user_creation_allowed"
-        ] = settings.NEW_USER_ACCOUNT_CREATION_ALLOWED
+        context["new_user_creation_allowed"] = (
+            settings.NEW_USER_ACCOUNT_CREATION_ALLOWED
+        )
         return context
 
     def make_fake_username(self, email):

--- a/ynr/context_processors.py
+++ b/ynr/context_processors.py
@@ -66,9 +66,9 @@ def add_notification_data(request):
                 .count()
             )
         if TRUSTED_TO_MERGE_GROUP_NAME in groups:
-            result[
-                "duplicate_suggestions"
-            ] = DuplicateSuggestion.objects.open().count()
+            result["duplicate_suggestions"] = (
+                DuplicateSuggestion.objects.open().count()
+            )
         if TRUSTED_TO_EDIT_NAME in groups:
             result["person_name_edits"] = OtherName.objects.filter(
                 needs_review=True

--- a/ynr/wsgi.py
+++ b/ynr/wsgi.py
@@ -13,6 +13,7 @@ middleware here, or combine a Django application with an application of another
 framework.
 
 """
+
 import os
 from os.path import abspath, dirname
 from sys import path


### PR DESCRIPTION
Bumps ruff from 0.2.2 to 0.15.22. Largest job in the rollout.

| Commit | What |
|---|---|
| `946864184` | Version bump only. Intentionally leaves lint/format failing. |
| `de8256b6c` | `ruff format .` — 51 of 1064 files. Mechanical. |
| `3cb04e495` | `ruff check --fix .` — 21 found, 2 fixed. |
| `5f8329183` | `pytest-ruff` 0.2.1 to 0.5 — repairs the lint gate. |

The pre-commit rev moved from `v0.2.2` to `v0.15.22` to match.

Branch is `ruff-0.15.22` with a hyphen: a local branch named `ruff` already
exists in this repo, which makes `ruff/0.15.22` an illegal ref.

## The lint gate was a no-op

`pytest-ruff` 0.2.1 shells out to `ruff check --show-source` — an argument
removed in ruff 0.5.0 — and then only inspects stdout, discarding stderr and
the exit code. Against ruff 0.15.22 the call exits 2 with nothing on stdout,
so every ruff test passed regardless of violations. 0.5 checks the return
code. Expect CI to go red on this PR.

## Still failing after this PR — 19 violations

**Start with F507 — it is a real bug, not a style issue:**

    ynr/apps/candidates/templatetags/metadescription.py:21:35  F507
    ynr/apps/candidates/templatetags/metadescription.py:30:35  F507

A `%`-format string with 0 placeholders but 1 substitution raises
`TypeError: not all arguments converted during string formatting` at
runtime. Worth checking whether that template tag is reached.

**SIM115 (5) — resource leaks, worth fixing properly:**

    ynr/apps/moderation_queue/models.py:135
    ynr/apps/parties/importer.py:461
    ynr/apps/parties/importer.py:482
    ynr/apps/parties/tests/test_importer.py:65
    ynr/storages.py:23

**E721 (2) — type comparison with `==` rather than `is`/`isinstance`:**

    ynr/apps/api/views.py:17
    ynr/apps/cached_counts/report_helpers.py:1240

**SIM103 (10) — style, unsafe fixes only:**

    ynr/apps/candidates/models/popolo_extra.py:501, :519, :673
    ynr/apps/data_exports/views.py:98
    ynr/apps/elections/uk/lib.py:17
    ynr/apps/official_documents/management/commands/official_documents_import_sopns.py:95
    ynr/apps/resultsbot/importers/modgov.py:283
    ynr/apps/sopn_parsing/helpers/parse_tables.py:86, :93
    ynr/apps/uk_results/models.py:50

10 of the 19 have unsafe fixes available; the rest need manual work.
`ruff format --check .` is clean (1064 files).

---

Part of the org-wide rollout moving every DemocracyClub repo onto ruff `0.15.22`. Commits are deliberately split so each step reviews on its own — please review commit by commit rather than as a combined diff.
